### PR TITLE
Prevent collection modification.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -567,7 +567,7 @@ namespace TShockAPI
 			string cmdName = args[0].ToLower();
 			args.RemoveAt(0);
 
-			IEnumerable<Command> cmds = ChatCommands.Where(c => c.HasAlias(cmdName));
+			IEnumerable<Command> cmds = ChatCommands.Where(c => c.HasAlias(cmdName)).ToList();
 
 			if (Hooks.PlayerHooks.OnPlayerCommand(player, cmdName, cmdText, args, ref cmds))
 				return true;


### PR DESCRIPTION
When a command handler is called, if that callback attempts to register a new command it will cause the collection to be modified since it is not a copied list. 

For example with my Addons plugin, when you use:
/addon load test

This will invoke the plugins handler for the addon command. If an addon that is loaded during this time tries to register its own command the collection will be modified and error. Adding .ToList() to the Where clause will prevent this as a copy of the collection is created instead of iterating the existing collection during runtime.
