### PR TITLE
Fixed negative spawnrate

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2271,8 +2271,19 @@ namespace TShockAPI
 				return;
 			}
 
-			int amount = Convert.ToInt32(args.Parameters[0]);
-			int.TryParse(args.Parameters[0], out amount);
+			int amount = -1;
+			if (!int.TryParse(args.Parameters[0], out amount))
+			{
+				args.Player.SendWarningMessage(string.Format("Invalid spawnrate ({0})", args.Parameters[0]));
+				return;
+			}
+
+			if (amount < 0)
+			{
+				args.Player.SendWarningMessage("Spawnrate cannot be negative!");
+				return;
+			}
+
 			NPC.defaultSpawnRate = amount;
 			TShock.Config.DefaultSpawnRate = amount;
 			TSPlayer.All.SendInfoMessage(string.Format("{0} changed the spawn rate to {1}.", args.Player.Name, amount));


### PR DESCRIPTION
Fixes:

```
2012-10-05 12:04:53 - Utils: INFO: Server executed: /spawnrate -10.

(crashlog.txt)
5/10/2012 12:04:53 PM
System.ArgumentOutOfRangeException: 'maxValue' must be greater than zero.
Parameter name: maxValue
   at System.Random.Next(Int32 maxValue)
   at Terraria.NPC.SpawnNPC()
   at Terraria.Main.Update()
   at Terraria.Main.DedServ()
   at Terraria.ProgramServer.Main(String[] args)
```

Also Fixes:

```
2012-10-05 12:23:59 - Commands: INFO: Server executed: /spawnrate str.
2012-10-05 12:23:59 - Commands: ERROR: System.FormatException: Input string was not in a correct format.
   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   at System.Convert.ToInt32(String value)
   at TShockAPI.Commands.SpawnRate(CommandArgs args)
   at TShockAPI.Command.Run(String msg, TSPlayer ply, List`1 parms)
```
