### PR TITLE
Revert "Remove superadmin customization config options"

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -80,11 +80,11 @@ namespace TShockAPI
 
 		/// <summary>SuperAdminChatRGB - The chat color for the superadmin group.</summary>
 		[Description("#.#.# = Red/Blue/Green - RGB Colors for the Admin Chat Color. Max value: 255.")]
-		public int[] SuperAdminChatRGB = { 255, 0, 0 };
+		public int[] SuperAdminChatRGB = { 255, 255, 255 };
 
 		/// <summary>SuperAdminChatPrefix - The superadmin chat prefix.</summary>
 		[Description("Super admin group chat prefix.")]
-		public string SuperAdminChatPrefix = "(Admin) ";
+		public string SuperAdminChatPrefix = "(Super Admin) ";
 
 		/// <summary>SuperAdminChatSuffix - The superadmin chat suffix.</summary>
 		[Description("Super admin group chat suffix.")]

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -78,6 +78,18 @@ namespace TShockAPI
 		[Description("Disables any building / placing of blocks.")]
 		public bool DisableBuild;
 
+		/// <summary>SuperAdminChatRGB - The chat color for the superadmin group.</summary>
+		[Description("#.#.# = Red/Blue/Green - RGB Colors for the Admin Chat Color. Max value: 255.")]
+		public int[] SuperAdminChatRGB = { 255, 0, 0 };
+
+		/// <summary>SuperAdminChatPrefix - The superadmin chat prefix.</summary>
+		[Description("Super admin group chat prefix.")]
+		public string SuperAdminChatPrefix = "(Admin) ";
+
+		/// <summary>SuperAdminChatSuffix - The superadmin chat suffix.</summary>
+		[Description("Super admin group chat suffix.")]
+		public string SuperAdminChatSuffix = "";
+
 		/// <summary>BackupInterval - The backup frequency in minutes.</summary>
 		[Description("Backup frequency in minutes. So, a value of 60 = 60 minutes. Backups are stored in the \\tshock\\backups folder.")]
 		public int BackupInterval;

--- a/TShockAPI/Group.cs
+++ b/TShockAPI/Group.cs
@@ -340,11 +340,11 @@ namespace TShockAPI
 		public SuperAdminGroup()
 			: base("superadmin")
 		{
-			R = (byte)255;
-			G = (byte)255;
-			B = (byte)255;
-			Prefix = "(Super Admin) ";
-			Suffix = "";
+			R = (byte)TShock.Config.SuperAdminChatRGB[0];
+			G = (byte)TShock.Config.SuperAdminChatRGB[1];
+			B = (byte)TShock.Config.SuperAdminChatRGB[2];
+			Prefix = TShock.Config.SuperAdminChatPrefix;
+			Suffix = TShock.Config.SuperAdminChatSuffix;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This reverts commit 1e68ac22c7d7c191f05e6f86b7847c2b4f885340.

Essentially, I prematurely did this change to discourage superadmin use. But because the direction we went in was basically to obsolete it (and more notably, provided no upgrade path for existing databases), we're just breaking people's existing setups for no reason.

I propose we remove these changes if and only if we write something that migrates people to the new permission set from the old one. If we do, we can keep these. If not, though, existing databases really have no refuge to go to post-removal of these changes.