### PR TITLE
Fix /setup not working with owner groups; update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _These instructions assume Windows. If you're setting up on Linux or macOS, plea
 
 1. Look at the server console for the _setup code_. Type `/setup [code]` (example: `/setup 12345`), then a space, then the code you see in the console in your game chat. Instead of chatting, you'll run a command on the server. This one makes you temporary admin. All commands are prefixed with `/` or `!` (to make them silent).
 
-1. Use the in-game command `/register [password]` (example: `/register lovely-ashes`) to create an account. This gives you owner rights on your server, which you can configure more to your liking later. Your `character name` is your `account name`.
+1. Use the in-game command `/user add [account name] [password] owner` (example: `/user add shank lovely-ashes owner`) to create an account. This gives you owner rights on your server, which you can configure more to your liking later.
 
 1. Login to your newly created account with `/login [account name] [password]` (example: `/login shank lovely-ashes`). You should see a login success message.
 

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4845,7 +4845,7 @@ namespace TShockAPI
 			}
 
 			// If the user account is already a superadmin (permanent), disable the system
-			if (args.Player.IsLoggedIn && args.Player.tempGroup == null && args.Player.Group.Name == new SuperAdminGroup().Name)
+			if (args.Player.IsLoggedIn && args.Player.tempGroup == null)
 			{
 				args.Player.SendSuccessMessage("Your new account has been verified, and the {0}setup system has been turned off.", Specifier);
 				args.Player.SendSuccessMessage("You can always use the {0}user command to manage players.", Specifier);


### PR DESCRIPTION
A bug introduced in the new setup system prevented owner accounts from shutting down the first time setup system. This fixes that.

This also changes the readme back to referring to `/user add`. The problem is that `/register` isn't going to put you in the owner group, which obviously means you're not admin.

What was I thinking with changing it to register? I read that on Ijwu's guide and had a memory lapse. Oops.