### PR TITLE
Fixed Command IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 
+* Fixed worldmode command (@Ristellise)
 * Fixed NPC buff anticheat issue conflicting with Terraria gameplay changes (whips). (@Patrikkk)
 * Renamed `/bloodmoon` to `/tbloodmoon` because of conflict with Terraria reserved words. (@hakusaro)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 
-* Fixed worldmode command (@Ristellise)
+* Fixed `/worldmode` command to correctly target world mode. (@Ristellise)
 * Fixed NPC buff anticheat issue conflicting with Terraria gameplay changes (whips). (@Patrikkk)
 * Renamed `/bloodmoon` to `/tbloodmoon` because of conflict with Terraria reserved words. (@hakusaro)
 

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2145,10 +2145,10 @@ namespace TShockAPI
 
 		static Dictionary<string, int> _worldModes = new Dictionary<string, int>
 		{
-			{ "normal",    1 },
-			{ "expert",    2 },
-			{ "master",    3 },
-			{ "creative",  4 },
+			{ "normal",    0 },
+			{ "expert",    1 },
+			{ "master",    2 },
+			{ "creative",  3 },
 		};
 
 		private static void ChangeWorldMode(CommandArgs args)


### PR DESCRIPTION
`master` world mode correctly changes to `master` instead of `journey`