### PR TITLE
Proposed fix for #1653 - Testing required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Add NPCAddBuff data handler and bouncer (@AxeelAnder)
 * Improved config file documentation (@Enerdy)
 * Add PlayerZone data handler and bouncer (@AxeelAnder)
+* Fix banned armour checks not clearing properly (thanks @tysonstrange)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1130,6 +1130,8 @@ namespace TShockAPI
 						}
 						if (check != "none")
 							player.IsDisabledForBannedWearable = true;
+						else
+							player.IsDisabledForBannedWearable = false;
 
 						if (player.IsBeingDisabled())
 						{


### PR DESCRIPTION
From #1653:
>From latest version (2301)
If a player puts on a banned peice of armour, they get the message to say "You are wearing banned equipment"
After they take it off, the messages stop, but they keep getting disabled.
Solution:
Approx line 1131 in tShock.cs on `OnSecondUpdate` the `tsplayer.IsDisabledForBannedWearable` gets set to true, but it never gets set to false.
Change:
```csharp
if (check != "none")
player.IsDisabledForBannedWearable = true;
```
>To:
```csharp
if (check != "none")
player.IsDisabledForBannedWearable = true;
else
player.IsDisabledForBannedWearable = false;
```

Requires testing