### PR TITLE
Fix Force Xmas Message Display

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1413,7 +1413,7 @@ namespace TShockAPI
 		{
 			TShock.Config.ForceXmas = !TShock.Config.ForceXmas;
 			Main.checkXMas();
-			TSPlayer.All.SendInfoMessage("{0} {1}abled Christmas mode!", args.Player.Name, (TShock.Config.ForceHalloween ? "en" : "dis"));
+			TSPlayer.All.SendInfoMessage("{0} {1}abled Christmas mode!", args.Player.Name, (TShock.Config.ForceXmas ? "en" : "dis"));
 		}
 
 		private static void TempGroup(CommandArgs args)


### PR DESCRIPTION
Don't know why it was already seen long time ago by those who added Halloween Force but it wasn't fixed in long time yet. So, lemme do it or else you will see it all time the disabled if you get Halloween off.
