### PR TITLE
Fix SilentKickInProgress

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -825,12 +825,9 @@ namespace TShockAPI
 
 			if (tsplr != null && tsplr.ReceivedInfo)
 			{
-				if (!tsplr.SilentKickInProgress || tsplr.State > 1)
+				if (!tsplr.SilentKickInProgress && tsplr.State >= 3)
 				{
-					if (tsplr.State >= 2)
-					{
-                        Utils.Broadcast(tsplr.Name + " left", Color.Yellow);    
-					}
+					Utils.Broadcast(tsplr.Name + " left", Color.Yellow);
 				}
 				Log.Info(string.Format("{0} disconnected.", tsplr.Name));
 


### PR DESCRIPTION
https://github.com/TShock/TShock/commit/d01ae01468f6b53abba529f457326c5d2a983c32 will broadcast the leave message if the player's state is >= 2 regardless of SilentKickInProgress. It is also doing the same check twice for > 1, however in the commit nicatron says "if their state is > 2"

looking at the messageBuffer, the player's state gets changed to 3 before they get sent tile selection: https://github.com/Deathmax/TerrariaAPI-Server/blob/master/Terraria/messageBuffer.cs#L380
