### PR TITLE
Make Kick/BanOnMediumcoreDeath behave like their Hardcore equvivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * `Utils.GetIPv4Address()` is now `Utils.GetIPv4AddressFromHostname()`. (@hakusaro)
 * Fixed the disappearing problem when placing tile entities. (@mistzzt)
 * Removed the stat tracking system. (@hakusaro)
+* Fixed erroneous kicks and bans when using `KickOnMediumcoreDeath` and `BanOnMediumcoreDeath` options. (@DankRank)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2380,16 +2380,21 @@ namespace TShockAPI
 				}
 			}
 
-			if (args.TPlayer.difficulty == 2 && (TShock.Config.KickOnHardcoreDeath || TShock.Config.BanOnHardcoreDeath))
+			if (args.TPlayer.difficulty != 0)
 			{
-				if (TShock.Config.BanOnHardcoreDeath)
-				{
-					if (!args.Player.Ban(TShock.Config.HardcoreBanReason, false, "hardcore-death"))
+				bool mediumcore = args.TPlayer.difficulty == 1;
+				bool shouldBan = mediumcore ? TShock.Config.BanOnMediumcoreDeath : TShock.Config.BanOnHardcoreDeath;
+				bool shouldKick = mediumcore ? TShock.Config.KickOnMediumcoreDeath : TShock.Config.KickOnHardcoreDeath;
+				string banReason = mediumcore ? TShock.Config.MediumcoreBanReason : TShock.Config.HardcoreBanReason;
+				string kickReason = mediumcore ? TShock.Config.MediumcoreKickReason : TShock.Config.HardcoreKickReason;
+				string banAdminName = mediumcore ? "mediumcore-death" : "hardcore-death";
+
+				if(shouldBan) {
+					if (!args.Player.Ban(banReason, false, banAdminName))
 						args.Player.Kick("You died! Normally, you'd be banned.", true, true);
 				}
-				else
-				{
-					args.Player.Kick(TShock.Config.HardcoreKickReason, true, true, null, false);
+				else if(shouldKick) {
+					args.Player.Kick(kickReason, true, true, null, false);
 				}
 			}
 
@@ -2440,27 +2445,7 @@ namespace TShockAPI
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnx, spawny))
 				return true;
 
-			if (args.Player.InitSpawn && args.TPlayer.inventory[args.TPlayer.selectedItem].type != 50)
-			{
-				if (args.TPlayer.difficulty == 1 && (TShock.Config.KickOnMediumcoreDeath || TShock.Config.BanOnMediumcoreDeath))
-				{
-					if (args.TPlayer.selectedItem != 50)
-					{
-						if (TShock.Config.BanOnMediumcoreDeath)
-						{
-							if (!args.Player.Ban(TShock.Config.MediumcoreBanReason, false, "mediumcore-death"))
-								args.Player.Kick("You died! Normally, you'd be banned.", true, true);
-						}
-						else
-						{
-							args.Player.Kick(TShock.Config.MediumcoreKickReason, true, true, null, false);
-						}
-						return true;
-					}
-				}
-			}
-			else
-				args.Player.InitSpawn = true;
+			args.Player.InitSpawn = true;
 
 			if ((Main.ServerSideCharacter) && (args.Player.sX > 0) && (args.Player.sY > 0) && (args.TPlayer.SpawnX > 0) && ((args.TPlayer.SpawnX != args.Player.sX) && (args.TPlayer.SpawnY != args.Player.sY)))
 			{


### PR DESCRIPTION
fixes #1618

---
Should we get rid of TSPlayer.InitSpawn? It's not used anywhere else, but it's a public field.