### PR TITLE
Reload the server with its existing startup command line arguments

### DIFF
--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -576,8 +576,12 @@ namespace TShockAPI
 					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
 						TShock.InventoryDB.InsertPlayerData(player);
 
+		    String startupParameters = "";
+		    foreach (String s in Environment.GetCommandLineArgs())
+		        startupParameters += " " + s;
+
 			StopServer(true, reason);
-			System.Diagnostics.Process.Start(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase);
+			System.Diagnostics.Process.Start(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase, startupParameters);
 			Environment.Exit(0);
 		}
 


### PR DESCRIPTION
This should in theory fix #480, but as mentioned in that issue there are more elegant solutions to pursue for rebooting the server than what we currently do.

At least for the time being, I think this should be added as a crutch until a more clever solution is implemented to more cleanly reboot the server.
