### PR TITLE
Adds kick/ban on hardcore death.

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -93,9 +93,9 @@ namespace TShockAPI
 		public bool HardcoreOnly;
 		[Description("Mediumcore players ONLY. This means softcore players cannot join.")]
 		public bool MediumcoreOnly;
-		[Description("Kicks a hardcore player on death.")]
+		[Description("Kicks a mediumcore player on death.")]
 		public bool KickOnMediumcoreDeath;
-		[Description("Bans a hardcore player on death.")]
+		[Description("Bans a mediumcore player on death.")]
 		public bool BanOnMediumcoreDeath;
 
 		[Description("Enable/disable Terraria's built in auto save.")]
@@ -375,6 +375,19 @@ namespace TShockAPI
 
 		[Description("Specifies which string starts a command")]
 		public string CommandSpecifier = "/";
+		
+		[Description("Kicks a hardcore player on death.")]
+		public bool KickOnHardcoreDeath;
+		
+		[Description("Bans a hardcore player on death.")]
+		public bool BanOnHardcoreDeath;
+		
+		[Description("Bans a hardcore player on death.")]
+		public string HardcoreBanReason = "Death results in a ban";
+		
+		[Description("Kicks a hardcore player on death.")]
+		public string HardcoreKickReason = "Death results in a kick";
+		
 
 		/// <summary>
 		/// Reads a configuration file from a given path

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2612,6 +2612,19 @@ namespace TShockAPI
 				}
 			}
 
+            if (args.TPlayer.difficulty == 2 && (TShock.Config.KickOnHardcoreDeath || TShock.Config.BanOnHardcoreDeath))
+            {
+                if (TShock.Config.BanOnHardcoreDeath)
+                {
+                    if (!TShock.Utils.Ban(args.Player, TShock.Config.HardcoreBanReason, false, "hardcore-death"))
+                        TShock.Utils.ForceKick(args.Player, "Death results in a ban, but can't ban you.", true);
+                }
+                else
+                {
+                    TShock.Utils.ForceKick(args.Player, TShock.Config.HardcoreKickReason, true, false);
+                }
+            }
+			
 			if (args.TPlayer.difficulty == 2 && TShock.Config.ServerSideCharacter && args.Player.IsLoggedIn)
 			{
 				User user = TShock.Users.GetUserByName(args.Player.UserAccountName);


### PR DESCRIPTION
Because it exists for Mediumcore, and gives a way to prevent ghosts from roaming about.
