### PR TITLE
Move TShock.CheckSpawn to Utils.IsInSpawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added `TSPlayer.CheckIgnores()` and removed `TShock.CheckIgnores(TSPlayer)`. (@hakusaro)
 * Hooks inside TShock can now be registered with their `Register` method and can be prioritized according to the TShock HandlerList system. (@hakusaro)
 * Fix message requiring login not using the command specifier set in the config file. (@hakusaro)
+* Move `TShock.CheckSpawn` to `Utils.IsInSpawn`. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1846,7 +1846,7 @@ namespace TShockAPI
 			{
 				if (!player.HasPermission(Permissions.editspawn))
 				{
-					if (CheckSpawn(tileX, tileY))
+					if (Utils.IsInSpawn(tileX, tileY))
 					{
 						if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 2000)
 						{
@@ -1913,7 +1913,7 @@ namespace TShockAPI
 			{
 				if (!player.HasPermission(Permissions.editspawn))
 				{
-					if (CheckSpawn(tileX, tileY))
+					if (Utils.IsInSpawn(tileX, tileY))
 					{
 						if (((DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond) - player.SPm) > 1000)
 						{
@@ -1927,16 +1927,7 @@ namespace TShockAPI
 			return false;
 		}
 
-		/// <summary>CheckSpawn - Checks to see if a location is inside the spawn protection zone.</summary>
-		/// <param name="x">x - The x coordinate to check.</param>
-		/// <param name="y">y - The y coordinate to check.</param>
-		/// <returns>bool - True if the location is inside the spawn protection zone.</returns>
-		public static bool CheckSpawn(int x, int y)
-		{
-			Vector2 tile = new Vector2(x, y);
-			Vector2 spawn = new Vector2(Main.spawnTileX, Main.spawnTileY);
-			return Utils.Distance(spawn, tile) <= Config.SpawnProtectionRadius;
-		}
+
 
 		/// <summary>Distance - Determines the distance between two vectors.</summary>
 		/// <param name="value1">value1 - The first vector location.</param>

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1525,6 +1525,17 @@ namespace TShockAPI
 			return (float)Math.Sqrt(num3);
 		}
 
+		/// <summary>Checks to see if a location is in the spawn protection area.</summary>
+		/// <param name="x">The x coordinate to check.</param>
+		/// <param name="y">The y coordinate to check.</param>
+		/// <returns>If the given x,y location is in the spawn area.</returns>
+		public static bool IsInSpawn(int x, int y)
+		{
+			Vector2 tile = new Vector2(x, y);
+			Vector2 spawn = new Vector2(Main.spawnTileX, Main.spawnTileY);
+			return Distance(spawn, tile) <= TShock.Config.SpawnProtectionRadius;
+		}
+
 		/// <summary>Computes the max styles...</summary>
 		internal void ComputeMaxStyles()
 		{


### PR DESCRIPTION
Continuing in the quest to clean things out of the TShock main class, this moves CheckSpawn out and renames it for clarity. This is part of the fragments goal, just like moving all of the other methods out of the TShock main class.