### PR TITLE
Adds HelpDesc, an optional, more detailed version of HelpText

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -70,7 +70,7 @@ namespace TShockAPI
 		/// </summary>
 		public string HelpText { get; set; }
         /// <summary>
-        /// Gets or sets the help text of this command.
+        /// Gets or sets an extended description of this command.
         /// </summary>
         public string[] HelpDesc { get; set; }
 		/// <summary>
@@ -3613,15 +3613,17 @@ namespace TShockAPI
 				}
 
 				args.Player.SendSuccessMessage("/{0} help: ", command.Name);
-                if (command.HelpDesc != null)
+                if (command.HelpDesc == null)
+                {
+                    args.Player.SendInfoMessage(command.HelpText);
+                }
+                else if (command.HelpDesc != null)
                 {
                     foreach (string line in command.HelpDesc)
                     {
                         args.Player.SendInfoMessage(line);
                     }
                 }
-                else
-				    args.Player.SendInfoMessage(command.HelpText);
 			}
 		}
 


### PR DESCRIPTION
Adds better support for multiple line HelpText by changing it into a string array.

Changed all TShock commands's HelpText to reflect this change. Instead of a simple HelpText = "string", it will now require HelpText = new[] {"string1", "string2", "stringx"} as you're obviously familiar with.

This will, however, break other developer's plugins which use HelpText.

I felt like this would be an useful change because line-break(\n) has it's own limitations based on Terraria's Chat Handling system. If more than 5 line breaks are made, the lines would overlap each other, since Terraria can only show 5 lines at a time.
