### PR TITLE
Discourage superadmin use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a warning notifying users of the minimum memory required to run TShock (@bartico6)
 * Added /group rename to allow changing group names (@ColinBohn, @ProfessorXZ)
 * Added /region rename and OnRegionRenamed hook (@koneko-nyan, @deadsurgeon42)
-* Added /su, which temporarily elevates players with the tshock.su permission to super admin. In addition added, a new group, owner, that is suggested for new users to setup TShock with as opposed to superadmin. If a user has the tshock.su permission, they're informed that they have access to /su if they can't run a command as a result from their degraded permission set. Finally, /su is implemented such that a 10 minute timeout will occur preventing people from just camping with it on. (@hakusaro)
+* Added /su, which temporarily elevates players with the tshock.su permission to super admin. In addition added, a new group, owner, that is suggested for new users to setup TShock with as opposed to superadmin. Finally, /su is implemented such that a 10 minute timeout will occur preventing people from just camping with it on. (@hakusaro)
+* Added /sudo, which runs a command as the superadmin group. If a user fails to execute a command but can sudo, they'll be told that they can override the permission check with sudo. Much better than just telling them to run /su and then re-run the command. (@hakusaro)
 
 
 ## TShock 4.3.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a warning notifying users of the minimum memory required to run TShock (@bartico6)
 * Added /group rename to allow changing group names (@ColinBohn, @ProfessorXZ)
 * Added /region rename and OnRegionRenamed hook (@koneko-nyan, @deadsurgeon42)
+* Added /su, which temporarily elevates players with the tshock.su permission to super admin. In addition added, a new group, owner, that is suggested for new users to setup TShock with as opposed to superadmin. If a user has the tshock.su permission, they're informed that they have access to /su if they can't run a command as a result from their degraded permission set. Finally, /su is implemented such that a 10 minute timeout will occur preventing people from just camping with it on. (@hakusaro)
 
 
 ## TShock 4.3.24

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -311,6 +311,10 @@ namespace TShockAPI
 			{
 				HelpText = "Temporarily sets another player's group."
 			});
+			add(new Command(Permissions.su, SubstituteUser, "su")
+			{
+				HelpText = "Temporarily elevates you to Super Admin."
+			});
 			add(new Command(Permissions.userinfo, GrabUserUserInfo, "userinfo", "ui")
 			{
 				HelpText = "Shows information about a player."
@@ -685,6 +689,10 @@ namespace TShockAPI
 				{
 					TShock.Utils.SendLogs(string.Format("{0} tried to execute {1}{2}.", player.Name, Specifier, cmdText), Color.PaleVioletRed, player);
 					player.SendErrorMessage("You do not have access to this command.");
+					if (player.HasPermission(Permissions.su))
+					{
+						player.SendInfoMessage("You can use {0}su to temporarily become Super Admin, which can run this command.", Specifier);
+					}
 				}
 				else if (!cmd.AllowServer && !player.RealPlayer)
 				{
@@ -1811,6 +1819,27 @@ namespace TShockAPI
 					ply[0].Name, g.Name, args.Parameters[2]));
 				ply[0].SendSuccessMessage(String.Format("Your group has been changed to {0} for {1}",
 					g.Name, args.Parameters[2]));
+			}
+		}
+
+		private static void SubstituteUser(CommandArgs args)
+		{
+
+			if (args.Player.tempGroup != null)
+			{
+				args.Player.tempGroup = null;
+				args.Player.tempGroupTimer.Stop();
+				args.Player.SendSuccessMessage("Your previous permission set has been restored.");
+				return;
+			}
+			else
+			{
+				args.Player.tempGroup = new SuperAdminGroup();
+				args.Player.tempGroupTimer = new System.Timers.Timer(600 * 1000);
+				args.Player.tempGroupTimer.Elapsed += args.Player.TempGroupTimerElapsed;
+				args.Player.tempGroupTimer.Start();
+				args.Player.SendSuccessMessage("Your account has been elevated to Super Admin for 10 minutes.");
+				return;
 			}
 		}
 
@@ -4842,10 +4871,10 @@ namespace TShockAPI
 			if (args.Player.Group.Name != "superadmin")
 				args.Player.tempGroup = new SuperAdminGroup();
 
-			args.Player.SendInfoMessage("Superadmin has been temporarily given to you. It will be removed on logout.");
+			args.Player.SendInfoMessage("Temporary system access has been given to you, so you can run one command.");
 			args.Player.SendInfoMessage("Please use the following to create a permanent account for you.");
-			args.Player.SendInfoMessage("{0}user add <username> <password> superadmin", Specifier);
-			args.Player.SendInfoMessage("Creates: <username> with the password <password> as part of the superadmin group.");
+			args.Player.SendInfoMessage("{0}user add <username> <password> owner", Specifier);
+			args.Player.SendInfoMessage("Creates: <username> with the password <password> as part of the owner group.");
 			args.Player.SendInfoMessage("Please use {0}login <username> <password> after this process.", Specifier);
 			args.Player.SendInfoMessage("If you understand, please {0}login <username> <password> now, and then type {0}auth.", Specifier);
 			return;

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -315,6 +315,10 @@ namespace TShockAPI
 			{
 				HelpText = "Temporarily elevates you to Super Admin."
 			});
+			add(new Command(Permissions.su, SubstituteUserDo, "sudo")
+			{
+				HelpText = "Executes a command as the super admin."
+			});
 			add(new Command(Permissions.userinfo, GrabUserUserInfo, "userinfo", "ui")
 			{
 				HelpText = "Shows information about a player."
@@ -691,7 +695,7 @@ namespace TShockAPI
 					player.SendErrorMessage("You do not have access to this command.");
 					if (player.HasPermission(Permissions.su))
 					{
-						player.SendInfoMessage("You can use {0}su to temporarily become Super Admin, which can run this command.", Specifier);
+						player.SendInfoMessage("You can use '{0}sudo {0}{1}' to override this check.", Specifier, cmdText);
 					}
 				}
 				else if (!cmd.AllowServer && !player.RealPlayer)
@@ -1846,6 +1850,23 @@ namespace TShockAPI
 		#endregion Player Management Commands
 
 		#region Server Maintenence Commands
+
+		// Executes a command as a superuser if you have sudo rights.
+		private static void SubstituteUserDo(CommandArgs args)
+		{
+			if (args.Parameters.Count == 0)
+			{
+				args.Player.SendErrorMessage("Usage: /sudo [command].");
+				args.Player.SendErrorMessage("Example: /sudo /ban add Shank 2d Hacking.");
+				return;
+			}
+
+			string replacementCommand = String.Join(" ", args.Parameters);
+			args.Player.tempGroup = new SuperAdminGroup();
+			HandleCommand(args.Player, replacementCommand);
+			args.Player.tempGroup = null;
+			return;
+		}
 
 		private static void Broadcast(CommandArgs args)
 		{

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -78,18 +78,6 @@ namespace TShockAPI
 		[Description("Disables any building / placing of blocks.")]
 		public bool DisableBuild;
 
-		/// <summary>SuperAdminChatRGB - The chat color for the superadmin group.</summary>
-		[Description("#.#.# = Red/Blue/Green - RGB Colors for the Admin Chat Color. Max value: 255.")]
-		public int[] SuperAdminChatRGB = { 255, 0, 0 };
-
-		/// <summary>SuperAdminChatPrefix - The superadmin chat prefix.</summary>
-		[Description("Super admin group chat prefix.")]
-		public string SuperAdminChatPrefix = "(Admin) ";
-
-		/// <summary>SuperAdminChatSuffix - The superadmin chat suffix.</summary>
-		[Description("Super admin group chat suffix.")]
-		public string SuperAdminChatSuffix = "";
-
 		/// <summary>BackupInterval - The backup frequency in minutes.</summary>
 		[Description("Backup frequency in minutes. So, a value of 60 = 60 minutes. Backups are stored in the \\tshock\\backups folder.")]
 		public int BackupInterval;

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -77,6 +77,8 @@ namespace TShockAPI.DB
 					string.Join(",", Permissions.maintenance, "tshock.cfg.*", "tshock.world.*", Permissions.butcher, Permissions.item, Permissions.give,
 						Permissions.heal, Permissions.immunetoban, Permissions.usebanneditem));
 
+				AddDefaultGroup("owner", "trustedadmin", string.Join(",", Permissions.su));
+
 				AddDefaultGroup("vip", "default", string.Join(",", Permissions.reservedslot));
 			}
 

--- a/TShockAPI/Group.cs
+++ b/TShockAPI/Group.cs
@@ -340,11 +340,11 @@ namespace TShockAPI
 		public SuperAdminGroup()
 			: base("superadmin")
 		{
-			R = (byte)TShock.Config.SuperAdminChatRGB[0];
-			G = (byte)TShock.Config.SuperAdminChatRGB[1];
-			B = (byte)TShock.Config.SuperAdminChatRGB[2];
-			Prefix = TShock.Config.SuperAdminChatPrefix;
-			Suffix = TShock.Config.SuperAdminChatSuffix;
+			R = (byte)255;
+			G = (byte)255;
+			B = (byte)255;
+			Prefix = "(Super Admin) ";
+			Suffix = "";
 		}
 
 		/// <summary>

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -221,6 +221,9 @@ namespace TShockAPI
 		[Description("Meant for super admins only.")]
 		public static readonly string user = "tshock.superadmin.user";
 
+		[Description("Allows a user to elevate to superadmin for 10 minutes.")]
+		public static readonly string su = "tshock.su";
+
 		// tshock.tp nodes
 
 		[Description("User can teleport *everyone* to them.")]

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -550,11 +550,6 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Unused.
-		/// </summary>
-		public bool TpLock;
-
-		/// <summary>
 		/// Checks if the player has any inventory slots available.
 		/// </summary>
 		public bool InventorySlotAvailable


### PR DESCRIPTION
This PR attempts to discourage superadmin use. It removes the configuration options for configuring the group's prefix, suffix, and color. To further discourage use, I changed the color to white and made the prefix longer.

This also implements a ```/su``` command which substitutes your current user group with the super admin group for 10 minutes. If you use it again after elevating, you can downgrade back instantly. This lets you temporarily get a permission set that can do more, while simultaneously keeping you from permanently using it.

Since old databases won't have these changes, this is a "going forward" thing. A new database will ideally not have superadmin users, but someone who knows the system might do it anyway. We can't really stop it, but we did discourage new people from going though that process in the first place.