### PR TITLE
User friendly duplicate user message when trying to /user add a user that already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * API: Added hooks for item, projectile and tile bans (@deadsurgeon42)
 * API: Changed `PlayerHooks` permission hook mechanisms to allow negation from hooks (@deadsurgeon42)
 * API: New WorldGrassSpread hook which shold allow corruption/crimson/hallow creep config options to work (@DeathCradle)
+* Fixed a missing case in UserManager exception handling, which caused a rather cryptic console error instead of the intended error message (@deadsurgeon42)
 * Fixed saving when one player is one the server and another one joins (@MarioE)
 * Fixed /spawnmob not spawning negative IDs (@MarioE)
 * Validated tile placement on PlaceObject; clients can no longer place frames, paintings etc with dirt blocks (@bartico6, @ProfessorXZ)

--- a/TShockAPI/DB/UserManager.cs
+++ b/TShockAPI/DB/UserManager.cs
@@ -76,7 +76,7 @@ namespace TShockAPI.DB
 			catch (Exception ex)
 			{
 				// Detect duplicate user using a regexp as Sqlite doesn't have well structured exceptions
-				if (Regex.IsMatch(ex.Message, "Username.*not unique"))
+				if (Regex.IsMatch(ex.Message, "Username.*not unique|UNIQUE constraint failed: Users\\.Username"))
 					throw new UserAccountExistsException(account.Name);
 				throw new UserAccountManagerException("AddUser SQL returned an error (" + ex.Message + ")", ex);
 			}


### PR DESCRIPTION
fixes #1599.

Apparently, the exception message thrown by the sql query in AddUserAccount() changed slightly, causing it to not realize the error is in fact a UserAccountExistsException and just blurt the whole exception text in the console instead.