### PR TITLE
Make TShock pull OTAPI from the correct folder on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Update OTAPI to 2.0.0.31, which also updates Newtonsoft.Json to 10.0.3 (@Ryozuki)
 * Fixed DumpItems() from trying to dump older versions of certain items (negative item IDs). (@Zaicon)
 * Added the `/dump-reference-data` command, which when run, runs Utils.Dump() and outputs Terraria reference data to the server folder. (@hakusaro)
+* Fixed builds to not require a specific version of OTAPI and to not fail when in Release mode (@bartico6)
 
 ## TShock 4.3.24
 * Updated OpenTerraria API to 1.3.5.3 (@DeathCradle)

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -71,11 +71,9 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="OTAPI, Version=1.3.4.4, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="OTAPI=">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Debug\OTAPI.dll</HintPath>
-      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\Release\OTAPI.dll</HintPath>
-      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\$(Configuration)\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\$(Configuration)\OTAPI.dll</HintPath>
+      <HintPath Condition="Exists('..\TerrariaServerAPI\TerrariaServerAPI\bin\$(ConfigurationName)\OTAPI.dll')">..\TerrariaServerAPI\TerrariaServerAPI\bin\$(ConfigurationName)\OTAPI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
Fixes build issues for non-debug configurations

Must be merged alongside https://github.com/Pryaxis/TerrariaAPI-Server/pull/152