### PR TITLE
Remove /restart & Permissions.updateplugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Update Assembly Company to Pryaxis (@Ryozuki)
 * Removed `/restart` command. (@hakusaro)
 * Removed `Permissions.updateplugins` permission. (@hakusaro)
+* Removed REST `/v3/server/restart/` route and `/server/restart/` route. (@hakusaro)
 
 ## TShock 4.3.24
 * Updated OpenTerraria API to 1.3.5.3 (@DeathCradle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added the `/dump-reference-data` command, which when run, runs Utils.Dump() and outputs Terraria reference data to the server folder. (@hakusaro)
 * Fixed builds to not require a specific version of OTAPI and to not fail when in Release mode (@bartico6)
 * Update Assembly Company to Pryaxis (@Ryozuki)
+* Removed `/restart` command. (@hakusaro)
+* Removed `Permissions.updateplugins` permission. (@hakusaro)
 
 ## TShock 4.3.24
 * Updated OpenTerraria API to 1.3.5.3 (@DeathCradle)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -366,10 +366,6 @@ namespace TShockAPI
 			{
 				HelpText = "Reloads the server configuration file."
 			});
-			add(new Command(Permissions.maintenance, Restart, "restart")
-			{
-				HelpText = "Restarts the server."
-			});
 			add(new Command(Permissions.cfgpassword, ServerPassword, "serverpassword")
 			{
 				HelpText = "Changes the server password."
@@ -1900,25 +1896,6 @@ namespace TShockAPI
 
 			string reason = ((args.Parameters.Count > 0) ? "Server shutting down: " + String.Join(" ", args.Parameters) : "Server shutting down!");
 			TShock.Utils.StopServer(true, reason);
-		}
-
-		private static void Restart(CommandArgs args)
-		{
-			if (TShock.NoRestart)
-			{
-				args.Player.SendErrorMessage("This command has been disabled.");
-				return;
-			}
-
-			if (ServerApi.RunningMono)
-			{
-				TShock.Log.ConsoleInfo("Sorry, this command has not yet been implemented in Mono.");
-			}
-			else
-			{
-				string reason = ((args.Parameters.Count > 0) ? "Server shutting down: " + String.Join(" ", args.Parameters) : "Server shutting down!");
-				TShock.Utils.RestartServer(true, reason);
-			}
 		}
 
 		private static void OffNoSave(CommandArgs args)

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -125,9 +125,6 @@ namespace TShockAPI
 		[Description("User can reload the configurations file.")]
 		public static readonly string cfgreload = "tshock.cfg.reload";
 
-		[Description("User can download updates to plugins that are currently running.")]
-		public static readonly string updateplugins = "tshock.cfg.updateplugins";
-
 		[Description("User can create reference files of Terraria IDs and the permission matrix in the server folder.")]
 		public static readonly string createdumps = "tshock.cfg.createdumps";
 

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -205,7 +205,6 @@ namespace TShockAPI
 			Rest.RegisterRedirect("/server/broadcast", "/v2/server/broadcast");
 			Rest.RegisterRedirect("/server/reload", "/v2/server/reload");
 			Rest.RegisterRedirect("/server/off", "/v2/server/off");
-			Rest.RegisterRedirect("/server/restart", "/v3/server/restart");
 			Rest.RegisterRedirect("/server/rawcmd", "/v3/server/rawcmd");
 
 			//user commands
@@ -247,7 +246,6 @@ namespace TShockAPI
 			Rest.Register(new SecureRestCommand("/v2/server/broadcast", ServerBroadcast));
 			Rest.Register(new SecureRestCommand("/v3/server/reload", ServerReload, RestPermissions.restcfg));
 			Rest.Register(new SecureRestCommand("/v2/server/off", ServerOff, RestPermissions.restmaintenance));
-			Rest.Register(new SecureRestCommand("/v3/server/restart", ServerRestart, RestPermissions.restmaintenance));
 			Rest.Register(new SecureRestCommand("/v3/server/rawcmd", ServerCommandV3, RestPermissions.restrawcommand));
 			Rest.Register(new SecureRestCommand("/tokentest", ServerTokenTest));
 
@@ -333,25 +331,6 @@ namespace TShockAPI
 			TShock.Utils.StopServer(!GetBool(args.Parameters["nosave"], false), reason);
 
 			return RestResponse("The server is shutting down");
-		}
-
-		[Description("Attempt to restart the server.")]
-		[Route("/v3/server/restart")]
-		[Permission(RestPermissions.restmaintenance)]
-		[Noun("confirm", true, "Confirm that you actually want to restart the server", typeof(bool))]
-		[Noun("message", false, "The shutdown message.", typeof(String))]
-		[Noun("nosave", false, "Shutdown without saving.", typeof(bool))]
-		[Token]
-		private object ServerRestart(RestRequestArgs args)
-		{
-			if (!GetBool(args.Parameters["confirm"], false))
-				return RestInvalidParam("confirm");
-
-			// Inform players the server is shutting down
-			var reason = string.IsNullOrWhiteSpace(args.Parameters["message"]) ? "Server is restarting" : args.Parameters["message"];
-			TShock.Utils.RestartServer(!GetBool(args.Parameters["nosave"], false), reason);
-
-			return RestResponse("The server is shutting down and will attempt to restart");
 		}
 
 		[Description("Reload config files for the server.")]

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -581,24 +581,6 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Stops the server after kicking all players with a reason message, and optionally saving the world then attempts to
-		/// restart it.
-		/// </summary>
-		/// <param name="save">bool perform a world save before stop (default: true)</param>
-		/// <param name="reason">string reason (default: "Server shutting down!")</param>
-		public void RestartServer(bool save = true, string reason = "Server shutting down!")
-		{
-			if (Main.ServerSideCharacter)
-				foreach (TSPlayer player in TShock.Players)
-					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
-						TShock.CharacterDB.InsertPlayerData(player);
-
-			StopServer(true, reason);
-			System.Diagnostics.Process.Start(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase);
-			Environment.Exit(0);
-		}
-
-		/// <summary>
 		/// Reloads all configuration settings, groups, regions and raises the reload event.
 		/// </summary>
 		public void Reload(TSPlayer player)


### PR DESCRIPTION
1. Restart is never used in production. Anyone who runs a server at least runs it in a loop and reboots with "exit" causing a relaunch. Bonus: it doesn't work on mono. Bonus: it's always been unreliable, even on Windows.
2. Permission is never going to get used.