### PR TITLE
Fix BoC false positive kick in NPCAddBuffTimeMax

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1869,7 +1869,7 @@ namespace TShockAPI
 			{ BuffID.DryadsWardDebuff, 120 },
 			{ BuffID.BetsysCurse, 600 },
 			{ BuffID.Oiled, 540 },
-			{ BuffID.Confused, 360 }, // Brain of Confusion Internal Item ID: 3223
+			{ BuffID.Confused, 450 }, // Brain of Confusion Internal Item ID: 3223
 			{ BuffID.Daybreak, 300 } // Solar Eruption Item ID: 3473, Daybreak Item ID: 3543
 		};
 		


### PR DESCRIPTION
360 ticks = 6 seconds, according to the wiki, the max possible duration is proportional to dmg taken which goes up to 7.5 when taking up to 300 dmg, so 7.5 seconds would be the max duration (aka 450 ticks)

https://terraria.gamepedia.com/Brain_of_Confusion (see the debuff equation for yourselves, extracted from the 1.3.5.3 source code)

Didn't know this was an issue until players on my server were getting bounced. They were messing around and jumping off tall buildings, which did ~300 fall damage. One of them had BoC (Brain of Confusion) equipped, so the confused debuff was likely applied for >6 seconds to a nearby mob and caused that player to be force kicked.