### PR TITLE
fix in SSI

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -544,6 +544,11 @@ namespace TShockAPI
 
 		public void StoreSlot(int slot, int netID, int prefix, int stack)
 		{
+			if(slot > (this.inventory.Length - 1)) //if the slot is out of range then dont save
+			{
+				return;
+			}	
+			
 			this.inventory[slot].netID = netID;
 			if (this.inventory[slot].netID != 0)
 			{


### PR DESCRIPTION
fix for GetDataHandlers: ERROR: System.IndexOutOfRangeException: Array index is out of range. in TShockAPI.PlayerData.StoreSlot

added range check, i wonder what exactly is happening, players are saying they just normaly pick up items
