### PR TITLE
Add AnnounceSave option

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -80,6 +80,7 @@ namespace TShockAPI
 		[Description("Bans a hardcore player on death.")] public bool BanOnMediumcoreDeath;
 
 		[Description("Enable/disable Terraria's built in auto save.")] public bool AutoSave = true;
+		[Description("Enable/disable save announcements.")] public bool AnnounceSave = true;
 
 		[Description("Number of failed login attempts before kicking the player.")] public int MaximumLoginAttempts = 3;
 

--- a/TShockAPI/SaveManager.cs
+++ b/TShockAPI/SaveManager.cs
@@ -48,16 +48,19 @@ namespace TShockAPI
 		/// </summary>
 		public void OnSaveWorld(WorldSaveEventArgs args)
 		{
-			// Protect against internal errors causing save failures
-			// These can be caused by an unexpected error such as a bad or out of date plugin
-			try
+			if (TShock.Config.AnnounceSave)
 			{
-				TShock.Utils.Broadcast("Saving world. Momentary lag might result from this.", Color.Red);
-			}
-			catch (Exception ex)
-			{
-				Log.Error("World saved notification failed");
-				Log.Error(ex.ToString());
+				// Protect against internal errors causing save failures
+				// These can be caused by an unexpected error such as a bad or out of date plugin
+				try
+				{
+					TShock.Utils.Broadcast("Saving world. Momentary lag might result from this.", Color.Red);
+				}
+				catch (Exception ex)
+				{
+					Log.Error("World saved notification failed");
+					Log.Error(ex.ToString());
+				}
 			}
 		}
 

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -42,6 +42,7 @@ An example configuration file is below.
 	  "KickOnMediumcoreDeath": false,
 	  "BanOnMediumcoreDeath": false,
 	  "AutoSave": true,
+	  "AnnounceSave": true,
 	  "MaximumLoginAttempts": 3,
 	  "RconPassword": "",
 	  "RconPort": 7777,
@@ -139,6 +140,11 @@ The following is the official documentation for the configuration file:
 ## AutoSave  
 **Type:** Boolean  
 **Description:** Enable/Disable Terrarias built in auto save  
+**Default:** "True"  
+
+## AnnounceSave  
+**Type:** Boolean  
+**Description:** Enable/Disable save announcements  
 **Default:** "True"  
 
 ## BackupInterval  


### PR DESCRIPTION
Rationale:
1. The save announcement is unnecessary for small worlds / few players / high-end servers
2. The save announcement is a bit distracting since it appears as a chat message
3. Since the auto-save always happens at dawn, it's a cheap way to know the time when underground.
