### PR TITLE
Redo some permissions

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -332,7 +332,11 @@ namespace TShockAPI
 			{
 				HelpText = "Kills hostile NPCs or NPCs of a certain type."
 			});
-			add(new Command(Permissions.cfgmaxspawns, MaxSpawns, "maxspawns")
+			add(new Command(Permissions.invade, Invade, "invade")
+			{
+				HelpText = "Starts an NPC invasion."
+			});
+			add(new Command(Permissions.maxspawns, MaxSpawns, "maxspawns")
 			{
 				HelpText = "Sets the maximum number of NPCs."
 			});
@@ -346,7 +350,7 @@ namespace TShockAPI
 				AllowServer = false,
 				HelpText = "Spawns a number of mobs around you."
 			});
-			add(new Command(Permissions.cfgspawnrate, SpawnRate, "spawnrate")
+			add(new Command(Permissions.spawnrate, SpawnRate, "spawnrate")
 			{
 				HelpText = "Sets the spawn rate of NPCs."
 			});
@@ -379,11 +383,11 @@ namespace TShockAPI
 			});
 			#endregion
 			#region World Commands
-			add(new Command(Permissions.editspawn, ToggleAntiBuild, "antibuild")
+			add(new Command(Permissions.antibuild, ToggleAntiBuild, "antibuild")
 			{
 				HelpText = "Toggles build protection."
 			});
-			add(new Command(Permissions.causeevents, Bloodmoon, "bloodmoon")
+			add(new Command(Permissions.bloodmoon, Bloodmoon, "bloodmoon")
 			{
 				HelpText = "Sets a blood moon."
 			});
@@ -392,11 +396,11 @@ namespace TShockAPI
 				AllowServer = false,
 				HelpText = "Grows plants at your location."
 			});
-			add(new Command(Permissions.causeevents, DropMeteor, "dropmeteor")
+			add(new Command(Permissions.dropmeteor, DropMeteor, "dropmeteor")
 			{
 				HelpText = "Drops a meteor somewhere in the world."
 			});
-			add(new Command(Permissions.causeevents, Eclipse, "eclipse")
+			add(new Command(Permissions.eclipse, Eclipse, "eclipse")
 			{
 				HelpText = "Sets an eclipse."
 			});
@@ -404,7 +408,7 @@ namespace TShockAPI
 			{
 				HelpText = "Toggles christmas mode (present spawning, santa, etc)."
 			});
-			add(new Command(Permissions.causeevents, Fullmoon, "fullmoon")
+			add(new Command(Permissions.fullmoon, Fullmoon, "fullmoon")
 			{
 				HelpText = "Sets a full moon."
 			});
@@ -412,15 +416,11 @@ namespace TShockAPI
 			{
 				HelpText = "Toggles the world's hardmode status."
 			});
-			add(new Command(Permissions.causeevents, Invade, "invade")
-			{
-				HelpText = "Starts an NPC invasion."
-			});
 			add(new Command(Permissions.editspawn, ProtectSpawn, "protectspawn")
 			{
 				HelpText = "Toggles spawn protection."
 			});
-			add(new Command(Permissions.causeevents, Rain, "rain")
+			add(new Command(Permissions.rain, Rain, "rain")
 			{
 				HelpText = "Toggles the rain."
 			});

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -64,7 +64,7 @@ namespace TShockAPI.DB
 				string.Join(",", Permissions.kick, Permissions.editspawn, Permissions.reservedslot));
 
 			AddDefaultGroup("admin", "newadmin",
-				string.Join(",", Permissions.ban, Permissions.whitelist, Permissions.causeevents, Permissions.spawnboss,
+				string.Join(",", Permissions.ban, Permissions.whitelist, "tshock.world.time.*", Permissions.spawnboss,
 					Permissions.spawnmob, Permissions.managewarp, Permissions.time, Permissions.tp, Permissions.slap,
 					Permissions.kill, Permissions.logs,
 					Permissions.immunetokick, Permissions.tphere));

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -40,6 +40,9 @@ namespace TShockAPI
 
 		// tshock.admin nodes
 
+		[Description("User can set build protection status.")]
+		public static readonly string antibuild = "tshock.admin.antibuild";
+
 		[Description("Prevents you from being kicked.")]
 		public static readonly string immunetokick = "tshock.admin.nokick";
 
@@ -107,12 +110,6 @@ namespace TShockAPI
 		[Description("User can reload the configurations file.")]
 		public static readonly string cfgreload = "tshock.cfg.reload";
 
-		[Description("User can edit the max spawns.")]
-		public static readonly string cfgmaxspawns = "tshock.cfg.maxspawns";
-
-		[Description("User can edit the spawnrate.")]
-		public static readonly string cfgspawnrate = "tshock.cfg.spawnrate";
-
 		[Description("User can download updates to plugins that are currently running.")]
 		public static readonly string updateplugins = "tshock.cfg.updateplugins";
 
@@ -157,6 +154,15 @@ namespace TShockAPI
 		public static readonly string usebanneditem = "tshock.item.usebanned";
 
 		// tshock.npc nodes
+
+		[Description("User can edit the max spawns.")]
+		public static readonly string maxspawns = "tshock.npc.maxspawns";
+
+		[Description("User can edit the spawnrate.")]
+		public static readonly string spawnrate = "tshock.npc.spawnrate";
+
+		[Description("User can start an invasion.")]
+		public static readonly string invade = "tshock.npc.invade";
 
 		[Description("User can spawn bosses.")]
 		public static readonly string spawnboss = "tshock.npc.spawnboss";
@@ -209,8 +215,14 @@ namespace TShockAPI
 		[Description("Allows you to edit the spawn.")]
 		public static readonly string editspawn = "tshock.world.editspawn";
 
+		[Description("Allows you to edit regions.")]
+		public static readonly string editregion = "tshock.world.editregion";
+
+		[Description("User can force a blood moon.")]
+		public static readonly string bloodmoon = "tshock.world.time.bloodmoon";
+
 		[Description("User can set the time.")]
-		public static readonly string time = "tshock.world.settime";
+		public static readonly string time = "tshock.world.time.set";
 
 		[Description("User can grow plants.")]
 		public static readonly string grow = "tshock.world.grow";
@@ -239,14 +251,23 @@ namespace TShockAPI
 		[Description("User can set the world spawn.")]
 		public static readonly string worldspawn = "tshock.world.setspawn";
 
-		[Description("User can cause some events.")]
-		public static readonly string causeevents = "tshock.world.causeevents";
+		[Description("User can drop a meteor.")]
+		public static readonly string dropmeteor = "tshock.world.time.dropmeteor";
+
+		[Description("User can force an eclipse.")]
+		public static readonly string eclipse = "tshock.world.time.eclipse";
+
+		[Description("User can force a full moon.")]
+		public static readonly string fullmoon = "tshock.world.time.fullmoon";
 
 		[Description("User can modify the world.")]
 		public static readonly string canbuild = "tshock.world.modify";
 		
 		[Description("User can paint tiles.")]
 		public static readonly string canpaint = "tshock.world.paint";
+
+		[Description("User can turn on or off the rain.")]
+		public static readonly string rain = "tshock.world.rain";
 
 		// Non-grouped
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1476,7 +1476,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (!player.Group.HasPermission(Permissions.editspawn) && !Regions.CanBuild(tileX, tileY, player) &&
+			if (!player.Group.HasPermission(Permissions.editregion) && !Regions.CanBuild(tileX, tileY, player) &&
 				Regions.InArea(tileX, tileY))
 			{
 				if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.RPm) > 2000)
@@ -1489,7 +1489,7 @@ namespace TShockAPI
 
 			if (Config.DisableBuild)
 			{
-				if (!player.Group.HasPermission(Permissions.editspawn))
+				if (!player.Group.HasPermission(Permissions.antibuild))
 				{
 					if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000)
 					{
@@ -1531,7 +1531,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (!player.Group.HasPermission(Permissions.editspawn) && !Regions.CanBuild(tileX, tileY, player) &&
+			if (!player.Group.HasPermission(Permissions.editregion) && !Regions.CanBuild(tileX, tileY, player) &&
 				Regions.InArea(tileX, tileY))
 			{
 				if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.RPm) > 2000)
@@ -1544,7 +1544,7 @@ namespace TShockAPI
 
 			if (Config.DisableBuild)
 			{
-				if (!player.Group.HasPermission(Permissions.editspawn))
+				if (!player.Group.HasPermission(Permissions.antibuild))
 				{
 					if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.WPm) > 2000)
 					{


### PR DESCRIPTION
Splits up tshock.world.causeevents & tshock.world.editspawn (fixing #671 in the process) and moves /maxspawns and /spawnrate to the npc node.
