### PR TITLE
Allow a player to run a command if the permissions are empty.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -118,7 +118,7 @@ namespace TShockAPI
 
 		public bool CanRun(TSPlayer ply)
 		{
-			if (Permissions == null)
+			if (Permissions == null || Permissions.Count < 1)
 				return true;
 			foreach (var Permission in Permissions)
 			{


### PR DESCRIPTION
Olink set the default value for permissions to an empty list: https://github.com/TShock/TShock/commit/b37552ff271c8a335815f9cf41dede7da71eafcb#L0R87
However the CanRun function doesn't take this into account and wouldn't allow the player to execute the command.
