### PR TITLE
Prevents users from sneaking items onto server in their hands!

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -151,6 +151,8 @@ namespace TShockAPI
 
 		[Description("Enable Server Side Inventory checks, EXPERIMENTAL")] public bool ServerSideInventory;
 
+		[Description("Time, in milliseconds, to disallow discarding items after logging in when ServerSideInventory is ON")] public int LogonDiscardThreshold=250;
+		
 		[Description("Disables reporting of playercount to the stat system.")] public bool DisablePlayerCountReporting;
 
 		[Description("Disables clown bomb projectiles from spawning")] public bool DisableClownBombs;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2374,7 +2374,14 @@ namespace TShockAPI
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);
 				return true;
 			}
-
+			if ((TShock.Config.ServerSideInventory) && (DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond - args.Player.LoginMS < TShock.Config.LogonDiscardThreshold))
+			{
+			//Player is probably trying to sneak items onto the server in their hands!!!
+				Log.ConsoleInfo(string.Format("Player {0} tried to sneak {1} onto the server!", args.Player.Name, item.name));
+				args.Player.SendData(PacketTypes.ItemDrop, "", id);
+				return true;
+			
+			}
 			if (TShock.CheckIgnores(args.Player))
 			{
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -76,11 +76,11 @@ namespace TShockAPI
 		public bool RequiresPassword;
 		public bool SilentKickInProgress;
 		public List<Point> IceTiles;
-                public long RPm=1;
-                public long WPm=1;
-                public long SPm=1;
-                public long BPm=1;
-
+        public long RPm=1;
+        public long WPm=1;
+        public long SPm=1;
+        public long BPm=1;
+		public long LoginMS;
 
 		public bool RealPlayer
 		{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -41,7 +41,7 @@ namespace TShockAPI
 	public class TShock : TerrariaPlugin
 	{
 		public static readonly Version VersionNum = Assembly.GetExecutingAssembly().GetName().Version;
-		public static readonly string VersionCodename = "Pre-Release - Code Freeze";
+		public static readonly string VersionCodename = "1.1.2 was sudden";
 
 		public static string SavePath = "tshock";
 
@@ -819,7 +819,8 @@ namespace TShockAPI
 				e.Handled = true;
 				return;
 			}
-
+			player.LoginMS= DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+			
 			Utils.ShowFileToUser(player, "motd.txt");
 
 			if (Config.PvPMode == "always" && !player.TPlayer.hostile)
@@ -1153,10 +1154,9 @@ namespace TShockAPI
                     {		
 					if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 2000){
                         player.SendMessage("Spawn protected from changes.", Color.Red);
-			player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-
-}
-                        return true;
+						player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+						}
+                    return true;
                     }
                 }
             }
@@ -1167,14 +1167,14 @@ namespace TShockAPI
 		{
 			if (!player.Group.HasPermission(Permissions.canbuild))
 			{
+
 		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.BPm) > 2000){
 					player.SendMessage("You do not have permission to build!", Color.Red);
-			player.BPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-
-}
-
+					player.BPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+					}
 				return true;
 			}
+			
 			if (!player.Group.HasPermission(Permissions.editspawn) && !Regions.CanBuild(tileX, tileY, player) &&
 				Regions.InArea(tileX, tileY))
 			{
@@ -1182,24 +1182,19 @@ namespace TShockAPI
 
 		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.RPm) > 2000){
                         player.SendMessage("Region protected from changes.", Color.Red);
-			player.RPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-
-}
-
-
+						player.RPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+						}
 				return true;
 			}
+			
 			if (Config.DisableBuild)
 			{
 				if (!player.Group.HasPermission(Permissions.editspawn))
 				{
-		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000){
+				if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000){
                         player.SendMessage("World protected from changes.", Color.Red);
-			player.WPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-
-}
-
-
+						player.WPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+						}
 					return true;
 				}
 			}
@@ -1210,11 +1205,11 @@ namespace TShockAPI
 					var flag = CheckSpawn(tileX, tileY);
 					if (flag)
 					{
-		    if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 1000){
+					if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 1000){
                         player.SendMessage("Spawn protected from changes.", Color.Red);
-			player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
+						player.SPm=DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
 
-}
+						}
 
 
 						return true;


### PR DESCRIPTION
This code adds 1 Configuration option - LogonDiscardThreshold. It is a time, in milliseconds, to disallow player drops from the time they logon to the server when ServerSideInventory is enabled.

Previously, a user could sneak items onto a server by holding the item in their hand while they quit another world. The item is automagically dropped when they login to the new world, bypassing inventory checks.

It defaults at 250ms. The thinking behind this is that there aren't any items legitimately discarded 1/4 of a second within joining a server. 
