### PR TITLE
Added compatibiliy shims for old method signatures

### DIFF
--- a/TShockAPI/DB/BanManager.cs
+++ b/TShockAPI/DB/BanManager.cs
@@ -110,6 +110,13 @@ namespace TShockAPI.DB
 			return null;
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public bool AddBan(string ip, string name, string reason)
+		{
+			return AddBan(ip, name, reason, false);
+		}
+#endif
 		public bool AddBan(string ip, string name = "", string reason = "", bool exceptions = false)
 		{
 			try
@@ -124,8 +131,14 @@ namespace TShockAPI.DB
 			}
 			return false;
 		}
-		
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public bool RemoveBan(string ip)
+		{
+			return RemoveBan(ip, false, true, false);
+		}
+#endif
 		public bool RemoveBan(string match, bool byName = false, bool casesensitive = true, bool exceptions = false)
 		{
 			try

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -28,7 +28,6 @@ namespace TShockAPI.DB
 	public class GroupManager : IEnumerable<Group>
 	{
 		private IDbConnection database;
-
 		public readonly List<Group> groups = new List<Group>();
 
 		public GroupManager(IDbConnection db)
@@ -101,7 +100,7 @@ namespace TShockAPI.DB
 		/// <param name="permissions">permissions</param>
 		/// <param name="chatcolor">chatcolor</param>
 		/// <param name="exceptions">exceptions true indicates use exceptions for errors false otherwise</param>
-		public String AddGroup(String name, string parentname, String permissions, String chatcolor = "255,255,255", bool exceptions = false)
+		public String AddGroup(String name, string parentname, String permissions, String chatcolor = Group.defaultChatColor, bool exceptions = false)
 		{
 			if (GroupExists(name))
 			{
@@ -142,9 +141,22 @@ namespace TShockAPI.DB
 
 		public String AddGroup(String name, String permissions)
 		{
-			return AddGroup(name, "", permissions, "255,255,255");
+			return AddGroup(name, null, permissions, Group.defaultChatColor, false);
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public String AddGroup(String name, string parentname, String permissions)
+		{
+			return AddGroup(name, parentname, permissions, Group.defaultChatColor, false);
+		}
+
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public String AddGroup(String name, string parentname, String permissions, String chatcolor)
+		{
+			return AddGroup(name, parentname, permissions, chatcolor, false);
+		}
+#endif
 		/// <summary>
 		/// Updates a group including permissions
 		/// </summary>
@@ -175,6 +187,13 @@ namespace TShockAPI.DB
 			groups.Add(newgroup);
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public String DeleteGroup(String name)
+		{
+			return DeleteGroup(name, false);
+		}
+#endif
 		public String DeleteGroup(String name, bool exceptions = false)
 		{
 			if (!GroupExists(name))

--- a/TShockAPI/Group.cs
+++ b/TShockAPI/Group.cs
@@ -23,6 +23,9 @@ namespace TShockAPI
 {
 	public class Group
 	{
+		// NOTE: Using a const still suffers from needing to recompile to change the default
+		// ideally we would use a static but this means it can't be used for the default parameter :(
+		public const string defaultChatColor = "255.255.255";
 		public readonly List<string> permissions = new List<string>();
 		public readonly List<string> negatedpermissions = new List<string>();
 
@@ -105,6 +108,14 @@ namespace TShockAPI
 		public byte R = 255;
 		public byte G = 255;
 		public byte B = 255;
+
+#if COMPAT_SIGS
+		[Obsolete("This constructor is for signature compatibility for external code only")]
+		public Group(string groupname, Group parentgroup, string chatcolor)
+			: this(groupname, parentgroup, chatcolor, null)
+		{
+		}
+#endif
 
 		public Group(string groupname, Group parentgroup = null, string chatcolor = "255,255,255", string permissions = null)
 		{

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -43,7 +43,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;COMPAT_SIGS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -530,6 +530,13 @@ namespace TShockAPI
 			Netplay.disconnect = true;
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public bool ForceKick(TSPlayer player, string reason)
+		{
+			return Kick(player, reason, true, false, string.Empty);
+		}
+#endif
 		/// <summary>
 		/// Kicks a player from the server without checking for immunetokick permission.
 		/// </summary>
@@ -541,6 +548,13 @@ namespace TShockAPI
 			Kick(player, reason, true, silent);
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public bool Kick(TSPlayer player, string reason, string adminUserName)
+		{
+			return Kick(player, reason, false, false, adminUserName);
+		}
+#endif
 		/// <summary>
 		/// Kicks a player from the server.
 		/// </summary>
@@ -569,6 +583,13 @@ namespace TShockAPI
 			return false;
 		}
 
+#if COMPAT_SIGS
+		[Obsolete("This method is for signature compatibility for external code only")]
+		public bool Ban(TSPlayer player, string reason, string adminUserName)
+		{
+			return Ban(player, reason, false, adminUserName);
+		}
+#endif
 		/// <summary>
 		/// Bans and kicks a player from the server.
 		/// </summary>


### PR DESCRIPTION
 without which existing compiled plugins will error with missing method ...

This fixes #410

NOTE: By default the compat shims are only enabled on the Release build and not on the debug build so that developers developing / testing will only see the latest signatures
