### PR TITLE
Publish artifacts in github for debug builds from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,17 +25,39 @@ jobs:
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\TerrariaServerAPI\TShock.4.OTAPI.sln /p:Configuration=Release
         cd .\TerrariaServerAPI\TShock.Modifications.Bootstrapper\bin\Release
         TShock.Modifications.Bootstrapper.exe
-    - name: TerrariaServerAPI
+    - name: TerrariaServerAPI Debug
+      shell: cmd
+      run: |
+        cd .\TerrariaServerAPI
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\TerrariaServerAPI\TerrariaServerAPI.csproj /p:Configuration=Debug
+    - name: TShock Debug
+      shell: cmd
+      run: |
+        nuget restore TShock.sln
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\TShockAPI\TShockAPI.csproj /p:Configuration=Debug
+    - name: TerrariaServerAPI Release
       shell: cmd
       run: |
         cd .\TerrariaServerAPI
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\TerrariaServerAPI\TerrariaServerAPI.csproj /p:Configuration=Release
-    - name: TShock
+    - name: TShock Release
       shell: cmd
       run: |
         nuget restore TShock.sln
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" .\TShockAPI\TShockAPI.csproj /p:Configuration=Release
     - uses: actions/upload-artifact@master
       with:
-        name: TShockRelease
+        name: Experimental TShock (not debug)
         path: TShockAPI\bin\Release
+    - uses: actions/upload-artifact@master
+      with:
+        name: Experimental TShock (debug)
+        path: TShockAPI\bin\Debug
+    - uses: actions/upload-artifact@master
+      with:
+        name: Experimental (debug) OTAPI Bootstrapper
+        path: .\TerrariaServerAPI\TShock.Modifications.Bootstrapper\bin\Debug\TShock.Modifications.Bootstrapper.exe
+    - uses: actions/upload-artifact@master
+      with:
+        name: Experimental (not debug) OTAPI Bootstrapper
+        path: .\TerrariaServerAPI\TShock.Modifications.Bootstrapper\bin\Release\TShock.Modifications.Bootstrapper.exe

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To download experimental versions of TShock, you have two real options: AppVeyor
 
 On [AppVeyor](https://ci.appveyor.com/project/hakusaro/tshock/), click on history, find the build you want, click on the commit message, and then click on the artifacts tab. You can download either the debug or the release build. AppVeyor only keeps builds back 6 months though.
 
-On [GitHub](https://github.com/Pryaxis/TShock/), click on the actions tab, then click on "build server" on the commit or branch you want. If it was successful, you can download "TShockRelease" under the artifacts section to get that build artifact.
+On [GitHub](https://github.com/Pryaxis/TShock/), click on the actions tab, then click on "build server" on the commit or branch you want. If it was successful, you can download either the experimental release or debug artifacts.
 
 For old builds from Travis CI, you can still get them (for now) from us directly, on [our Travis CI artifact mirror](https://travis.tshock.co/). Please note that these builds should be considered legacy and for archival purposes only. If you need them in the long term, please raise an issue explaining why before they are removed.
 


### PR DESCRIPTION
It's helpful to have debug builds available for people to download if
they need them.

Also includes the OTAPI bootstrapper, because why not?