### PR TITLE
Rebuilt TSPlayer.CheckIgnores() as TSPlayer.IsBeingDisabled(). Fixes #1561.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added `TSPlayer` to `GetDataHandlers.GemLockToggle`. (@hakusaro)
 * Added `GetDataHandlers.PlaceItemFrame` hook and related arguments. (@hakusaro)
 * Added `TSPlayer.IsBouncerThrottled()`. (@hakusaro)
-* Added `TSPlayer.CheckIgnores()` and removed `TShock.CheckIgnores(TSPlayer)`. (@hakusaro)
+* Added `TSPlayer.IsBeingDisabled()` and removed `TShock.CheckIgnores(TSPlayer)`. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -857,7 +857,7 @@ namespace TShockAPI
 						}
 						else if (args.Player.IsDisabledForSSC)
 						{
-							args.Player.SendErrorMessage("Disabled. You need to {0}login to use your server inventory and items.", TShock.Config.CommandSpecifier);
+							args.Player.SendErrorMessage("Disabled. You need to {0}login to load your saved data.", TShock.Config.CommandSpecifier);
 						}
 						else if (TShock.Config.RequireLogin && !args.Player.IsLoggedIn)
 						{

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -863,7 +863,7 @@ namespace TShockAPI
 						{
 							args.Player.SendErrorMessage("Please /register or /login to play!");
 						}
-						else if (args.Player.IgnoreActionsForClearingTrashCan)
+						else if (args.Player.IsDisabledPendingTrashRemoval)
 						{
 							args.Player.SendErrorMessage("You need to rejoin to ensure your trash can is cleared!");
 						}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -857,7 +857,7 @@ namespace TShockAPI
 						}
 						else if (args.Player.IsDisabledForSSC)
 						{
-							args.Player.SendErrorMessage("Disabled. You need to {0}login, since server side characters is enabled.", TShock.Config.CommandSpecifier);
+							args.Player.SendErrorMessage("Disabled. You need to {0}login to use your server inventory and items.", TShock.Config.CommandSpecifier);
 						}
 						else if (TShock.Config.RequireLogin && !args.Player.IsLoggedIn)
 						{

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -69,7 +69,7 @@ namespace TShockAPI
 		/// <param name="args">The packet arguments that the event has.</param>
 		internal void OnPlaceItemFrame(object sender, GetDataHandlers.PlaceItemFrameEventArgs args)
 		{
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				NetMessage.SendData((int)PacketTypes.UpdateTileEntity, -1, -1, NetworkText.Empty, args.ItemFrame.ID, 0, 1);
 				args.Handled = true;
@@ -108,7 +108,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Handled = true;
 				return;
@@ -126,7 +126,7 @@ namespace TShockAPI
 		/// <param name="args">The packet arguments that the event has.</param>
 		internal void OnPlaceTileEntity(object sender, GetDataHandlers.PlaceTileEntityEventArgs args)
 		{
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Handled = true;
 				return;
@@ -177,7 +177,7 @@ namespace TShockAPI
 					return;
 				}	
 
-				if (args.Player.CheckIgnores())
+				if (args.Player.IsBeingDisabled())
 				{
 					args.Handled = true;
 					return;
@@ -196,7 +196,7 @@ namespace TShockAPI
 		/// <param name="args">args</param>
 		internal void OnPlayerAnimation(object sender, GetDataHandlers.PlayerAnimationEventArgs args)
 		{
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.PlayerAnimation, "", args.Player.Index);
 				args.Handled = true;
@@ -245,7 +245,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.NpcUpdate, "", id);
 				args.Handled = true;
@@ -311,7 +311,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.PlayerHp, "", id);
 				args.Player.SendData(PacketTypes.PlayerUpdate, "", id);
@@ -421,7 +421,7 @@ namespace TShockAPI
 
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);
 				args.Handled = true;
@@ -444,7 +444,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.PlayerAddBuff, "", id);
 				args.Handled = true;
@@ -503,7 +503,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendData(PacketTypes.ChestItem, "", id, slot);
 				args.Handled = true;
@@ -558,7 +558,7 @@ namespace TShockAPI
 		/// <param name="args">The packet arguments that the event has.</param>
 		internal void OnChestOpen(object sender, GetDataHandlers.ChestOpenEventArgs args)
 		{
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Handled = true;
 				return;
@@ -595,7 +595,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendTileSquare(tileX, tileY, 3);
 				args.Handled = true;
@@ -656,7 +656,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendTileSquare(tileX, tileY, 1);
 				args.Handled = true;
@@ -791,7 +791,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.RemoveProjectile(args.ProjectileIdentity, args.ProjectileOwner);
 				args.Handled = true;
@@ -841,7 +841,7 @@ namespace TShockAPI
 				float distance = Vector2.Distance(new Vector2(pos.X / 16f, pos.Y / 16f),
 					new Vector2(args.Player.LastNetPosition.X / 16f, args.Player.LastNetPosition.Y / 16f));
 
-				if (args.Player.CheckIgnores())
+				if (args.Player.IsBeingDisabled())
 				{
 					// If the player has moved outside the disabled zone...
 					if (distance > TShock.Config.MaxRangeForDisabled)
@@ -982,7 +982,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.RemoveProjectile(ident, owner);
 				args.Handled = true;
@@ -1115,7 +1115,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendTileSquare(x, y, 4);
 				args.Handled = true;
@@ -1470,7 +1470,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if (args.Player.CheckIgnores())
+				if (args.Player.IsBeingDisabled())
 				{
 					args.Player.SendTileSquare(tileX, tileY, 4);
 					args.Handled = true;
@@ -1586,7 +1586,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores() || args.Player.IsBouncerThrottled())
+			if (args.Player.IsBeingDisabled() || args.Player.IsBouncerThrottled())
 			{
 				args.Handled = true;
 				return;
@@ -1627,7 +1627,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.CheckIgnores())
+			if (args.Player.IsBeingDisabled())
 			{
 				args.Player.SendTileSquare(tileX, tileY, size);
 				args.Handled = true;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -847,15 +847,15 @@ namespace TShockAPI
 					if (distance > TShock.Config.MaxRangeForDisabled)
 					{
 						// We need to tell them they were disabled and why, then revert the change.
-						if (args.Player.IsDisabledForStackDetection == true)
+						if (args.Player.IsDisabledForStackDetection)
 						{
 							args.Player.SendErrorMessage("Disabled. You went too far with hacked item stacks.");
 						}
-						else if (args.Player.IgnoreActionsForDisabledArmor != "none")
+						else if (args.Player.IsDisabledForBannedWearable)
 						{
-							args.Player.SendErrorMessage("Disabled for banned armor: " + args.Player.IgnoreActionsForDisabledArmor);
+							args.Player.SendErrorMessage("Disabled. You went too far with banned armor.");
 						}
-						else if (args.Player.IsDisabledForSSC == true)
+						else if (args.Player.IsDisabledForSSC)
 						{
 							args.Player.SendErrorMessage("Disabled. You need to {0}login, since server side characters is enabled.", TShock.Config.CommandSpecifier);
 						}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -847,9 +847,9 @@ namespace TShockAPI
 					if (distance > TShock.Config.MaxRangeForDisabled)
 					{
 						// We need to tell them they were disabled and why, then revert the change.
-						if (args.Player.IgnoreActionsForCheating != "none")
+						if (args.Player.IsDisabledForStackDetection == true)
 						{
-							args.Player.SendErrorMessage("Disabled for cheating: " + args.Player.IgnoreActionsForCheating);
+							args.Player.SendErrorMessage("Disabled. You went too far with hacked item stacks.");
 						}
 						else if (args.Player.IgnoreActionsForDisabledArmor != "none")
 						{
@@ -857,7 +857,7 @@ namespace TShockAPI
 						}
 						else if (args.Player.IsDisabledForSSC == true)
 						{
-							args.Player.SendErrorMessage("Disabled. Server side characters is enabled, and you aren't logged in.");
+							args.Player.SendErrorMessage("Disabled. You need to {0}login, since server side characters is enabled.", TShock.Config.CommandSpecifier);
 						}
 						else if (TShock.Config.RequireLogin && !args.Player.IsLoggedIn)
 						{

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -855,9 +855,9 @@ namespace TShockAPI
 						{
 							args.Player.SendErrorMessage("Disabled for banned armor: " + args.Player.IgnoreActionsForDisabledArmor);
 						}
-						else if (args.Player.IgnoreActionsForInventory != "none")
+						else if (args.Player.IsDisabledForSSC == true)
 						{
-							args.Player.SendErrorMessage("Disabled for Server Side Inventory: " + args.Player.IgnoreActionsForInventory);
+							args.Player.SendErrorMessage("Disabled. Server side characters is enabled, and you aren't logged in.");
 						}
 						else if (TShock.Config.RequireLogin && !args.Player.IsLoggedIn)
 						{

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -848,7 +848,7 @@ namespace TShockAPI
 					args.Player.tempGroup = null;
 					args.Player.Account = account;
 					args.Player.IsLoggedIn = true;
-					args.Player.IgnoreActionsForInventory = "none";
+					args.Player.IsDisabledForSSC = false;
 
 					if (Main.ServerSideCharacter)
 					{

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -865,7 +865,7 @@ namespace TShockAPI
 						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
-						args.Player.IgnoreActionsForDisabledArmor = "none";
+						args.Player.IsDisabledForBannedWearable = false;
 
 					args.Player.SendSuccessMessage("Authenticated as " + account.Name + " successfully.");
 

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1636,7 +1636,7 @@ namespace TShockAPI
 				args.Player.SendSuccessMessage("SSC has been saved.");
 				foreach (TSPlayer player in TShock.Players)
 				{
-					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
+					if (player != null && player.IsLoggedIn && !player.IsDisabledPendingTrashRemoval)
 					{
 						TShock.CharacterDB.InsertPlayerData(player, true);
 					}
@@ -1681,7 +1681,7 @@ namespace TShockAPI
 				args.Player.SendErrorMessage("Player \"{0}\" has to perform a /login attempt first.", matchedPlayer.Name);
 				return;
 			}
-			if (matchedPlayer.IgnoreActionsForClearingTrashCan)
+			if (matchedPlayer.IsDisabledPendingTrashRemoval)
 			{
 				args.Player.SendErrorMessage("Player \"{0}\" has to reconnect first.", matchedPlayer.Name);
 				return;
@@ -1887,7 +1887,7 @@ namespace TShockAPI
 			{
 				foreach (TSPlayer player in TShock.Players)
 				{
-					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
+					if (player != null && player.IsLoggedIn && !player.IsDisabledPendingTrashRemoval)
 					{
 						player.SaveServerCharacter();
 					}

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -862,7 +862,7 @@ namespace TShockAPI
 					args.Player.LoginFailsBySsi = false;
 
 					if (args.Player.HasPermission(Permissions.ignorestackhackdetection))
-						args.Player.IgnoreActionsForCheating = "none";
+						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
 						args.Player.IgnoreActionsForDisabledArmor = "none";

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1784,7 +1784,7 @@ namespace TShockAPI
 					args.Player.tempGroup = null;
 					args.Player.Account = account;
 					args.Player.IsLoggedIn = true;
-					args.Player.IgnoreActionsForInventory = "none";
+					args.Player.IsDisabledForSSC = false;
 
 					if (Main.ServerSideCharacter)
 					{
@@ -1856,7 +1856,7 @@ namespace TShockAPI
 					args.Player.tempGroup = null;
 					args.Player.Account = account;
 					args.Player.IsLoggedIn = true;
-					args.Player.IgnoreActionsForInventory = "none";
+					args.Player.IsDisabledForSSC = false;
 
 					if (Main.ServerSideCharacter)
 					{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1612,7 +1612,7 @@ namespace TShockAPI
 				args.Player.HasSentInventory && !args.Player.HasPermission(Permissions.bypassssc))
 			{
 				// The player might have moved an item to their trash can before they performed a single login attempt yet.
-				args.Player.IgnoreActionsForClearingTrashCan = true;
+				args.Player.IsDisabledPendingTrashRemoval = true;
 			}
 
 			if (slot == 58) //this is the hand

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1801,7 +1801,7 @@ namespace TShockAPI
 						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
-						args.Player.IgnoreActionsForDisabledArmor = "none";
+						args.Player.IsDisabledForBannedWearable = false;
 
 					args.Player.SendSuccessMessage("Authenticated as " + account.Name + " successfully.");
 					TShock.Log.ConsoleInfo(args.Player.Name + " authenticated successfully as user " + args.Player.Name + ".");
@@ -1873,7 +1873,7 @@ namespace TShockAPI
 						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
-						args.Player.IgnoreActionsForDisabledArmor = "none";
+						args.Player.IsDisabledForBannedWearable = false;
 
 
 					args.Player.SendMessage("Authenticated as " + args.Player.Name + " successfully.", Color.LimeGreen);

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1798,7 +1798,7 @@ namespace TShockAPI
 					args.Player.LoginFailsBySsi = false;
 
 					if (args.Player.HasPermission(Permissions.ignorestackhackdetection))
-						args.Player.IgnoreActionsForCheating = "none";
+						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
 						args.Player.IgnoreActionsForDisabledArmor = "none";
@@ -1870,7 +1870,7 @@ namespace TShockAPI
 					args.Player.LoginFailsBySsi = false;
 
 					if (args.Player.HasPermission(Permissions.ignorestackhackdetection))
-						args.Player.IgnoreActionsForCheating = "none";
+						args.Player.IsDisabledForStackDetection = false;
 
 					if (args.Player.HasPermission(Permissions.usebanneditem))
 						args.Player.IgnoreActionsForDisabledArmor = "none";

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -283,7 +283,8 @@ namespace TShockAPI
 		/// <summary>Determines if the player is disabled by Bouncer for having hacked item stacks.</summary>
 		public bool IsDisabledForStackDetection = false;
 
-		public string IgnoreActionsForDisabledArmor = "none";
+		/// <summary>Determines if the player is disabled by the item bans system for having banned wearables on the server.</summary>
+		public bool IsDisabledForBannedWearable = false;
 
 		public bool IgnoreActionsForClearingTrashCan;
 
@@ -299,7 +300,7 @@ namespace TShockAPI
 		/// <returns>bool - True if any ignore is not none, false, or login state differs from the required state.</returns>
 		public bool CheckIgnores()
 		{
-			return IsDisabledForSSC || IsDisabledForStackDetection || IgnoreActionsForDisabledArmor != "none" || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
+			return IsDisabledForSSC || IsDisabledForStackDetection || IsDisabledForBannedWearable || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
 		}
 
 		/// <summary>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -296,12 +296,15 @@ namespace TShockAPI
 			return (DateTime.UtcNow - LastThreat).TotalMilliseconds < 5000;
 		}
 
-		/// <summary>CheckIgnores - Checks a players ignores...?</summary>
-		/// <param name="player">player - The TSPlayer object.</param>
-		/// <returns>bool - True if any ignore is not none, false, or login state differs from the required state.</returns>
-		public bool CheckIgnores()
+		/// <summary>Easy check if a player has any of IsDisabledForSSC, IsDisabledForStackDetection, IsDisabledForBannedWearable, or IsDisabledPendingTrashRemoval set. Or if they're not logged in and a login is required.</summary>
+		/// <returns>If any of the checks that warrant disabling are set on this player. If true, Disable() is repeatedly called on them.</returns>
+		public bool IsBeingDisabled()
 		{
-			return IsDisabledForSSC || IsDisabledForStackDetection || IsDisabledForBannedWearable || IsDisabledPendingTrashRemoval || !IsLoggedIn && TShock.Config.RequireLogin;
+			return IsDisabledForSSC
+			|| IsDisabledForStackDetection
+			|| IsDisabledForBannedWearable
+			|| IsDisabledPendingTrashRemoval
+			|| !IsLoggedIn && TShock.Config.RequireLogin;
 		}
 
 		/// <summary>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -277,7 +277,8 @@ namespace TShockAPI
 
 		private string CacheIP;
 
-		public string IgnoreActionsForInventory = "none";
+		/// <summary>Determines if the player is disabled by the SSC subsystem for not being logged in.</summary>
+		public bool IsDisabledForSSC = false;
 
 		public string IgnoreActionsForCheating = "none";
 
@@ -297,7 +298,7 @@ namespace TShockAPI
 		/// <returns>bool - True if any ignore is not none, false, or login state differs from the required state.</returns>
 		public bool CheckIgnores()
 		{
-			return IgnoreActionsForInventory != "none" || IgnoreActionsForCheating != "none" || IgnoreActionsForDisabledArmor != "none" || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
+			return IsDisabledForSSC || IgnoreActionsForCheating != "none" || IgnoreActionsForDisabledArmor != "none" || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
 		}
 
 		/// <summary>
@@ -656,7 +657,7 @@ namespace TShockAPI
 			PlayerHooks.OnPlayerLogout(this);
 			if (Main.ServerSideCharacter)
 			{
-				IgnoreActionsForInventory = $"Server side characters is enabled! Please {Commands.Specifier}register or {Commands.Specifier}login to play!";
+				IsDisabledForSSC = true;
 				if (!IgnoreActionsForClearingTrashCan && (!Dead || TPlayer.difficulty != 2))
 				{
 					PlayerData.CopyCharacter(this);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -286,7 +286,8 @@ namespace TShockAPI
 		/// <summary>Determines if the player is disabled by the item bans system for having banned wearables on the server.</summary>
 		public bool IsDisabledForBannedWearable = false;
 
-		public bool IgnoreActionsForClearingTrashCan;
+		/// <summary>Determines if the player is disabled for not clearing their trash. A re-login is the only way to reset this.</summary>
+		public bool IsDisabledPendingTrashRemoval;
 
 		/// <summary>Checks to see if active throttling is happening on events by Bouncer. Rejects repeated events by malicious clients in a short window.</summary>
 		/// <returns>If the player is currently being throttled by Bouncer, or not.</returns>
@@ -300,7 +301,7 @@ namespace TShockAPI
 		/// <returns>bool - True if any ignore is not none, false, or login state differs from the required state.</returns>
 		public bool CheckIgnores()
 		{
-			return IsDisabledForSSC || IsDisabledForStackDetection || IsDisabledForBannedWearable || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
+			return IsDisabledForSSC || IsDisabledForStackDetection || IsDisabledForBannedWearable || IsDisabledPendingTrashRemoval || !IsLoggedIn && TShock.Config.RequireLogin;
 		}
 
 		/// <summary>
@@ -660,7 +661,7 @@ namespace TShockAPI
 			if (Main.ServerSideCharacter)
 			{
 				IsDisabledForSSC = true;
-				if (!IgnoreActionsForClearingTrashCan && (!Dead || TPlayer.difficulty != 2))
+				if (!IsDisabledPendingTrashRemoval && (!Dead || TPlayer.difficulty != 2))
 				{
 					PlayerData.CopyCharacter(this);
 					TShock.CharacterDB.InsertPlayerData(this);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -280,7 +280,8 @@ namespace TShockAPI
 		/// <summary>Determines if the player is disabled by the SSC subsystem for not being logged in.</summary>
 		public bool IsDisabledForSSC = false;
 
-		public string IgnoreActionsForCheating = "none";
+		/// <summary>Determines if the player is disabled by Bouncer for having hacked item stacks.</summary>
+		public bool IsDisabledForStackDetection = false;
 
 		public string IgnoreActionsForDisabledArmor = "none";
 
@@ -298,7 +299,7 @@ namespace TShockAPI
 		/// <returns>bool - True if any ignore is not none, false, or login state differs from the required state.</returns>
 		public bool CheckIgnores()
 		{
-			return IsDisabledForSSC || IgnoreActionsForCheating != "none" || IgnoreActionsForDisabledArmor != "none" || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
+			return IsDisabledForSSC || IsDisabledForStackDetection || IgnoreActionsForDisabledArmor != "none" || IgnoreActionsForClearingTrashCan || !IsLoggedIn && TShock.Config.RequireLogin;
 		}
 
 		/// <summary>

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1083,7 +1083,7 @@ namespace TShockAPI
 
 					if (Main.ServerSideCharacter && !player.IsLoggedIn)
 					{
-						if (player.CheckIgnores())
+						if (player.IsBeingDisabled())
 						{
 							player.Disable(flags: flags);
 						}
@@ -1163,7 +1163,7 @@ namespace TShockAPI
 						}
 						player.IsDisabledForBannedWearable = true;
 
-						if (player.CheckIgnores())
+						if (player.IsBeingDisabled())
 						{
 							player.Disable(flags: flags);
 						}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1161,7 +1161,7 @@ namespace TShockAPI
 								break;
 							}
 						}
-						player.IgnoreActionsForDisabledArmor = check;
+						player.IsDisabledForBannedWearable = true;
 
 						if (player.CheckIgnores())
 						{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1106,7 +1106,7 @@ namespace TShockAPI
 								break;
 							}
 						}
-						player.IgnoreActionsForCheating = check;
+						player.IsDisabledForStackDetection = true;
 						check = "none";
 						// Please don't remove this for the time being; without it, players wearing banned equipment will only get debuffed once
 						foreach (Item item in player.TPlayer.armor)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -945,7 +945,7 @@ namespace TShockAPI
 				foreach (TSPlayer player in Players)
 				{
 					// prevent null point exceptions
-					if (player != null && player.IsLoggedIn && !player.IgnoreActionsForClearingTrashCan)
+					if (player != null && player.IsLoggedIn && !player.IsDisabledPendingTrashRemoval)
 					{
 
 						CharacterDB.InsertPlayerData(player);
@@ -1409,7 +1409,7 @@ namespace TShockAPI
 					Utils.Broadcast(tsplr.Name + " has left.", Color.Yellow);
 				Log.Info("{0} disconnected.", tsplr.Name);
 
-				if (tsplr.IsLoggedIn && !tsplr.IgnoreActionsForClearingTrashCan && Main.ServerSideCharacter && (!tsplr.Dead || tsplr.TPlayer.difficulty != 2))
+				if (tsplr.IsLoggedIn && !tsplr.IsDisabledPendingTrashRemoval && Main.ServerSideCharacter && (!tsplr.Dead || tsplr.TPlayer.difficulty != 2))
 				{
 					tsplr.PlayerData.CopyCharacter(tsplr);
 					CharacterDB.InsertPlayerData(tsplr);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1684,8 +1684,8 @@ namespace TShockAPI
 			{
 				if (Main.ServerSideCharacter)
 				{
-					player.SendErrorMessage(
-						player.IgnoreActionsForInventory = String.Format("Server side characters is enabled! Please {0}register or {0}login to play!", Commands.Specifier));
+					player.IsDisabledForSSC = true;
+					player.SendErrorMessage(String.Format("Server side characters is enabled! Please {0}register or {0}login to play!", Commands.Specifier));
 					player.LoginHarassed = true;
 				}
 				else if (Config.RequireLogin)


### PR DESCRIPTION
This addresses the problem of what `TSPlayer.CheckIgnores()` is actually checking in a clear way. It rewrites all of the "ignores" into booleans, removes some redundant messages, and generally improves code quality.

Each commit message has a pretty good rationale behind it. When reviewing, it's easier to go to the first commit and use the keyboard shortcuts to go in order of commits (n and p) to see how this story was worked. You can read each rationale and see the diff as it was implemented.