### PR TITLE
Adds HelpDesc to Command, a more detailed version of HelpText, which may...

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -69,6 +69,10 @@ namespace TShockAPI
 		/// Gets or sets the help text of this command.
 		/// </summary>
 		public string HelpText { get; set; }
+        /// <summary>
+        /// Gets or sets an extended description of this command.
+        /// </summary>
+        public string[] HelpDesc { get; set; }
 		/// <summary>
 		/// Gets the name of the command.
 		/// </summary>
@@ -118,6 +122,7 @@ namespace TShockAPI
 			CommandDelegate = cmd;
 			DoLog = true;
 			HelpText = "No help available.";
+            HelpDesc = null;
 			Names = new List<string>(names);
 			Permissions = new List<string>();
 		}
@@ -3608,7 +3613,17 @@ namespace TShockAPI
 				}
 
 				args.Player.SendSuccessMessage("/{0} help: ", command.Name);
-				args.Player.SendInfoMessage(command.HelpText);
+                if (command.HelpDesc == null)
+                {
+                    args.Player.SendInfoMessage(command.HelpText);
+                }
+                else if (command.HelpDesc != null)
+                {
+                    foreach (string line in command.HelpDesc)
+                    {
+                        args.Player.SendInfoMessage(line);
+                    }
+                }
 			}
 		}
 


### PR DESCRIPTION
... be used by Devs to create a functional multi-line /help <command> description. If HelpDesc is given a value, HelpText will not show.

This will not break any of the current plugins, since it's entirely optional. Adds variety, removes nothing.

If this were to be universalized, players would use built-in /help <command> for every plugin instead of browsing specific plugin help commands, making everything much simpler.

_Thanks for the help with Pull Requests Olink, this is what happens when github fails you._
