### PR TITLE
Rename PlayerID to PlayerId in SpawnEventArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Removed the stat tracking system. (@hakusaro)
 * Fixed erroneous kicks and bans when using `KickOnMediumcoreDeath` and `BanOnMediumcoreDeath` options. (@DankRank)
 * Removed `TSPlayer.InitSpawn` field. (@DankRank)
+* `OnPlayerSpawn`'s player ID field is now `PlayerId`. (@DankRank)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -803,7 +803,7 @@ namespace TShockAPI
 			/// <summary>
 			/// The Terraria playerID of the player
 			/// </summary>
-			public byte PlayerID { get; set; }
+			public byte PlayerId { get; set; }
 			/// <summary>
 			/// X location of the player's spawn
 			/// </summary>
@@ -827,7 +827,7 @@ namespace TShockAPI
 			{
 				Player = player,
 				Data = data,
-				PlayerID = pid,
+				PlayerId = pid,
 				SpawnX = spawnX,
 				SpawnY = spawnY,
 			};


### PR DESCRIPTION
Everywhere else it's called PlayerId.

No need for changelog, since in last stable version this field was called `Player`. It's covered by this entry, I believe:
```
* All `GetDataHandlers` hooks now inherit from `GetDataHandledEventArgs` which includes a `TSPlayer` and a `MemoryStream` of raw data. (@hakusaro)
```