### PR TITLE
Fix Completed Quests typo in SSC

### DIFF
--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -105,7 +105,7 @@ namespace TShockAPI.DB
 			string initialItems = "-15,1,0~-13,1,0~-16,1,45~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0~0,0,0";
 			try
 			{
-				database.Query("INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, spawnX, spawnY, completedQuests) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8);", user.ID,
+				database.Query("INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, spawnX, spawnY, questsCompleted) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8);", user.ID,
 							   100, 100, 20, 20, initialItems, -1, -1, 0);
 				return true;
 			}


### PR DESCRIPTION
Word is spelled correctly but in wrong order.
Everywhere normally uses "questsCompleted" as column name to save quests amount done but Olink accidently uses "completedQuests" when inserting new row on player register. So that will create an error where column "completedQuests" does not exist so new row wasn't made and so SSC won't save.

This failure was created by this commit : 0ea58cde3e8b88301fddd35ec776db53ed787729 (Update SSC to include quests, skin color, eye color)
