### PR TITLE
Allow time parser to take spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed erroneous kicks and bans when using `KickOnMediumcoreDeath` and `BanOnMediumcoreDeath` options. (@DankRank)
 * Removed `TSPlayer.InitSpawn` field. (@DankRank)
 * `OnPlayerSpawn`'s player ID field is now `PlayerId`. (@DankRank)
+* `Utils.TryParseTime` can now take spaces (e.g., `3d 5h 2m 3s`) (@QuiCM)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -534,7 +534,7 @@ namespace TShockAPI
 			var sb = new StringBuilder(3);
 			for (int i = 0; i < str.Length; i++)
 			{
-				if (Char.IsDigit(str[i]) || (str[i] == '-' || str[i] == '+'))
+				if (Char.IsDigit(str[i]) || (str[i] == '-' || str[i] == '+' || str[i] == ' '))
 					sb.Append(str[i]);
 				else
 				{


### PR DESCRIPTION
So you can pass in `10h 5m 2s` instead of `10h+5m+2s`.
Works for things like `10h +5m -2s` as well