### PR TITLE
Fix for skeletron prime disabling players & new config option to ignore shrapnel

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -175,6 +175,9 @@ namespace TShockAPI
 		[Description("Disable a player if they exceed this number of projectile new within 1 second.")] public int
 			ProjectileThreshold = 50;
 
+		[Description("Ignore shrapnel from crystal bullets for Projectile Threshold.")] public bool 
+			ProjIgnoreShrapnel = true;
+		
 		[Description("Require all players to register or login before being allowed to play.")] public bool RequireLogin;
 
 		[Description(
@@ -200,7 +203,7 @@ namespace TShockAPI
         [Description("The maximum damage a projectile can inflict")] public int MaxProjDamage = 175;
 
         [Description("Ignores checking to see if player 'can' update a projectile")] public bool IgnoreProjUpdate = false;
-
+		
         [Description("Ignores checking to see if player 'can' kill a projectile")] public bool IgnoreProjKill = false;
 
 	    [Description("Ignores all no clip checks for players")] public bool IgnoreNoClip = false;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1916,8 +1916,15 @@ namespace TShockAPI
 
 			if (!TShock.Config.IgnoreProjUpdate && TShock.CheckProjectilePermission(args.Player, index, type))
 			{
-				args.Player.Disable("Does not have projectile permission to update projectile.");
-				args.Player.RemoveProjectile(ident, owner);
+			if (type == 100)
+					{	//fix for skele prime
+						Log.Debug("Skeletron Prime's death laser ignored for cheat detection..");
+					}
+					else
+					{
+						args.Player.Disable("Does not have projectile permission to update projectile.");
+						args.Player.RemoveProjectile(ident, owner);
+					}
 				return true;
 			}
 
@@ -1936,7 +1943,14 @@ namespace TShockAPI
 
 			if (!args.Player.Group.HasPermission(Permissions.ignoreprojectiledetection))
 			{
-				args.Player.ProjectileThreshold++;
+				if ((type ==90) && (TShock.Config.ProjIgnoreShrapnel))// ignore shrapnel
+					{
+						Log.Debug("Ignoring shrapnel per config..");
+					}
+					else
+					{
+						args.Player.ProjectileThreshold++;
+					}
 			}
 
 			return false;


### PR DESCRIPTION
- New config option to ignore crystal shrapnel for projectile updates.
- Ignore projectile type 100 for player projectile update.
