### PR TITLE
RememberPosManager should never store a zero value as part of a player position.

### DIFF
--- a/TShockAPI/DB/RememberPosManager.cs
+++ b/TShockAPI/DB/RememberPosManager.cs
@@ -52,7 +52,14 @@ namespace TShockAPI.DB
 				{
 					if (reader.Read())
 					{
-						return new Vector2(reader.Get<int>("X"), reader.Get<int>("Y"));
+						int checkX=reader.Get<int>("X");
+						int checkY=reader.Get<int>("Y");
+						//fix leftover inconsistancies
+						if (checkX==0)
+						   checkX++;
+						if (checkY==0)
+						   checkY++;
+						return new Vector2(checkX, checkY);
 					}
 				}
 			}
@@ -92,6 +99,7 @@ namespace TShockAPI.DB
 			{
 				try
 				{
+					if ((X != 0) && ( Y !=0)) //invalid pos!
 					database.Query("INSERT INTO RememberedPos (Name, IP, X, Y, WorldID) VALUES (@0, @1, @2, @3, @4);", name, IP, X, Y , Main.worldID.ToString());
 				}
 				catch (Exception ex)
@@ -103,6 +111,7 @@ namespace TShockAPI.DB
 			{
 				try
 				{
+					if ((X != 0) && ( Y !=0)) //invalid pos!
 					database.Query("UPDATE RememberedPos SET X = @0, Y = @1, IP = @2 WHERE Name = @3 AND WorldID = @4;", X, Y, IP, name, Main.worldID.ToString());
 				}
 				catch (Exception ex)


### PR DESCRIPTION
Add checks for invalid positions when the server does not report the correct player position values to the RememberPosManager system.
