### PR TITLE
SSI Exploit Fix and Made /overidessi Actually Useful

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -160,14 +160,20 @@ namespace TShockAPI
 		public string UserAccountName { get; set; }
 
         /// <summary>
-        /// Unused can be removed.
+        /// Whether the player performed a valid login attempt (i.e. entered valid user name and password) but is still blocked
+        /// from logging in because of SSI.
         /// </summary>
-		public bool HasBeenSpammedWithBuildMessage;
+		public bool LoginFailsBySsi { get; set; }
 
         /// <summary>
         /// Whether the player is logged in or not.
         /// </summary>
 		public bool IsLoggedIn;
+
+        /// <summary>
+        /// Whether the player has sent their whole inventory to the server while connecting.
+        /// </summary>
+		public bool HasSentInventory { get; set; }
 
         /// <summary>
         /// The player's user id( from the db ).


### PR DESCRIPTION
The /overridessi command appeared, to be completely useless to me.
It's meant to fix the inventory of a player so that they can login again by just overwriting their inventory in the database with their current inventory. But the targeting player had to be logged in in order to use this command on them, where no login was possible at this point.

About the exploit, it worked like this:
-Join a server with DisableLoginBeforeJoin = true.
-Put an item into your trash can.
-Login now.
-Take the item out of your trash can.
-Successfully sneaked that item around SSI and IgnoreActionsForClearingTrashCan is false.

If the player would have done /login before moving the item to their trash can, it wouldn't have worked though because IgnoreActionsForClearingTrashCan would have been set to true in that case.
