### PR TITLE
Tick the HintPath for OTAPI to 1.3.5.3

### DIFF
--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -71,7 +71,7 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OTAPI, Version=1.3.4.4, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="OTAPI, Version=1.3.5.3, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll</HintPath>
       <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll</HintPath>


### PR DESCRIPTION
In https://github.com/Pryaxis/TShock/pull/1481, hinting was fixed so that OTAPI could be built correctly no matter where it was. This, however, needs to be kept in sync version wise with Terraria versions or the patch won't work.

Looking for suggestions as to how to make sure we don't forget this in the future.