### PR TITLE
-maxplayers and -players override ; added hallowed vines and plants to /removespecial

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2210,6 +2210,7 @@ namespace TShockAPI
 		private static void Reload(CommandArgs args)
 		{
 			FileTools.SetupConfig();
+            TShock.HandleCommandLinePostConfigLoad(Environment.GetCommandLineArgs());
 			TShock.Groups.LoadPermisions();
 			TShock.Regions.ReloadAllRegions();
 			args.Player.SendMessage(

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -355,7 +355,7 @@ namespace TShockAPI
 			}
 		}
 
-		private void HandleCommandLinePostConfigLoad(string[] parms)
+		public static void HandleCommandLinePostConfigLoad(string[] parms)
 		{
 			for (int i = 0; i < parms.Length; i++)
 			{


### PR DESCRIPTION
maxplayers and players command line options should override config
hallowed vines and plants should also be removed during /removespecial.
