### PR TITLE
Tile entity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming Changes
 
+## TShock 4.3.27
+* Fixed a number of bugs relating to Tile Entities (Item Frames, Target Dummies, Logic Sensors)
+
 ## TShock 4.3.26
 * Removed the stat tracking system. (@hakusaro)
 * Updated SQLite binaries. (@hakusaro)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1816,7 +1816,7 @@ namespace TShockAPI
 				{
 					foreach (Point p in player.IceTiles)
 					{
-						if (p.X == tileX && p.Y == tileY && (Main.tile[p.X, p.Y].type == 0 || Main.tile[p.X, p.Y].type == 127))
+						if (p.X == tileX && p.Y == tileY && (Main.tile[p.X, p.Y].type == 0 || Main.tile[p.X, p.Y].type == TileID.MagicalIceBlock))
 						{
 							player.IceTiles.Remove(p);
 							return false;
@@ -1831,7 +1831,7 @@ namespace TShockAPI
 					return true;
 				}
 
-				if (TShock.Config.AllowIce && actionType == GetDataHandlers.EditAction.PlaceTile && tileType == 127)
+				if (TShock.Config.AllowIce && actionType == GetDataHandlers.EditAction.PlaceTile && tileType == TileID.MagicalIceBlock)
 				{
 					player.IceTiles.Add(new Point(tileX, tileY));
 					return false;
@@ -1950,6 +1950,37 @@ namespace TShockAPI
 					}
 				}
 			}
+			return false;
+		}
+
+
+
+		/// <summary>
+		/// Determines if a player may edit all tiles of a tile object that spans multiple blocks
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="tileX"></param>
+		/// <param name="tileY"></param>
+		/// <param name="offsetX"></param>
+		/// <param name="offsetY"></param>
+		/// <param name="width"></param>
+		/// <param name="height"></param>
+		/// <returns>True if the player should not be allowed to place the tile object</returns>
+		public static bool CheckTileObjectPermission(TSPlayer player, int tileX, int tileY, int offsetX, int offsetY, int width, int height)
+		{
+			//if (newtile.Type < TileObjectData._data.Count && (tileObjectData = TileObjectData._data[newtile.Type]) != null)
+
+			for (int x = offsetX; x < offsetX + width; x++)
+			{
+				for (int y = offsetY; y < offsetY + height; y++)
+				{
+					if (CheckTilePermission(player, tileX + x, tileY + y))
+					{
+						return true;
+					}
+				}
+			}
+
 			return false;
 		}
 


### PR DESCRIPTION
This pull request resolves a number of issues, primarily surrounding item frames but also with some touches on the other Tile Entity objects.
* Item frames place properly on the first try
* Item frames return items instead of eating them 
* Objects that span multiple tiles (eg Item Frames which are a 2x2 tile) are now first class citizens for region protection. See ASCII art diagram below
* Resolves #1693 and others of its ilk

Old region protection.
Region borders marked with | & -, item frame marked with x & *
```
 |------|
*|x    x|*
*|x    x|*
 |      |
 |------|
```
In this diagram, the x tiles of the item frame were safe, however the frame itself could still be destroyed by destroying the * sections.
In the new protection, the * parts are recognized as part of the object and the region's protection is extended to them.