### PR TITLE
Remove broken noclip detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Replace `TShock.CheckTilePermission` with `TSPlayer.HasBuildPermission`, `TSPlayer.HasPaintPermission`, and `TSPlayer.HasModifiedIceSuccessfully` respectively. (@hakusaro)
 * Fix stack hack detection being inconsistent between two different check points. Moved `TShock.HackedInventory` to `TSPlayer.HasHackedItemStacks`. Added `GetDataHandlers.GetDataHandledEventArgs` which is where most hooks will inherit from in the future. (@hakusaro)
 * All `GetDataHandlers` hooks now inherit from `GetDataHandledEventArgs` which includes a `TSPlayer` and a `MemoryStream` of raw data. (@hakusaro)
+* Removed broken noclip detection and attempted prevention. TShock wasn't doing a good job at stopping noclip. It's always worse to claim that you do something that you can't/don't do, so removing this is better than keeping broken detection in. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -909,22 +909,6 @@ namespace TShockAPI
 					args.Handled = true;
 					return;
 				}
-
-				// Noclip detection
-				if (!args.Player.HasPermission(Permissions.ignorenoclipdetection) &&
-					TSCheckNoclip(pos, args.Player.TPlayer.width, args.Player.TPlayer.height - (args.Player.TPlayer.mount.Active ? args.Player.TPlayer.mount.HeightBoost : 0)) && !TShock.Config.IgnoreNoClip
-					&& !args.Player.TPlayer.tongued)
-				{
-					var lastTileX = args.Player.LastNetPosition.X;
-					var lastTileY = args.Player.LastNetPosition.Y;
-					if (!args.Player.Teleport(lastTileX, lastTileY))
-					{
-						args.Player.SendErrorMessage("You got stuck in a solid object, Sent to spawn point.");
-						args.Player.Spawn();
-					}
-					args.Handled = true;
-					return;
-				}
 			}
 
 			return;

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -353,10 +353,6 @@ namespace TShockAPI
 		[Description("Ignores checking to see if player 'can' kill a projectile.")]
 		public bool IgnoreProjKill = false;
 
-		/// <summary>IgnoreNoClip - Ignores all no clip checks for players.</summary>
-		[Description("Ignores all no clip checks for players.")]
-		public bool IgnoreNoClip = false;
-
 		/// <summary>AlllowIce - Allows ice placement even where a user cannot usually build.</summary>
 		[Description("Allow ice placement even when user does not have canbuild.")]
 		public bool AllowIce = false;

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -146,7 +146,6 @@ namespace TShockAPI.DB
 						Permissions.ignorekilltiledetection,
 						Permissions.ignoreliquidsetdetection,
 						Permissions.ignoremp,
-						Permissions.ignorenoclipdetection,
 						Permissions.ignorepaintdetection,
 						Permissions.ignoreplacetiledetection,
 						Permissions.ignoreprojectiledetection,

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -550,61 +550,6 @@ namespace TShockAPI
 			return args.Handled;
 		}
 
-		public static bool TSCheckNoclip(Vector2 Position, int Width, int Height)
-		{
-			int num = (int)(Position.X / 16f);
-			int num2 = (int)((Position.X + (float)Width) / 16f);
-			int num3 = (int)(Position.Y / 16f);
-			int num4 = (int)((Position.Y + (float)Height) / 16f);
-			if (num < 0)
-			{
-				num = 0;
-			}
-			if (num2 > Main.maxTilesX)
-			{
-				num2 = Main.maxTilesX;
-			}
-			if (num3 < 0)
-			{
-				num3 = 0;
-			}
-			if (num4 > Main.maxTilesY)
-			{
-				num4 = Main.maxTilesY;
-			}
-			for (int c = num; c < num2; c++)
-			{
-				for (int d = num3; d < num4; d++)
-				{
-					if (Main.tile[c, d].liquid != 0)
-						return false;
-				}
-			}
-			for (int i = num; i < num2; i++)
-			{
-				for (int j = num3; j < num4; j++)
-				{
-					if (Main.tile[i, j] == null || Main.tileSand[Main.tile[i, j].type]
-						|| !TShock.Utils.TileSolid(i, j) || !TShock.Utils.TileSolid(i + 1, j) || !TShock.Utils.TileSolid(i - 1, j)
-						|| !TShock.Utils.TileSolid(i, j + 1) || !TShock.Utils.TileSolid(i + 1, j + 1) || !TShock.Utils.TileSolid(i - 1, j + 1)
-						|| !TShock.Utils.TileSolid(i, j - 1) || !TShock.Utils.TileSolid(i + 1, j - 1) || !TShock.Utils.TileSolid(i - 1, j - 1)
-						|| Main.tileSolidTop[(int)Main.tile[i, j].type])
-					{
-						continue;
-					}
-
-					Vector2 vector;
-					vector.X = (float)(i * 16);
-					vector.Y = (float)(j * 16);
-					if (Position.X + (float)Width > vector.X && Position.X < vector.X + 16f && Position.Y + (float)Height > vector.Y && Position.Y < vector.Y + 16f)
-					{
-						return true;
-					}
-				}
-			}
-			return false;
-		}
-
 		/// <summary>The event args object for the HealOtherPlayer event</summary>
 		public class HealOtherPlayerEventArgs : GetDataHandledEventArgs
 		{

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -149,9 +149,6 @@ namespace TShockAPI
 		[Description("Prevents you from being disabled by paint abuse detection.")]
 		public static readonly string ignorepaintdetection = "tshock.ignore.paint";
 
-		[Description("Prevents you from being reverted by no clip detection.")]
-		public static readonly string ignorenoclipdetection = "tshock.ignore.noclip";
-
 		[Description("Prevents you from being disabled by stack hack detection.")]
 		public static readonly string ignorestackhackdetection = "tshock.ignore.itemstack";
 


### PR DESCRIPTION
This removes TShock's noclip detection, prevention, and config system. It was confirmed broken in Discord by Joshwoo, and we have no intention of fixing it so that it works. A plugin that handles this would be a better way to go as a plugin developer can have a faster release cadence and better chance of mitigating exploits than TShock.

Fixes #1582.
Fixes #1592.