### PR TITLE
Log Name change

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -108,7 +108,8 @@ namespace TShockAPI
 				Directory.CreateDirectory(SavePath);
 
 #if DEBUG
-			Log.Initialize(Path.Combine(SavePath, "log.txt"), LogLevel.All, false);
+            DateTime now = DateTime.Now;
+			Log.Initialize(Path.Combine(SavePath, now.ToString("yyyyMMddHHmmss")+".log"), LogLevel.All, false);
 #else
 			Log.Initialize(Path.Combine(SavePath, "log.txt"), LogLevel.All & ~LogLevel.Debug, false);
 #endif


### PR DESCRIPTION
Commit changes log names from log.txt to a timestamp with the format yyyyMMddHHmmss.log 
This will also ensure that there is a new log created every time TShock is started.
