### PR TITLE
Fixed double teleporting with SSC

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1138,10 +1138,10 @@ namespace TShockAPI
 
 			player.LastNetPosition = new Vector2(Main.spawnTileX*16f, Main.spawnTileY*16f);
 
-			if (Config.RememberLeavePos && (RememberedPos.GetLeavePos(player.Name, player.IP) != Vector2.Zero))
+            if (Config.RememberLeavePos && (RememberedPos.GetLeavePos(player.Name, player.IP) != Vector2.Zero) && Config.ServerSideCharacter && Config.DisableLoginBeforeJoin)
 			{
-			player.RPPending=3;
-			player.SendMessage("You will be teleported to your last known location...", Color.Red);
+			    player.RPPending=3;
+			    player.SendMessage("You will be teleported to your last known location...", Color.Red);
 			}
 			
 			args.Handled = true;


### PR DESCRIPTION
users getting teleported twice with ssc and rememberpos if they didn't
have loginbeforejoin enabled
