### PR TITLE
Switched to using HttpStatusCode for status codes in Rest API.

### DIFF
--- a/TShockAPI/Rest/Rest.cs
+++ b/TShockAPI/Rest/Rest.cs
@@ -144,7 +144,14 @@ namespace Rests
 			e.Response.ContentType = new ContentTypeHeader("application/json");
 			e.Response.Add(serverHeader);
 			e.Response.Body.Write(Encoding.ASCII.GetBytes(str), 0, str.Length);
-			e.Response.Status = HttpStatusCode.OK;
+			if (obj is RestObject)
+			{
+				e.Response.Status = ((RestObject)obj).Status;
+			}
+			else
+			{
+				e.Response.Status = HttpStatusCode.OK;
+			}
 		}
 
 		protected virtual object ProcessRequest(object sender, RequestEventArgs e)
@@ -180,14 +187,14 @@ namespace Rests
 			}
 			catch (Exception exception)
 			{
-				return new RestObject("500")
+				return new RestObject(HttpStatusCode.InternalServerError)
 				       	{
 				       		{"error", "Internal server error."},
 				       		{"errormsg", exception.Message},
 				       		{"stacktrace", exception.StackTrace},
 				       	};
 			}
-			return new RestObject("404")
+			return new RestObject(HttpStatusCode.NotFound)
 			       	{
 			       		{"error", "Specified API endpoint doesn't exist. Refer to the documentation for a list of valid endpoints."}
 			       	};

--- a/TShockAPI/Rest/RestCommand.cs
+++ b/TShockAPI/Rest/RestCommand.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using HttpServer;
 
@@ -92,13 +93,13 @@ namespace Rests
 
 		public override object Execute(RestVerbs verbs, IParameterCollection parameters)
 		{
-			return new RestObject("401") { Error = "Not authorized. The specified API endpoint requires a token." };
+			return new RestObject(HttpStatusCode.Unauthorized) { Error = "Not authorized. The specified API endpoint requires a token." };
 		}
 
 		public object Execute(RestVerbs verbs, IParameterCollection parameters, SecureRest.TokenData tokenData)
 		{
 			if (tokenData.Equals(SecureRest.TokenData.None))
-				return new RestObject("401") { Error = "Not authorized. The specified API endpoint requires a token." };
+				return new RestObject(HttpStatusCode.Unauthorized) { Error = "Not authorized. The specified API endpoint requires a token." };
 
 			return callback(verbs, parameters, tokenData);
 		}

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Net;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -186,7 +187,7 @@ namespace TShockAPI
 		{
 			string motdFilePath = Path.Combine(TShock.SavePath, "motd.txt");
 			if (!File.Exists(motdFilePath))
-				return this.RestError("The motd.txt was not found.", "500");
+				return this.RestError("The motd.txt was not found.", HttpStatusCode.InternalServerError);
 
 			return new RestObject()
 			{
@@ -198,7 +199,7 @@ namespace TShockAPI
 		{
 			string rulesFilePath = Path.Combine(TShock.SavePath, "rules.txt");
 			if (!File.Exists(rulesFilePath))
-				return this.RestError("The rules.txt was not found.", "500");
+				return this.RestError("The rules.txt was not found.", HttpStatusCode.InternalServerError);
 
 			return new RestObject()
 			{
@@ -733,12 +734,12 @@ namespace TShockAPI
 
 		#region Utility Methods
 
-		private RestObject RestError(string message, string status = "400")
+		private RestObject RestError(string message, HttpStatusCode status = HttpStatusCode.BadRequest)
 		{
 			return new RestObject(status) {Error = message};
 		}
 
-		private RestObject RestResponse(string message, string status = "200")
+		private RestObject RestResponse(string message, HttpStatusCode status = HttpStatusCode.OK)
 		{
 			return new RestObject(status) {Response = message};
 		}

--- a/TShockAPI/Rest/RestObject.cs
+++ b/TShockAPI/Rest/RestObject.cs
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 using System;
+using System.Net;
 using System.Collections.Generic;
 
 namespace Rests
@@ -24,9 +25,9 @@ namespace Rests
 	[Serializable]
 	public class RestObject : Dictionary<string, object>
 	{
-		public string Status
+		public HttpStatusCode Status
 		{
-			get { return this["status"] as string; }
+			get { return (HttpStatusCode)this["status"]; }
 			set { this["status"] = value; }
 		}
 
@@ -46,10 +47,10 @@ namespace Rests
 		// Note: The constructor with all defaults isn't good enough :(
 		public RestObject()
 		{
-			Status = "200";
+			Status = HttpStatusCode.OK;
 		}
 
-		public RestObject(string status = "200")
+		public RestObject(HttpStatusCode status = HttpStatusCode.OK)
 		{
 			Status = status;
 		}

--- a/TShockRestTestPlugin/TShockRestTestPlugin.cs
+++ b/TShockRestTestPlugin/TShockRestTestPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
@@ -38,8 +39,8 @@ namespace TshockRestTestPlugin
 	{
 		// The status of the JSON request
 		[DisplayName("JSON Status")]
-		[DefaultValue("400")]
-		public new string JSonStatus { get { return base.JSonStatus; } set { base.JSonStatus = value; } }
+		[DefaultValue(HttpStatusCode.BadRequest)]
+		public new HttpStatusCode JSonStatus { get { return base.JSonStatus; } set { base.JSonStatus = value; } }
 
 		// The name of the desired JSON property
 		[DisplayName("Property")]
@@ -164,8 +165,8 @@ namespace TshockRestTestPlugin
 	{
 		// The status of the JSON request
 		[DisplayName("JSON Status")]
-		[DefaultValue("200")]
-		public string JSonStatus { get; set; }
+		[DefaultValue(HttpStatusCode.OK)]
+		public HttpStatusCode JSonStatus { get; set; }
 
 		public RestObject ValidateJson(object sender, ValidationEventArgs e)
 		{


### PR DESCRIPTION
In addition if the return from the processing is a Rest object then the HTTP response code with be that of the Rest status code.

This addresses issue: https://github.com/NyxStudios/TShock/issues/660
