### PR TITLE
Fix /spawnboss to allow summoning all the bosses.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2156,83 +2156,83 @@ namespace TShockAPI
 					foreach (int i in npcIds)
 					{
 						npc.SetDefaults(i);
-						TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+						TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					}
 					TSPlayer.All.SendSuccessMessage("{0} has spawned all bosses {1} time(s).", args.Player.Name, amount);
 					return;
 				case "brain":
 				case "brain of cthulhu":
 					npc.SetDefaults(266);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Brain of Cthulhu {1} time(s).", args.Player.Name, amount);
 					return;
 				case "destroyer":
 					npc.SetDefaults(134);
 					TSPlayer.Server.SetTime(false, 0.0);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Destroyer {1} time(s).", args.Player.Name, amount);
 					return;
 				case "duke":
 				case "duke fishron":
 				case "fishron":
 					npc.SetDefaults(370);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Duke Fishron {1} time(s).", args.Player.Name, amount);
 					return;
 				case "eater":
 				case "eater of worlds":
 					npc.SetDefaults(13);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Eater of Worlds {1} time(s).", args.Player.Name, amount);
 					return;
 				case "eye":
 				case "eye of cthulhu":
 					npc.SetDefaults(4);
 					TSPlayer.Server.SetTime(false, 0.0);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Eye of Cthulhu {1} time(s).", args.Player.Name, amount);
 					return;
 				case "golem":
 					npc.SetDefaults(245);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Golem {1} time(s).", args.Player.Name, amount);
 					return;
 				case "king":
 				case "king slime":
 					npc.SetDefaults(50);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned King Slime {1} time(s).", args.Player.Name, amount);
 					return;
 				case "plantera":
 					npc.SetDefaults(262);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Plantera {1} time(s).", args.Player.Name, amount);
 					return;
 				case "prime":
 				case "skeletron prime":
 					npc.SetDefaults(127);
 					TSPlayer.Server.SetTime(false, 0.0);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Skeletron Prime {1} time(s).", args.Player.Name, amount);
 					return;
 				case "queen":
 				case "queen bee":
 					npc.SetDefaults(222);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Queen Bee {1} time(s).", args.Player.Name, amount);
 					return;
 				case "skeletron":
 					npc.SetDefaults(35);
 					TSPlayer.Server.SetTime(false, 0.0);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned Skeletron {1} time(s).", args.Player.Name, amount);
 					return;
 				case "twins":
 					TSPlayer.Server.SetTime(false, 0.0);
 					npc.SetDefaults(125);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					npc.SetDefaults(126);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Twins {1} time(s).", args.Player.Name, amount);
 					return;
 				case "wof":
@@ -2253,7 +2253,7 @@ namespace TShockAPI
 				case "moon":
 				case "moon lord":
 					npc.SetDefaults(398);
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player);
 					TSPlayer.All.SendSuccessMessage("{0} has spawned the Moon Lord {1} time(s).", args.Player.Name, amount);
 					return;
 				default:
@@ -2298,7 +2298,7 @@ namespace TShockAPI
 				var npc = npcs[0];
 				if (npc.type >= 1 && npc.type < Main.maxNPCTypes && npc.type != 113)
 				{
-					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player.TileX, args.Player.TileY, 50, 20);
+					TSPlayer.Server.SpawnNPC(npc.type, npc.name, amount, args.Player, 50, 20);
 					if (args.Silent)
 					{
 						args.Player.SendSuccessMessage("Spawned {0} {1} time(s).", npc.name, amount);

--- a/TShockAPI/TSServerPlayer.cs
+++ b/TShockAPI/TSServerPlayer.cs
@@ -142,18 +142,26 @@ namespace TShockAPI
 			TSPlayer.All.SendData(PacketTypes.TimeSet, "", dayTime ? 1 : 0, (int)time, Main.sunModY, Main.moonModY);
 		}
 
-		public void SpawnNPC(int type, string name, int amount, int startTileX, int startTileY, int tileXRange = 100,
+		public void SpawnNPC(int type, string name, int amount, TSPlayer player, int tileXRange = 100,
 			int tileYRange = 50)
 		{
 			for (int i = 0; i < amount; i++)
 			{
 				int spawnTileX;
 				int spawnTileY;
-				TShock.Utils.GetRandomClearTileWithInRange(startTileX, startTileY, tileXRange, tileYRange, out spawnTileX,
+				TShock.Utils.GetRandomClearTileWithInRange(player.TileX, player.TileY, tileXRange, tileYRange, out spawnTileX,
 															 out spawnTileY);
 				int npcid = NPC.NewNPC(spawnTileX * 16, spawnTileY * 16, type, 0);
-				// This is for special slimes
-				Main.npc[npcid].SetDefaults(name);
+
+				if (npcid < 200)
+				{
+					// This is for special slimes
+					if (Main.npcName[type] != Main.npc[npcid].displayName)
+						Main.npc[npcid].SetDefaults(name);
+					Main.npc[npcid].target = player.Index;
+					Main.npc[npcid].timeLeft *= 20;
+					NetMessage.SendData(23, -1, -1, "", npcid, 0f, 0f, 0f, 0, 0, 0);
+				}
 			}
 		}
 


### PR DESCRIPTION
I took a look at the decompiled SpawnOnPlayer which is what is used for natural spawn bosses.  I backported those changes into the TServerPlayer SpawnNPC function, wrapped the 200 npcid limit, and only do special mob name look ups if the name for that type is different from what the mobs display name is i.e. Eater of Worlds vs. Eater of Worlds Head. 

As far as I can tell this fixes most of the npc spawn issues, however, someone who knows exactly what non-boss mobs failed to spawn before should test this fix.  I was able to run /sb * which resulted in all sorts of bosses spawning including the moon lord, EoW, and bee queen.

This fixes #1381 and #1350 