### PR TITLE
XXXX protected from changes spam prevention

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -76,6 +76,10 @@ namespace TShockAPI
 		public bool RequiresPassword;
 		public bool SilentKickInProgress;
 		public List<Point> IceTiles;
+                public long RPm=1;
+                public long WPm=1;
+                public long SPm=1;
+                public long BPm=1;
 
 
 		public bool RealPlayer

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1100,7 +1100,11 @@ namespace TShockAPI
 							return false;
 						}
 					}
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.BPm) > 2000){
 					player.SendMessage("You do not have permission to build!", Color.Red);
+			player.BPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
 					return true;
 				}
 
@@ -1109,22 +1113,34 @@ namespace TShockAPI
 					player.IceTiles.Add(new Point(tileX, tileY));
 					return false;
 				}
+				
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.BPm) > 2000){
+					player.SendMessage("You do not have permission to build!", Color.Red);
+			player.BPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
 
-				player.SendMessage("You do not have permission to build!", Color.Red);
+}
 				return true;
 
             }
             if (!player.Group.HasPermission(Permissions.editspawn) && !Regions.CanBuild(tileX, tileY, player) &&
                 Regions.InArea(tileX, tileY))
             {
-                player.SendMessage("Region protected from changes.", Color.Red);
+                		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.RPm) > 2000){
+                        player.SendMessage("Region protected from changes.", Color.Red);
+			player.RPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
                 return true;
             }
             if (Config.DisableBuild)
             {
                 if (!player.Group.HasPermission(Permissions.editspawn))
                 {
-                    player.SendMessage("World protected from changes.", Color.Red);
+ 		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000){
+                        player.SendMessage("World protected from changes.", Color.Red);
+			player.WPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
                     return true;
                 }
             }
@@ -1134,8 +1150,12 @@ namespace TShockAPI
                 {
                     var flag = CheckSpawn(tileX, tileY);
                     if (flag)
-                    {
+                    {		
+					if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 2000){
                         player.SendMessage("Spawn protected from changes.", Color.Red);
+			player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
                         return true;
                     }
                 }
@@ -1147,20 +1167,39 @@ namespace TShockAPI
 		{
 			if (!player.Group.HasPermission(Permissions.canbuild))
 			{
-				player.SendMessage("You do not have permission to build!", Color.Red);
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.BPm) > 2000){
+					player.SendMessage("You do not have permission to build!", Color.Red);
+			player.BPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
+
 				return true;
 			}
 			if (!player.Group.HasPermission(Permissions.editspawn) && !Regions.CanBuild(tileX, tileY, player) &&
 				Regions.InArea(tileX, tileY))
 			{
-				player.SendMessage("Region protected from changes.", Color.Red);
+
+
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.RPm) > 2000){
+                        player.SendMessage("Region protected from changes.", Color.Red);
+			player.RPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
+
+
 				return true;
 			}
 			if (Config.DisableBuild)
 			{
 				if (!player.Group.HasPermission(Permissions.editspawn))
 				{
-					player.SendMessage("World protected from changes.", Color.Red);
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000){
+                        player.SendMessage("World protected from changes.", Color.Red);
+			player.WPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
+
+
 					return true;
 				}
 			}
@@ -1171,14 +1210,19 @@ namespace TShockAPI
 					var flag = CheckSpawn(tileX, tileY);
 					if (flag)
 					{
-						player.SendMessage("Spawn protected from changes.", Color.Red);
+		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 1000){
+                        player.SendMessage("Spawn protected from changes.", Color.Red);
+			player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+
+}
+
+
 						return true;
 					}
 				}
 			}
 			return false;
 		}
-
 		public static bool CheckSpawn(int x, int y)
 		{
 			Vector2 tile = new Vector2(x, y);


### PR DESCRIPTION
This causes TShock to keep track of when it sent the last XXX protected from changes per protection type per user, and will only send another if 2 seconds have passed.

also, it's based on current code - sorry about that Olink :)
