### PR TITLE
Gracefully remove  WorldID from the WHERE clause in UPDATE SQL for RememberedPosManager

### DIFF
--- a/TShockAPI/DB/RememberedPosManager.cs
+++ b/TShockAPI/DB/RememberedPosManager.cs
@@ -113,7 +113,7 @@ namespace TShockAPI.DB
 				try
 				{
 					if ((X != 0) && ( Y !=0)) //invalid pos!
-					database.Query("UPDATE RememberedPos SET X = @0, Y = @1, IP = @2 WHERE Name = @3 AND WorldID = @4;", X, Y, IP, name, Main.worldID.ToString());
+					database.Query("UPDATE RememberedPos SET X = @0, Y = @1, IP = @2, WorldID = @3 WHERE Name = @4;", X, Y, IP, Main.worldID.ToString(), name);
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
Including logic to update the WorldID as part of the same SQL, should completely address #523
