### PR TITLE
Fixed getting kicked for whipping mobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # TShock for Terraria
 
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
-
+## Upcoming
+* Fixed getting kicked for hitting mobs with whips (@ndragon798)
 ## TShock 4.4.0 (Pre-release 1)
 * Added confused debuff to Bouncer for confusion applied from Brain of Confusion
 * API: Added return in OnNameCollision if hook has been handled. (@Patrikkk)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1891,7 +1891,20 @@ namespace TShockAPI
 			{ BuffID.BetsysCurse, 600 },
 			{ BuffID.Oiled, 540 },
 			{ BuffID.Confused, 450 }, // Brain of Confusion Internal Item ID: 3223
-			{ BuffID.Daybreak, 300 } // Solar Eruption Item ID: 3473, Daybreak Item ID: 3543
+			{ BuffID.Daybreak, 300 },// Solar Eruption Item ID: 3473, Daybreak Item ID: 3543
+			{ BuffID.ThornWhipNPCDebuff, 300 },
+			{ BuffID.BlandWhipEnemyDebuff, 300},
+			{ BuffID.FlameWhipEnemyDebuff, 300 },
+			{ BuffID.MaceWhipNPCDebuff, 300 },
+			{ BuffID.RainbowWhipNPCDebuff, 300 },
+			{ BuffID.ScytheWhipEnemyDebuff, 300 },
+			{ BuffID.ThornWhipNPCDebuff, 300 }
+
+
+
+
+
+
 		};
 		
 		/// <summary>


### PR DESCRIPTION
This fixes issue #1759.
Where you would get kicked for using a whip on an enemy since the debuff wasn't allowed.