### PR TITLE
Fix #1492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed /spawnmob not spawning negative IDs (@MarioE)
 * Validated tile placement on PlaceObject; clients can no longer place frames, paintings etc with dirt blocks (@bartico6, @ProfessorXZ)
 * Updated to new stat tracking system with more data so we can actually make informed software decisions (Jordan Coulam)
+* Fixed /time display at the end of Terraria hours (@koneko-nyan)
 
 ## TShock 4.3.24
 * API: Changed `PlayerHooks` permission hook mechanisms to allow negation from hooks (@deadsurgeon42)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -3872,7 +3872,7 @@ namespace TShockAPI
 				if (!Main.dayTime)
 					time += 15.0;
 				time = time % 24.0;
-				args.Player.SendInfoMessage("The current time is {0}:{1:D2}.", (int)Math.Floor(time), (int)Math.Round((time % 1.0) * 60.0));
+				args.Player.SendInfoMessage("The current time is {0}:{1:D2}.", (int)Math.Floor(time), (int)Math.Floor((time % 1.0) * 60.0));
 				return;
 			}
 


### PR DESCRIPTION
Fixing time display.
(time % 1.0) * 60.0 can be equal to 59.8, which gets rounded to undesirable 60 displayed in the time format