### PR TITLE
Switch the "auth system" to "initial setup system" everywhere.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Removed `/restart` command. (@hakusaro)
 * Removed `Permissions.updateplugins` permission. (@hakusaro)
 * Removed REST `/v3/server/restart/` route and `/server/restart/` route. (@hakusaro)
+* The "auth system" is now referred to as the initial setup system (what it actually is). This is better verbiage for basically all situations. Who really wants to turn off the "authentication system?" In addition, the system now makes it more clear what the point of it is, rather than that it grants permissions. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -220,7 +220,7 @@ namespace TShockAPI
 				ChatCommands.Add(cmd);
 			};
 
-			add(new Command(AuthToken, "auth")
+			add(new Command(SetupToken, "setup")
 			{
 				AllowServer = false,
 				HelpText = "Used to authenticate as superadmin when first setting up TShock."
@@ -4736,7 +4736,7 @@ namespace TShockAPI
 				}
 
 				IEnumerable<string> cmdNames = from cmd in ChatCommands
-											   where cmd.CanRun(args.Player) && (cmd.Name != "auth" || TShock.AuthToken != 0)
+											   where cmd.CanRun(args.Player) && (cmd.Name != "auth" || TShock.SetupToken != 0)
 											   select Specifier + cmd.Name;
 
 				PaginationTools.SendPage(args.Player, pageNumber, PaginationTools.BuildLinesFromTerms(cmdNames),
@@ -4829,17 +4829,17 @@ namespace TShockAPI
 			);
 		}
 
-		private static void AuthToken(CommandArgs args)
+		private static void SetupToken(CommandArgs args)
 		{
-			if (TShock.AuthToken == 0)
+			if (TShock.SetupToken == 0)
 			{
 				if (args.Player.Group.Name == new SuperAdminGroup().Name)
-					args.Player.SendInfoMessage("The auth system is already disabled.");
+					args.Player.SendInfoMessage("The initial setup system is already disabled.");
 				else
 				{
-					args.Player.SendWarningMessage("The auth system is disabled. This incident has been logged.");
-					TShock.Utils.ForceKick(args.Player, "Auth system is disabled.", true, true);
-					TShock.Log.Warn("{0} attempted to use {1}auth even though it's disabled.", args.Player.IP, Specifier);
+					args.Player.SendWarningMessage("The initial setup system is disabled. This incident has been logged.");
+					TShock.Utils.ForceKick(args.Player, "The initial setup system is disabled.", true, true);
+					TShock.Log.Warn("{0} attempted to use the initial setup system even though it's disabled.", args.Player.IP);
 					return;
 				}
 			}
@@ -4847,28 +4847,28 @@ namespace TShockAPI
 			// If the user account is already a superadmin (permanent), disable the system
 			if (args.Player.IsLoggedIn && args.Player.tempGroup == null && args.Player.Group.Name == new SuperAdminGroup().Name)
 			{
-				args.Player.SendSuccessMessage("Your new account has been verified, and the {0}auth system has been turned off.", Specifier);
+				args.Player.SendSuccessMessage("Your new account has been verified, and the {0}setup system has been turned off.", Specifier);
 				args.Player.SendSuccessMessage("You can always use the {0}user command to manage players.", Specifier);
-				args.Player.SendSuccessMessage("The auth system will remain disabled as long as a superadmin exists (even if you delete auth.lck).");
+				args.Player.SendSuccessMessage("The setup system will remain disabled as long as a superadmin exists (even if you delete setup.lock).");
 				args.Player.SendSuccessMessage("Share your server, talk with other admins, and more on our forums -- https://tshock.co/");
 				args.Player.SendSuccessMessage("Thank you for using TShock for Terraria!");
-				FileTools.CreateFile(Path.Combine(TShock.SavePath, "auth.lck"));
-				File.Delete(Path.Combine(TShock.SavePath, "authcode.txt"));
-				TShock.AuthToken = 0;
+				FileTools.CreateFile(Path.Combine(TShock.SavePath, "setup.lock"));
+				File.Delete(Path.Combine(TShock.SavePath, "setup-code.txt"));
+				TShock.SetupToken = 0;
 				return;
 			}
 
 			if (args.Parameters.Count == 0)
 			{
-				args.Player.SendErrorMessage("You must provide an auth code!");
+				args.Player.SendErrorMessage("You must provide a setup code!");
 				return;
 			}
 
 			int givenCode;
-			if (!Int32.TryParse(args.Parameters[0], out givenCode) || givenCode != TShock.AuthToken)
+			if (!Int32.TryParse(args.Parameters[0], out givenCode) || givenCode != TShock.SetupToken)
 			{
-				args.Player.SendErrorMessage("Incorrect auth code. This incident has been logged.");
-				TShock.Log.Warn(args.Player.IP + " attempted to use an incorrect auth code.");
+				args.Player.SendErrorMessage("Incorrect setup code. This incident has been logged.");
+				TShock.Log.Warn(args.Player.IP + " attempted to use an incorrect setup code.");
 				return;
 			}
 
@@ -4880,7 +4880,7 @@ namespace TShockAPI
 			args.Player.SendInfoMessage("{0}user add <username> <password> owner", Specifier);
 			args.Player.SendInfoMessage("Creates: <username> with the password <password> as part of the owner group.");
 			args.Player.SendInfoMessage("Please use {0}login <username> <password> after this process.", Specifier);
-			args.Player.SendInfoMessage("If you understand, please {0}login <username> <password> now, and then type {0}auth.", Specifier);
+			args.Player.SendInfoMessage("If you understand, please {0}login <username> <password> now, and then type {0}setup.", Specifier);
 			return;
 		}
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -861,8 +861,8 @@ namespace TShockAPI
 				Config.ServerPassword = _cliPassword;
 			}
 
-			// Disable the auth system if "setup.lock" is present or a superadmin exists
-			if (File.Exists(Path.Combine(SavePath, "setup.lock")) || UserAccounts.GetUserAccounts().Exists(u => u.Group == new SuperAdminGroup().Name))
+			// Disable the auth system if "setup.lock" is present or a user account already exists
+			if (File.Exists(Path.Combine(SavePath, "setup.lock")) || (UserAccounts.GetUserAccounts().Count() > 0))
 			{
 				SetupToken = 0;
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -841,8 +841,8 @@ namespace TShockAPI
 			CliParser.ParseFromSource(parms);
 		}
 
-		/// <summary>AuthToken - The auth token used by the /auth system to grant temporary superadmin access to new admins.</summary>
-		public static int AuthToken = -1;
+		/// <summary>SetupToken - The auth token used by the setup system to grant temporary superadmin access to new admins.</summary>
+		public static int SetupToken = -1;
 		private string _cliPassword = null;
 
 		/// <summary>OnPostInit - Fired when the server loads a map, to perform world specific operations.</summary>
@@ -861,41 +861,41 @@ namespace TShockAPI
 				Config.ServerPassword = _cliPassword;
 			}
 
-			// Disable the auth system if "auth.lck" is present or a superadmin exists
-			if (File.Exists(Path.Combine(SavePath, "auth.lck")) || UserAccounts.GetUserAccounts().Exists(u => u.Group == new SuperAdminGroup().Name))
+			// Disable the auth system if "setup.lock" is present or a superadmin exists
+			if (File.Exists(Path.Combine(SavePath, "setup.lock")) || UserAccounts.GetUserAccounts().Exists(u => u.Group == new SuperAdminGroup().Name))
 			{
-				AuthToken = 0;
+				SetupToken = 0;
 
-				if (File.Exists(Path.Combine(SavePath, "authcode.txt")))
+				if (File.Exists(Path.Combine(SavePath, "setup-code.txt")))
 				{
-					Log.ConsoleInfo("A superadmin account has been detected in the user database, but authcode.txt is still present.");
-					Log.ConsoleInfo("TShock will now disable the auth system and remove authcode.txt as it is no longer needed.");
-					File.Delete(Path.Combine(SavePath, "authcode.txt"));
+					Log.ConsoleInfo("A superadmin account has been detected in the user database, but setup-code.txt is still present.");
+					Log.ConsoleInfo("TShock will now disable the initial setup system and remove setup-code.txt as it is no longer needed.");
+					File.Delete(Path.Combine(SavePath, "setup-code.txt"));
 				}
 
-				if (!File.Exists(Path.Combine(SavePath, "auth.lck")))
+				if (!File.Exists(Path.Combine(SavePath, "setup.lock")))
 				{
 					// This avoids unnecessary database work, which can get ridiculously high on old servers as all users need to be fetched
-					File.Create(Path.Combine(SavePath, "auth.lck"));
+					File.Create(Path.Combine(SavePath, "setup.lock"));
 				}
 			}
-			else if (!File.Exists(Path.Combine(SavePath, "authcode.txt")))
+			else if (!File.Exists(Path.Combine(SavePath, "setup-code.txt")))
 			{
 				var r = new Random((int)DateTime.Now.ToBinary());
-				AuthToken = r.Next(100000, 10000000);
+				SetupToken = r.Next(100000, 10000000);
 				Console.ForegroundColor = ConsoleColor.Yellow;
-				Console.WriteLine("TShock Notice: To become SuperAdmin, join the game and type {0}auth {1}", Commands.Specifier, AuthToken);
-				Console.WriteLine("This token will display until disabled by verification. ({0}auth)", Commands.Specifier);
+				Console.WriteLine("To setup the server, join the game and type {0}setup {1}", Commands.Specifier, SetupToken);
+				Console.WriteLine("This token will display until disabled by verification. ({0}setup)", Commands.Specifier);
 				Console.ResetColor();
-				File.WriteAllText(Path.Combine(SavePath, "authcode.txt"), AuthToken.ToString());
+				File.WriteAllText(Path.Combine(SavePath, "setup-code.txt"), SetupToken.ToString());
 			}
 			else
 			{
-				AuthToken = Convert.ToInt32(File.ReadAllText(Path.Combine(SavePath, "authcode.txt")));
+				SetupToken = Convert.ToInt32(File.ReadAllText(Path.Combine(SavePath, "setup-code.txt")));
 				Console.ForegroundColor = ConsoleColor.Yellow;
-				Console.WriteLine("TShock Notice: authcode.txt is still present, and the AuthToken located in that file will be used.");
-				Console.WriteLine("To become superadmin, join the game and type {0}auth {1}", Commands.Specifier, AuthToken);
-				Console.WriteLine("This token will display until disabled by verification. ({0}auth)", Commands.Specifier);
+				Console.WriteLine("TShock Notice: setup-code.txt is still present, and the code located in that file will be used.");
+				Console.WriteLine("To setup the server, join the game and type {0}setup {1}", Commands.Specifier, SetupToken);
+				Console.WriteLine("This token will display until disabled by verification. ({0}setup)", Commands.Specifier);
 				Console.ResetColor();
 			}
 


### PR DESCRIPTION
This is a followup from https://github.com/Pryaxis/TShock/pull/1558#discussion_r156857135. It changes the entire "auth system" to the initial setup system and replaces all instances of this verbiage in the system.

This should have no effect on existing servers. If a user exists the authentication system is disabled even if the lockfile is gone. I considered removing the `setup.lock` / `auth.lck` system entirely, but I decided against it. Should I?

This also fixes a bonus problem where the system could turn itself back on if the lock file was removed because the superadmin account wouldn't exist in an ideal scenario (the player created an owner account, not a superadmin account).