### PR TITLE
Some misc changes for player purposes.

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -811,8 +811,8 @@ namespace TShockAPI
 							item.type != 0)
 						{
 							check = "Remove item " + item.name + " (" + item.stack + ") exceeds max stack of " + item.maxStack;
-                            player.SendErrorMessage(check);
-                            break;
+							player.SendErrorMessage(check);
+							break;
 						}
 					}
 					player.IgnoreActionsForCheating = check;
@@ -824,8 +824,9 @@ namespace TShockAPI
 							player.SetBuff(30, 120); //Bleeding
 							player.SetBuff(36, 120); //Broken Armor
 							check = "Remove armor/accessory " + item.name;
-
-                            player.SendErrorMessage(string.Format("You are wearing banned equipment. {0}", check));
+							
+							player.SendErrorMessage(string.Format("You are wearing banned equipment. {0}", check));
+							break;
 						}
 					}
 					player.IgnoreActionsForDisabledArmor = check;


### PR DESCRIPTION
Added check for over-stacked items creating a negative amount for items over max stack count.
Added message output to player for why they are disabled when having an over-stacked item.
Added message output to player for why they are disabled when having a banned item equipped.

If users hack their stackable items using an inventory editor to a max int value, TShock will see this as a negative number and not properly disable the player. 

Also added outputs to the player if they are being disabled for a hacked item stack or banned equipment instead of them guessing why they are just frozen since the server does not send any info to the player during these occasions.
