### PR TITLE
Update Manager now uses TLS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
+* Update tracker now uses TLS (@pandabear41) 
 * API: Added return in OnNameCollision if hook has been handled. (@Patrikkk)
 * API: Added hooks for item, projectile and tile bans (@deadsurgeon42)
 * API: Changed `PlayerHooks` permission hook mechanisms to allow negation from hooks (@deadsurgeon42)

--- a/TShockAPI/UpdateManager.cs
+++ b/TShockAPI/UpdateManager.cs
@@ -33,7 +33,7 @@ namespace TShockAPI
 	/// </summary>
 	public class UpdateManager
 	{
-		private const string UpdateUrl = "http://update.tshock.co/latest/";
+		private const string UpdateUrl = "https://update.tshock.co/latest/";
 		private HttpClient _client = new HttpClient();
 
 		/// <summary>


### PR DESCRIPTION
Simple PR for Hacktoberfest.

Some things to change on your Cloudflare or I need to add code to allow the specific self-signed Cloudflare certificate. 

> * [x]  Need to configure cloudflare to use the Universal SSL cert. https://support.cloudflare.com/hc/en-us/articles/200170566-Why-isn-t-SSL-working-for-my-site- (@hakusaro)
> * [x]  Test code in Mono and .NET to see if it works or generates an HttpRequestException exception. (@pandabear41)

Solves issue #1633

