### PR TITLE
Fix tile square checking in Bouncer

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1786,7 +1786,7 @@ namespace TShockAPI
 			{
 				args.Player.SendTileSquare(tileX, tileY, size);
 			}
-			args.Handled = false;
+			args.Handled = true;
 			return;
 		}
 


### PR DESCRIPTION
Based on latest codes, players without build permissions can place objects like *item frame* everywhere.
tl;dr The tile square event should be handled inside bouncer.

References:
https://github.com/mistzzt/TShock/blob/85df1533d7b97db3f9fd1010ede29fe10f2cc736/TShockAPI/GetDataHandlers.cs#L1893