### PR TITLE
Don't let a player /grow stuff in regions he does not own.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4458,6 +4458,13 @@ namespace TShockAPI
 			var name = "Fail";
 			var x = args.Player.TileX;
 			var y = args.Player.TileY + 3;
+
+			if (TShock.Regions.Regions.Where(Region => !Region.HasPermissionToBuildInRegion(args.Player) && Region.InArea(x, y)).Count() > 0)
+			{
+				args.Player.SendErrorMessage("You're not allowed to build in this region!");
+				return;
+			}
+
 			switch (args.Parameters[0].ToLower())
 			{
 				case "tree":


### PR DESCRIPTION
It could also be a good idea to not let him build in other cases, like if antibuild is on, or if he is in spawn protection range, but I'm probably too stupid to find how to check all that in one line.
