### PR TITLE
Move OnTileEdit ban checks: Bouncer -> Itembans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fix banned armour checks not clearing properly (thanks @tysonstrange)
 * Added warning message on invalid group comand (@hakusaro, thanks to IcyPhoenix, nuLLzy & Cy on Discord)
 * Moved item bans subsystem to isolated file/contained mini-plugin & reorganized codebase accordingly. (@hakusaro)
+* Moved bouncer checks for item bans in OnTileEdit to item bans subsystem. (@hakusaro)
 
 ## TShock 4.3.25
 * Fixed a critical exploit in the Terraria protocol that could cause massive unpreventable world corruption as well as a number of other problems. Thanks to @bartico6 for reporting. Fixed by the efforts of @QuiCM, @hakusaro, and tips in the right directioon from @bartico6.

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -297,15 +297,7 @@ namespace TShockAPI
 						return;
 					}
 
-					// Using the actuation accessory can lead to actuator hacking
-					if (TShock.Itembans.ItemIsBanned("Actuator", args.Player) && args.Player.TPlayer.autoActuator)
-					{
-						args.Player.SendTileSquare(tileX, tileY, 1);
-						args.Player.SendErrorMessage("You do not have permission to place actuators.");
-						args.Handled = true;
-						return;
-					}
-					if (TShock.Itembans.ItemIsBanned(EnglishLanguage.GetItemNameById(selectedItem.netID), args.Player) || editData >= (action == EditAction.PlaceTile ? Main.maxTileSets : Main.maxWallTypes))
+					if (editData >= (action == EditAction.PlaceTile ? Main.maxTileSets : Main.maxWallTypes))
 					{
 						args.Player.SendTileSquare(tileX, tileY, 4);
 						args.Handled = true;

--- a/TShockAPI/ItemBans.cs
+++ b/TShockAPI/ItemBans.cs
@@ -59,6 +59,7 @@ namespace TShockAPI
 			ServerApi.Hooks.GameUpdate.Register(plugin, OnGameUpdate);
 			GetDataHandlers.PlayerUpdate += OnPlayerUpdate;
 			GetDataHandlers.ChestItemChange += OnChestItemChange;
+			GetDataHandlers.TileEdit += OnTileEdit;
 		}
 
 		/// <summary>Called on the game update loop (the XNA tickrate).</summary>
@@ -190,6 +191,27 @@ namespace TShockAPI
 
 			args.Handled = false;
 			return;
+		}
+
+		internal void OnTileEdit(object sender, TileEditEventArgs args)
+		{
+			if (args.Action == EditAction.PlaceTile || args.Action == EditAction.PlaceWall)
+			{
+				if (args.Player.TPlayer.autoActuator && DataModel.ItemIsBanned("Actuator", args.Player))
+				{
+					args.Player.SendTileSquare(args.X, args.Y, 1);
+					args.Player.SendErrorMessage("You do not have permission to place actuators.");
+					args.Handled = true;
+					return;
+				}
+
+				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(args.Player.SelectedItem.netID), args.Player))
+				{
+					args.Player.SendTileSquare(args.X, args.Y, 4);
+					args.Handled = true;
+					return;
+				}
+			}
 		}
 
 		private void UnTaint(TSPlayer player)


### PR DESCRIPTION
This PR adds the bouncer checks for OnTileEdit related to item bans into the item bans subsystem.

Note: Not tested in 1.3.5.3 because I no longer have a client for this verison of the game. However, the logic is pretty straightforward and I think it's okay to merge anyway.
