### PR TITLE
Fix #1584 / Revert "Change Utils.SearchProjectile to return -1 in error"

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -978,7 +978,7 @@ namespace TShockAPI
 			short type = args.Type;
 			int index = args.Index;
 
-			if (index > Main.maxProjectiles || index < 0)
+			if (index > Main.maxProjectiles)
 			{
 				args.Player.RemoveProjectile(ident, owner);
 				args.Handled = true;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -925,7 +925,7 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="identity">identity</param>
 		/// <param name="owner">owner</param>
-		/// <returns>projectile ID or -1 if not found</returns>
+		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner)
 		{
 			for (int i = 0; i < Main.maxProjectiles; i++)
@@ -933,7 +933,7 @@ namespace TShockAPI
 				if (Main.projectile[i].identity == identity && Main.projectile[i].owner == owner)
 					return i;
 			}
-			return -1;
+			return 1000;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This reverts commit e19fd22fe0a5600af0c47c07eade94aff119f343.

Not entirely sure why but in #1584 notes that we've regressed in behavior and that the previous function worked fine. This leads me to believe that negatives have an important value in the server somewhere. As a result, I want to revert the changes brought about by Bouncer related to this projectile check.