### PR TITLE
Fixed IndexOutOfRange exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added the ability to ban by account name instead of just banning a character name assuming its an account name. (@hakusaro)
 * Renamed TShock.DB.User to TShock.DB.UserAccount, including all the related methods, classes and events. (@Ryozuki)
 * Update OTAPI to 2.0.0.31, which also updates Newtonsoft.Json to 10.0.3 (@Ryozuki)
+* Fixed DumpItems() from trying to dump older versions of certain items (negative item IDs). (@Zaicon)
 
 ## TShock 4.3.24
 * Updated OpenTerraria API to 1.3.5.3 (@DeathCradle)

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1206,7 +1206,7 @@ namespace TShockAPI
 			RestManager.DumpDescriptions();
 			DumpPermissionMatrix("PermissionMatrix.txt");
 			DumpBuffs("BuffList.txt");
-			DumpItems("Items-1_0.txt", -48, 235);
+			DumpItems("Items-1_0.txt", 1, 235);
 			DumpItems("Items-1_1.txt", 235, 604);
 			DumpItems("Items-1_2.txt", 604, 2749);
 			DumpItems("Items-1_3.txt", 2749, Main.maxItemTypes);


### PR DESCRIPTION
All items with an ID less than 0 have updated replacements with IDs greater than 0. Terraria now uses an array to look up item tooltips based on item ID (and therefore trying to use IDs less than 0 fails when looking up in that array).

There's also no item with ID 0, so I started with item ID 1.