### PR TITLE
increase default MaxDamage

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -211,7 +211,7 @@ namespace TShockAPI
 
 		[Description("Allows users to login with any username with /login.")] public bool AllowLoginAnyUsername = true;
 
-        [Description("The maximum damage a player/npc can inflict.")] public int MaxDamage = 175;
+        [Description("The maximum damage a player/npc can inflict.")] public int MaxDamage = 200;
         
         [Description("The maximum damage a projectile can inflict.")] public int MaxProjDamage = 175;
 


### PR DESCRIPTION
In 1.2.3, some weapon will do more than 175 damage, ex: [Terra Blade](http://terraria.gamepedia.com/Terra_Blade), may be need greater than 200, please update.
