### PR TITLE
Added a more descriptive error message when database dlls are missing.

### DIFF
--- a/TShockAPI/DB/BanManager.cs
+++ b/TShockAPI/DB/BanManager.cs
@@ -39,7 +39,15 @@ namespace TShockAPI.DB
 			                                  db.GetSqlType() == SqlType.Sqlite
 			                                  	? (IQueryBuilder) new SqliteQueryCreator()
 			                                  	: new MysqlQueryCreator());
+								try{
 			creator.EnsureExists(table);
+								}
+								catch (DllNotFoundException ex)
+{
+System.Console.WriteLine("Possible problem with your database - is Sqlite3.dll present?");
+throw new Exception("Could not find a database library (probably Sqlite3.dll)");
+}
+
 		}
 
 		public Ban GetBanByIp(string ip)


### PR DESCRIPTION
Gives the user an error on the console when Sqlite3.dll is missing (seems to be a common problem lately)
