### PR TITLE
Made disable message for login use specifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added `GetDataHandlers.PlaceItemFrame` hook and related arguments. (@hakusaro)
 * Added `TSPlayer.IsBouncerThrottled()`. (@hakusaro)
 * Added `TSPlayer.CheckIgnores()` and removed `TShock.CheckIgnores(TSPlayer)`. (@hakusaro)
+* Fix message requiring login not using the command specifier set in the config file. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -861,7 +861,7 @@ namespace TShockAPI
 						}
 						else if (TShock.Config.RequireLogin && !args.Player.IsLoggedIn)
 						{
-							args.Player.SendErrorMessage("Please /register or /login to play!");
+							args.Player.SendErrorMessage("Account needed! Please {0}register or {0}login to play!", TShock.Config.CommandSpecifier);
 						}
 						else if (args.Player.IgnoreActionsForClearingTrashCan)
 						{


### PR DESCRIPTION
This changes the behavior of the disable message if not logged in to use the command specifier, not hard coded to `/register` and `/login`. This is technically a bugfix, so it gets a changelog entry.