### PR TITLE
Don't send PlayerTeam packet twice in SetTeam

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1520,7 +1520,6 @@ namespace TShockAPI
 		{
 			Main.player[Index].team = team;
 			NetMessage.SendData((int)PacketTypes.PlayerTeam, -1, -1, NetworkText.Empty, Index);
-			NetMessage.SendData((int)PacketTypes.PlayerTeam, -1, Index, NetworkText.Empty, Index);
 		}
 
 		private DateTime LastDisableNotification = DateTime.UtcNow;


### PR DESCRIPTION
Discord discussion:
![image](https://user-images.githubusercontent.com/4050457/39327973-658e174c-49a2-11e8-9fd3-c579e593cb4b.png)
![image](https://user-images.githubusercontent.com/4050457/39328005-82a17d42-49a2-11e8-9374-93d142d5822d.png)

---
I tested this change with a plugin of mine which uses SetTeam, and it seems to work.

I don't think changelog entry is needed, because this is just an optimization, with no significant behavioural changes. Please tell me if I'm wrong.