### PR TITLE
Allow /savessc to work on players that bypass ssc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added /region rename and OnRegionRenamed hook (@koneko-nyan, @deadsurgeon42)
 * Added /su, which temporarily elevates players with the tshock.su permission to super admin. In addition added, a new group, owner, that is suggested for new users to setup TShock with as opposed to superadmin. Finally, /su is implemented such that a 10 minute timeout will occur preventing people from just camping with it on. (@hakusaro)
 * Added /sudo, which runs a command as the superadmin group. If a user fails to execute a command but can sudo, they'll be told that they can override the permission check with sudo. Much better than just telling them to run /su and then re-run the command. (@hakusaro)
+* Fixed /savessc not bothering to save ssc data for people who bypass ssc. (@hakusaro)
 
 
 ## TShock 4.3.24

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1636,7 +1636,7 @@ namespace TShockAPI
 				{
 					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
 					{
-						TShock.CharacterDB.InsertPlayerData(player);
+						TShock.CharacterDB.InsertPlayerData(player, true);
 					}
 				}
 			}

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -156,17 +156,17 @@ namespace TShockAPI.DB
 		/// </summary>
 		/// <param name="player">player to take data from</param>
 		/// <returns>true if inserted successfully</returns>
-		public bool InsertPlayerData(TSPlayer player)
+		public bool InsertPlayerData(TSPlayer player, bool fromCommand = false)
 		{
 			PlayerData playerData = player.PlayerData;
 
 			if (!player.IsLoggedIn)
 				return false;
 
-			if (player.HasPermission(Permissions.bypassssc))
+			if (player.HasPermission(Permissions.bypassssc) && !fromCommand)
 			{
 				TShock.Log.ConsoleInfo("Skipping SSC Backup for " + player.User.Name); // Debug code
-				return true;
+				return false;
 			}
 
 			if (!GetPlayerData(player, player.User.ID).exists)


### PR DESCRIPTION
Fixes #1506 by permitting the command to run the insertion of SSC data if run from a command. Bonus fix: ```InsertPlayerData``` also returns false if normal save operations would not save someone for this reason.