### PR TITLE
Chests protected by regions

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -868,6 +868,11 @@ namespace TShockAPI
             {
                 return TShock.Utils.HandleGriefer(args.Player, TShock.Config.RangeCheckBanReason);
             }
+            if (!args.Player.Group.HasPermission(Permissions.editspawn) && !TShock.Regions.CanBuild(x, y, args.Player) && TShock.Regions.InArea(x, y))
+            {
+                args.Player.SendMessage("Region Name: " + TShock.Regions.InAreaRegionName(x, y) + " protected from changes.", Color.Red);
+                return true;
+            }
             return false;
         }
 


### PR DESCRIPTION
The contents of chests are now protected by the same rules that protect regions. (Sorry about trying to request a pull to master before, GitHub is still new to me and I'm trying to figure it all out.)
