### PR TITLE
Refactored server stop and world save operations fixing race condition

### DIFF
--- a/TShockAPI/BackupManager.cs
+++ b/TShockAPI/BackupManager.cs
@@ -63,11 +63,7 @@ namespace TShockAPI
 				TShock.Utils.Broadcast("Server map saving, potential lag spike");
 				Console.WriteLine("Backing up world...");
 
-				Thread SaveWorld = new Thread(TShock.Utils.SaveWorld);
-				SaveWorld.Start();
-
-				while (SaveWorld.ThreadState == ThreadState.Running)
-					Thread.Sleep(50);
+				SaveManager.Instance.SaveWorld();
 				Console.WriteLine("World backed up");
 				Console.ForegroundColor = ConsoleColor.Gray;
 				Log.Info(string.Format("World backed up ({0})", Main.worldPathName));

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1007,38 +1007,37 @@ namespace TShockAPI
 				}
 			}
 
-			TShock.Utils.ForceKickAll("Server shutting down!");
-			WorldGen.saveWorld();
-			Netplay.disconnect = true;
+			TShock.Utils.StopServer();
 		}
-        //Added restart command
-        private static void Restart(CommandArgs args)
-        {
-	if (Main.runningMono){
-	Log.ConsoleInfo("Sorry, this command has not yet been implemented in Mono");
-	}else{
-            if (TShock.Config.ServerSideInventory)
-            {
-                foreach (TSPlayer player in TShock.Players)
-                {
-                    if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
-                    {
-                        TShock.InventoryDB.InsertPlayerData(player);
-                    }
-                }
-            }
+		//Added restart command
+		private static void Restart(CommandArgs args)
+		{
+			if (Main.runningMono)
+			{
+				Log.ConsoleInfo("Sorry, this command has not yet been implemented in Mono");
+			}
+			else
+			{
+				if (TShock.Config.ServerSideInventory)
+				{
+					foreach (TSPlayer player in TShock.Players)
+					{
+						if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
+						{
+							TShock.InventoryDB.InsertPlayerData(player);
+						}
+					}
+				}
 
-            TShock.Utils.ForceKickAll("Server restarting!");
-            WorldGen.saveWorld();
-            Netplay.disconnect = true;
-            System.Diagnostics.Process.Start(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase);
-            Environment.Exit(0);
-        }}
+				TShock.Utils.StopServer();
+				System.Diagnostics.Process.Start(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase);
+				Environment.Exit(0);
+			}
+		}
 
 		private static void OffNoSave(CommandArgs args)
 		{
-			TShock.Utils.ForceKickAll("Server shutting down!");
-			Netplay.disconnect = true;
+			TShock.Utils.StopServer(false);
 		}
 
 		private static void CheckUpdates(CommandArgs args)
@@ -2258,10 +2257,7 @@ namespace TShockAPI
 		{
 			Main.spawnTileX = args.Player.TileX + 1;
 			Main.spawnTileY = args.Player.TileY + 3;
-
-			TShock.Utils.Broadcast("Server map saving, potential lag spike");
-			Thread SaveWorld = new Thread(TShock.Utils.SaveWorld);
-			SaveWorld.Start();
+			SaveManager.Instance.SaveWorld(false);
 		}
 
 		private static void Reload(CommandArgs args)
@@ -2288,9 +2284,7 @@ namespace TShockAPI
 
 		private static void Save(CommandArgs args)
 		{
-			TShock.Utils.Broadcast("Server map saving, potential lag spike");
-			Thread SaveWorld = new Thread(TShock.Utils.SaveWorld);
-			SaveWorld.Start();
+			SaveManager.Instance.SaveWorld(false);
 		}
 
 		private static void Settle(CommandArgs args)

--- a/TShockAPI/RconHandler.cs
+++ b/TShockAPI/RconHandler.cs
@@ -253,9 +253,7 @@ namespace TShockAPI
 				WorldGen.genRand = new Random();
 			if (text.StartsWith("exit"))
 			{
-				TShock.Utils.ForceKickAll("Server shutting down!");
-				WorldGen.saveWorld(false);
-				Netplay.disconnect = true;
+				TShock.Utils.StopServer();
 				return "Server shutting down.";
 			}
 			else if (text.StartsWith("playing") || text.StartsWith("/playing"))

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -102,16 +102,10 @@ namespace TShockAPI
 			if (!GetBool(parameters["confirm"], false))
 				return RestInvalidParam("confirm");
 
-			if (!GetBool(parameters["nosave"], false))
-				WorldGen.saveWorld();
-			Netplay.disconnect = true;
-
 			// Inform players the server is shutting down
 			var msg = string.IsNullOrWhiteSpace(parameters["message"]) ? "Server is shutting down" : parameters["message"];
-			foreach (TSPlayer player in TShock.Players.Where(p => null != p))
-			{
-				TShock.Utils.ForceKick(player, msg);
-			}
+			TShock.Utils.StopServer(!GetBool(parameters["nosave"], false), msg);
+
 			return RestResponse("The server is shutting down");
 		}
 
@@ -305,7 +299,7 @@ namespace TShockAPI
 				return ret;
 
 			User user = (User)ret;
-			return new RestObject() { { "group", user.Group }, { "id", user.ID.ToString() } };
+			return new RestObject() { { "group", user.Group }, { "id", user.ID.ToString() }, { "name", user.Name } };
 		}
 
 		#endregion
@@ -411,7 +405,7 @@ namespace TShockAPI
 
 		private object WorldSave(RestVerbs verbs, IParameterCollection parameters)
 		{
-			TShock.Utils.SaveWorld();
+			SaveManager.Instance.SaveWorld();
 
 			return RestResponse("World saved");
 		}

--- a/TShockAPI/SaveManager.cs
+++ b/TShockAPI/SaveManager.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using System.Diagnostics;
+using Terraria;
+
+namespace TShockAPI
+{
+	class SaveManager : IDisposable
+	{
+		// Singleton
+		private static readonly SaveManager instance = new SaveManager();
+		private SaveManager() 
+		{
+			_saveThread = new Thread(SaveWorker);
+			_saveThread.Name = "TShock SaveManager Worker";
+			_saveThread.Start();
+		}
+		public static SaveManager Instance { get { return instance; } }
+
+		// Producer Consumer
+		private EventWaitHandle _wh = new AutoResetEvent(false);
+		private Object _saveLock = new Object();
+		private Queue<SaveTask> _saveQueue = new Queue<SaveTask>();
+		private Thread _saveThread;
+		private int saveQueueCount { get { lock (_saveLock) return _saveQueue.Count; } }
+
+		/// <summary>
+		/// SaveWorld event handler which notifies users that the server may lag
+		/// </summary>
+		public void OnSaveWorld(bool resettime = false, HandledEventArgs e = null)
+		{
+			TShock.Utils.Broadcast("Saving world. Momentary lag might result from this.", Color.Red);
+		}
+
+		/// <summary>
+		/// Saves the map data
+		/// </summary>
+		/// <param name="wait">wait for all pending saves to finish (default: true)</param>
+		/// <param name="resetTime">reset the last save time counter (default: false)</param>
+		/// <param name="direct">use the realsaveWorld method instead of saveWorld event (default: false)</param>
+		public void SaveWorld(bool wait = true, bool resetTime = false, bool direct = false)
+		{
+			EnqueueTask(new SaveTask(resetTime, direct));
+			if (!wait)
+				return;
+
+			// Wait for all outstanding saves to complete
+			int count = saveQueueCount;
+			while (0 != count)
+			{
+				Thread.Sleep(50);
+				count = saveQueueCount;
+			}
+		}
+
+		/// <summary>
+		/// Processes any outstanding saves, shutsdown the save thread and returns
+		/// </summary>
+		public void Dispose()
+		{
+			EnqueueTask(null);
+			_saveThread.Join();
+			_wh.Close();
+		}
+
+		private void EnqueueTask(SaveTask task)
+		{
+			lock (_saveLock)
+			{
+				_saveQueue.Enqueue(task);
+			}
+			_wh.Set();
+		}
+
+		private void SaveWorker()
+		{
+			while (true)
+			{
+				lock (_saveLock)
+				{
+					// NOTE: lock for the entire process so wait works in SaveWorld
+					if (_saveQueue.Count > 0)
+					{
+						SaveTask task = _saveQueue.Dequeue();
+						if (null == task)
+							return;
+						else
+						{
+							if (task.direct)
+							{
+								OnSaveWorld();
+								WorldGen.realsaveWorld(task.resetTime);
+							}
+							else
+								WorldGen.saveWorld(task.resetTime);
+							TShock.Utils.Broadcast("World saved.", Color.Yellow);
+							Log.Info(string.Format("World saved at ({0})", Main.worldPathName));
+						}
+					}
+				}
+				_wh.WaitOne();
+			}
+		}
+
+		class SaveTask
+		{
+			public bool resetTime { get; set; }
+			public bool direct { get; set; }
+			public SaveTask(bool resetTime, bool direct)
+			{
+				this.resetTime = resetTime;
+				this.direct = direct;
+			}
+		
+			public override string ToString()
+			{
+				return string.Format("resetTime {0}, direct {1}", resetTime, direct);
+			}
+		}
+	}
+}


### PR DESCRIPTION
...so as to ensure operations always happen in a predicable order. This fixes output not appearing in the console / log for example. This adds TShock.Utils.StopServer method used by IGA, rcon and the RestAPI.

Fixed console title set not working

Optimised command line parsing

Made Utils a singleton to enforce the fact that only one copy should ever exist

Added name to /v2/user/read output as users can be found by id
