### PR TITLE
Implement revised default permission sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added /region rename and OnRegionRenamed hook (@koneko-nyan, @deadsurgeon42)
 * Added /su, which temporarily elevates players with the tshock.su permission to super admin. In addition added, a new group, owner, that is suggested for new users to setup TShock with as opposed to superadmin. Finally, /su is implemented such that a 10 minute timeout will occur preventing people from just camping with it on. (@hakusaro)
 * Added /sudo, which runs a command as the superadmin group. If a user fails to execute a command but can sudo, they'll be told that they can override the permission check with sudo. Much better than just telling them to run /su and then re-run the command. (@hakusaro)
+* Default permission sets for new databases are more modern. (@hakusaro)
 
 
 ## TShock 4.3.24

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -58,28 +58,121 @@ namespace TShockAPI.DB
 			{
 				// Add default groups if they don't exist
 				AddDefaultGroup("guest", "",
-					string.Join(",", Permissions.canbuild, Permissions.canregister, Permissions.canlogin, Permissions.canpartychat,
-						Permissions.cantalkinthird, Permissions.canchat));
+					string.Join(",",
+						Permissions.canbuild,
+						Permissions.canregister,
+						Permissions.canlogin,
+						Permissions.canpartychat,
+						Permissions.cantalkinthird,
+						Permissions.canchat));
 
 				AddDefaultGroup("default", "guest",
-					string.Join(",", Permissions.warp, Permissions.canchangepassword, Permissions.canlogout));
+					string.Join(",",
+						Permissions.warp,
+						Permissions.canchangepassword,
+						Permissions.canlogout,
+						Permissions.summonboss,
+						Permissions.whisper,
+						Permissions.wormhole,
+						Permissions.canpaint));
 
-				AddDefaultGroup("newadmin", "default",
-					string.Join(",", Permissions.kick, Permissions.editspawn, Permissions.reservedslot));
+				AddDefaultGroup("vip", "default",
+					string.Join(",",
+						Permissions.reservedslot,
+						Permissions.renamenpc,
+						Permissions.startinvasion,
+						Permissions.summonboss,
+						Permissions.whisper,
+						Permissions.wormhole));
+
+				AddDefaultGroup("newadmin", "vip",
+					string.Join(",",
+						Permissions.kick,
+						Permissions.editspawn,
+						Permissions.reservedslot,
+						Permissions.annoy,
+						Permissions.checkaccountinfo,
+						Permissions.getpos,
+						Permissions.mute,
+						Permissions.rod,
+						Permissions.savessc,
+						Permissions.seeids,
+						"tshock.world.time.*"));
 
 				AddDefaultGroup("admin", "newadmin",
-					string.Join(",", Permissions.ban, Permissions.whitelist, "tshock.world.time.*", Permissions.spawnboss,
-						Permissions.spawnmob, Permissions.managewarp, Permissions.time, Permissions.tp, Permissions.slap,
-						Permissions.kill, Permissions.logs,
-						Permissions.immunetokick, Permissions.tpothers));
+					string.Join(",",
+						Permissions.ban,
+						Permissions.whitelist,
+						Permissions.spawnboss,
+						Permissions.spawnmob,
+						Permissions.managewarp,
+						Permissions.time,
+						Permissions.tp,
+						Permissions.slap,
+						Permissions.kill,
+						Permissions.logs,
+						Permissions.immunetokick,
+						Permissions.tpothers,
+						Permissions.advaccountinfo,
+						Permissions.broadcast,
+						Permissions.home,
+						Permissions.tpallothers,
+						Permissions.tpallow,
+						Permissions.tpnpc,
+						Permissions.tppos,
+						Permissions.tpsilent,
+						Permissions.userinfo));
 
 				AddDefaultGroup("trustedadmin", "admin",
-					string.Join(",", Permissions.maintenance, "tshock.cfg.*", "tshock.world.*", Permissions.butcher, Permissions.item, Permissions.give,
-						Permissions.heal, Permissions.immunetoban, Permissions.usebanneditem));
+					string.Join(",",
+						Permissions.maintenance,
+						"tshock.cfg.*",
+						"tshock.world.*",
+						Permissions.butcher,
+						Permissions.item,
+						Permissions.give,
+						Permissions.heal,
+						Permissions.immunetoban,
+						Permissions.usebanneditem,
+						Permissions.allowclientsideworldedit,
+						Permissions.buff,
+						Permissions.buffplayer,
+						Permissions.clear,
+						Permissions.clearangler,
+						Permissions.godmode,
+						Permissions.godmodeother,
+						Permissions.ignoredamagecap,
+						Permissions.ignorehp,
+						Permissions.ignorekilltiledetection,
+						Permissions.ignoreliquidsetdetection,
+						Permissions.ignoremp,
+						Permissions.ignorenoclipdetection,
+						Permissions.ignorepaintdetection,
+						Permissions.ignoreplacetiledetection,
+						Permissions.ignoreprojectiledetection,
+						Permissions.ignorestackhackdetection,
+						Permissions.invade,
+						Permissions.startdd2,
+						Permissions.uploaddata,
+						Permissions.uploadothersdata));
 
-				AddDefaultGroup("owner", "trustedadmin", string.Join(",", Permissions.su));
-
-				AddDefaultGroup("vip", "default", string.Join(",", Permissions.reservedslot));
+				AddDefaultGroup("owner", "trustedadmin",
+					string.Join(",",
+						Permissions.su,
+						Permissions.allowdroppingbanneditems,
+						Permissions.antibuild,
+						Permissions.canusebannedprojectiles,
+						Permissions.canusebannedtiles,
+						Permissions.managegroup,
+						Permissions.manageitem,
+						Permissions.manageprojectile,
+						Permissions.manageregion,
+						Permissions.managetile,
+						Permissions.maxspawns,
+						Permissions.serverinfo,
+						Permissions.settempgroup,
+						Permissions.spawnrate,
+						Permissions.tpoverride));
 			}
 
 			// Load Permissions from the DB

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1204,6 +1204,7 @@ namespace TShockAPI
 			Permissions.DumpDescriptions();
 			ServerSideCharacters.ServerSideConfig.DumpDescriptions();
 			RestManager.DumpDescriptions();
+			DumpPermissionMatrix("PermissionMatrix.txt");
 			DumpBuffs("BuffList.txt");
 			DumpItems("Items-1_0.txt", -48, 235);
 			DumpItems("Items-1_1.txt", 235, 604);
@@ -1212,6 +1213,7 @@ namespace TShockAPI
 			DumpNPCs("NPCs.txt");
 			DumpProjectiles("Projectiles.txt");
 			DumpPrefixes("Prefixes.txt");
+
 			if (exit)
 			{
 				Environment.Exit(1);
@@ -1222,6 +1224,52 @@ namespace TShockAPI
 		{
 			for(int i = 0; i < Main.recipe.Length; i++)
 				Main.recipe[i] = new Recipe();
+		}
+		
+		// Dumps a matrix of all permissions and all groups in markdown format
+		// Hard coded to default groups because apparently we have poor querying tools
+		public void DumpPermissionMatrix(string path)
+		{
+			StringBuilder output = new StringBuilder();
+			output.Append("|Permission|");
+
+			// Traverse to build group name list
+			foreach (Group g in TShock.Groups.groups)
+			{
+				output.Append(g.Name);
+				output.Append("|");
+			}
+
+			output.AppendLine();
+			output.Append("|-------|");
+
+			foreach (Group g in TShock.Groups.groups)
+			{
+				output.Append("-------|");
+			}
+			output.AppendLine();
+
+			foreach (var field in typeof(Permissions).GetFields().OrderBy(f => f.Name))
+			{
+				output.Append("|");
+				output.Append((string) field.GetValue(null));
+				output.Append("|");
+
+				foreach (Group g in TShock.Groups.groups)
+				{
+					if (g.HasPermission((string) field.GetValue(null)))
+					{
+						output.Append("✔|");
+					}
+					else
+					{
+						output.Append("|");
+					}
+				}
+				output.AppendLine();
+			}
+
+			File.WriteAllText(path, output.ToString());
 		}
 
 		public void DumpBuffs(string path)


### PR DESCRIPTION
This fixes #1519. It introduces a revised set of default permissions. Most groups have had significant changes. This accounts for a lot of new or revised permissions that weren't ever updated in the default groups. Following this change, the default owner group is effectively the old superadmin, though with a few caveats and exceptions that I think are sane.

You can view the start and the end permission sets [on google docs](https://docs.google.com/spreadsheets/d/1R5_pTMeY2Z73-DPSdliuEDM38c6VHpA6qQLXY8D9jPM/edit?usp=sharing). The first tab in the spreadsheet is where I started with, along with what the suggestions were. The second sheet is the result of dumping the permission matrix from the newly implemented defaults.

Finally, this change adds a new method to Utils, ```DumpPermissionMatrix()```. This creates a markdown table that you can then use rich text copy paste to put into a spreadsheet system of your choice for later. 