### PR TITLE
Add missing "if handled - return" code to OnNameCollision.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
+* API: Added return in OnNameCollision if hook has been handled. (@Patrikkk)
 * API: Added hooks for item, projectile and tile bans (@deadsurgeon42)
 * API: Changed `PlayerHooks` permission hook mechanisms to allow negation from hooks (@deadsurgeon42)
 * API: New WorldGrassSpread hook which shold allow corruption/crimson/hallow creep config options to work (@DeathCradle)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -522,6 +522,11 @@ namespace TShockAPI
 		/// <param name="args">args - The NameCollisionEventArgs object.</param>
 		private void NetHooks_NameCollision(NameCollisionEventArgs args)
 		{
+			if (args.Handled)
+			{
+				return;
+			}
+
 			string ip = Utils.GetRealIP(Netplay.Clients[args.Who].Socket.GetRemoteAddress().ToString());
 
 			var player = Players.First(p => p != null && p.Name == args.Name && p.Index != args.Who);


### PR DESCRIPTION
I'm not sure why we had this return missing. I stumbled into this when I tried handling NameCollision in a plugin. I don't want TShock to handle collision, I'll handle it my self. 
But since there is no "if handled - return", TShock also tries executing code OnNameCollision. 

Can we add this please? Unless there is a good reason not to. (Which I don't see)