### PR TITLE
Fixed ChatAboveHeads format not working for 'ply'

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -986,8 +986,8 @@ namespace TShockAPI
 					string name = Main.player[args.Who].name;
 					Main.player[args.Who].name = String.Format(Config.ChatAboveHeadsFormat, tsplr.Group.Name, tsplr.Group.Prefix, tsplr.Name, tsplr.Group.Suffix);
 					NetMessage.SendData((int)PacketTypes.PlayerInfo, -1, -1, Main.player[args.Who].name, args.Who, 0, 0, 0, 0);
-					Main.player[args.Who].name = name;
 					Utils.Broadcast(args.Who, args.Text, tsplr.Group.R, tsplr.Group.G, tsplr.Group.B);
+					Main.player[args.Who].name = name;
 					NetMessage.SendData((int)PacketTypes.PlayerInfo, -1, -1, name, args.Who, 0, 0, 0, 0);
 					args.Handled = true;
 				}

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -203,20 +203,33 @@ namespace TShockAPI
 			Broadcast(msg, color.R, color.G, color.B);
 		}
 
-        /// <summary>
-        /// Broadcasts a message from a player, not TShock
-        /// </summary>
-        /// <param name="ply">TSPlayer ply - the player that will send the packet</param>
-        /// <param name="msg">string msg - the message</param>
-        /// <param name="red">r</param>
-        /// <param name="green">g</param>
-        /// <param name="blue">b</param>
-        public void Broadcast(int ply, string msg, byte red, byte green, byte blue)
-        {
-            TSPlayer.All.SendMessageFromPlayer(msg, red, green, blue, ply);
-            TSPlayer.Server.SendMessage(Main.player[ply].name + ": " + msg, red, green, blue);
-            Log.Info(string.Format("Broadcast: {0}", Main.player[ply].name + ": " + msg));
-        }
+		/// <summary>
+		/// Broadcasts a message from a player, not TShock
+		/// </summary>
+		/// <param name="ply">TSPlayer ply - the player that will send the packet</param>
+		/// <param name="msg">string msg - the message</param>
+		/// <param name="red">r</param>
+		/// <param name="green">g</param>
+		/// <param name="blue">b</param>
+		public void Broadcast(int ply, string msg, byte red, byte green, byte blue)
+		{
+			foreach (TSPlayer player in TShock.Players)
+			{
+				if (player != null)
+				{
+					if (player == TShock.Players[ply])
+					{
+						player.SendMessage(string.Format("<{0}> {1}", TShock.Players[ply].Name, msg), red, green, blue);
+					}
+					else
+					{
+						player.SendMessageFromPlayer(msg, red, green, blue, ply);
+					}
+				}
+			}
+			TSPlayer.Server.SendMessage(Main.player[ply].name + ": " + msg, red, green, blue);
+			Log.Info(string.Format("Broadcast: {0}", Main.player[ply].name + ": " + msg));
+		}
 
 		/// <summary>
 		/// Sends message to all players with 'logs' permission.


### PR DESCRIPTION
ChatAboveHeads format is currently not working for the chatting player.
Like, if I am chatting, I will only see "< simon311> Message", while as others will see "<(Admin) simon311> Message".
This fixes it. But, this might reduce performance.
Or, you can look into the issue more deeply and perhaps find better solution :)
