### PR TITLE
Change defaultChatColor to commas so people aren't completely confused

### DIFF
--- a/TShockAPI/Group.cs
+++ b/TShockAPI/Group.cs
@@ -28,7 +28,7 @@ namespace TShockAPI
         /// <summary>
         /// Default chat color.
         /// </summary>
-		public const string defaultChatColor = "255.255.255";
+		public const string defaultChatColor = "255,255,255";
 
         /// <summary>
         /// List of permissions available to the group.


### PR DESCRIPTION
This will make it so people don't keep asking why the chat colors aren't working.
Please note I am not very good with github, hopefully this works.
