### PR TITLE
fix MemoryStream passed to HandlerGetData containing an extra byte

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1379,7 +1379,7 @@ namespace TShockAPI
 			var male = args.Data.ReadBoolean();
 			args.Data.Position += 21;
 			var difficulty = args.Data.ReadInt8();
-			string name = Encoding.UTF8.GetString(args.Data.ReadBytes((int) (args.Data.Length - args.Data.Position - 1)));
+			string name = Encoding.UTF8.GetString(args.Data.ReadBytes((int) (args.Data.Length - args.Data.Position)));
 
 			if (OnPlayerInfo(playerid, hair, male, difficulty, name))
 			{
@@ -1487,7 +1487,7 @@ namespace TShockAPI
 			if (!args.Player.RequiresPassword)
 				return true;
 
-			string password = Encoding.UTF8.GetString(args.Data.ReadBytes((int) (args.Data.Length - args.Data.Position - 1)));
+			string password = Encoding.UTF8.GetString(args.Data.ReadBytes((int) (args.Data.Length - args.Data.Position)));
 
             if (Hooks.PlayerHooks.OnPlayerPreLogin(args.Player, args.Player.Name, password))
                 return true;
@@ -2518,7 +2518,7 @@ namespace TShockAPI
 			if (OnKillMe(id, direction, dmg, pvp))
 				return true;
 
-			int textlength = (int)(args.Data.Length - args.Data.Position - 1);
+			int textlength = (int)(args.Data.Length - args.Data.Position);
 			string deathtext = "";
 			if (textlength > 0)
 			{
@@ -3006,7 +3006,7 @@ namespace TShockAPI
 			if (OnPlayerDamage(id, direction, dmg, pvp, crit))
 				return true;
 
-			int textlength = (int) (args.Data.Length - args.Data.Position - 1);
+			int textlength = (int) (args.Data.Length - args.Data.Position);
 			string deathtext = "";
 			if (textlength > 0)
 			{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1115,7 +1115,7 @@ namespace TShockAPI
 				return;
 			}
 
-			using (var data = new MemoryStream(e.Msg.readBuffer, e.Index, e.Length))
+			using (var data = new MemoryStream(e.Msg.readBuffer, e.Index, e.Length - 1))
 			{
 				try
 				{


### PR DESCRIPTION
When OnGetData is called, it gets passed the position of the first
byte following the packet ID, but the length it is passed is the
length of the entire packet _including_ the packet ID byte. So when
the MemoryStream is constructed with that length, it actually
contains an extra byte not in the packet, whatever is next in the
buffer.

Fix this so that the MemoryStream only contains the packet itself,
without the extra byte.

---

I'm not entirely sure that this should be done here, exactly; it's possible that OnGetData's caller (in TerrariaServer) should be fixed instead, but it seems easier to fix it here.

While I do think that this fix is an improvement, this will break existing plugins which use the Length of the MemoryStream in calculations. I know for a fact that it will break InfiniteSigns, for example, but the fix is trivial, as it will likely be in most cases.
