### PR TITLE
Modify table creation in MySQL land to support utf8mb4

### DIFF
--- a/TShockAPI/DB/DBTools.cs
+++ b/TShockAPI/DB/DBTools.cs
@@ -75,6 +75,9 @@ namespace TShockAPI.DB
                     sb.Append(")");
             }
 
+            if (TShock.Config.StorageType.ToLower() == "mysql")
+                sb.append("CHARACTER SET utf8mb4 COLLATE utf8mb4_bin")
+
             using (var com = database.CreateCommand())
             {
                 com.CommandText = sb.ToString();


### PR DESCRIPTION
This should in theory fix #1463. Need testing + feedback from MySQL users who want to try this out.