### PR TITLE
Fix TSPlayer.ActiveChest attribution

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2889,6 +2889,9 @@ namespace TShockAPI
 				return true;
 			}
 
+			// This is only sent when closing, no need to read the value
+			args.Player.ActiveChest = -1;
+
 			return false;
 		}
 


### PR DESCRIPTION
Packet 33 is only sent by the client when the chest is closed, thus it gets kinda pointless for the attribution to be made there. This was causing players' ActiveChest to always be -1.
