### PR TITLE
Refactored npcStreamSpeed field name to be consistent with how it appears in serverconfig.txt.

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -389,7 +389,7 @@ namespace TShockAPI
 		public int MaxMP = 200;
 
 		[Description("Reduces enemy skipping but increases bandwidth usage. The lower the number the less skipping will happen, but more data is sent. 0 is off.")]
-		public int NpcStreamSpeed = 60;
+		public int NpcStream = 60;
 
 		/// <summary>
 		/// Reads a configuration file from a given path

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1763,7 +1763,7 @@ namespace TShockAPI
 			NPC.defaultMaxSpawns = file.DefaultMaximumSpawns;
 			NPC.defaultSpawnRate = file.DefaultSpawnRate;
 
-			Main.npcStreamSpeed = file.NpcStreamSpeed;
+			Main.npcStreamSpeed = file.NpcStream;
 			Main.autoSave = file.AutoSave;
 			if (Backups != null)
 			{


### PR DESCRIPTION
I know it's up for code review but this should probably also be done so that it maintains the same naming convention as the original configuration file for consistency.
