### PR TITLE
Missing backtick from RegionManager Group table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Update player spawn related things to 1.4. `Terraria.Player.Spawn` method now has a required argument, `PlayerSpawnContext context`. (@AxeelAnder)
 * Make sqlite db path configurable. (@AxeelAnder)
+* Make TShock database MySQL 8 compatible by backticking `Group` column name in Region table.
 
 ## TShock 4.4.0 (Pre-release 4)
 * Debug logging now provides ConsoleDebug and ILog has been updated to support the concept of debug logs. Debug logs are now controlled by `config.json` instead of by preprocessor debug flag. (@hakusaro)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Update player spawn related things to 1.4. `Terraria.Player.Spawn` method now has a required argument, `PlayerSpawnContext context`. (@AxeelAnder)
 * Make sqlite db path configurable. (@AxeelAnder)
-* Make TShock database MySQL 8 compatible by backticking `Group` column name in Region table.
+* Make TShock database MySQL 8 compatible by escaping column names in our IQueryBuilder code. (Name `Groups` is a reserved element in this version, which is used in our `Region` table.)
 
 ## TShock 4.4.0 (Pre-release 4)
 * Debug logging now provides ConsoleDebug and ILog has been updated to support the concept of debug logs. Debug logs are now controlled by `config.json` instead of by preprocessor debug flag. (@hakusaro)

--- a/TShockAPI/DB/IQueryBuilder.cs
+++ b/TShockAPI/DB/IQueryBuilder.cs
@@ -192,12 +192,12 @@ namespace TShockAPI.DB
 			var columns =
 				table.Columns.Select(
 					c =>
-					"{0} {1} {2} {3} {4} {5}".SFormat(c.Name, DbTypeToString(c.Type, c.Length),
+					"`{0}` {1} {2} {3} {4} {5}".SFormat(c.Name, DbTypeToString(c.Type, c.Length),
 												c.Primary ? "PRIMARY KEY" : "",
 												c.AutoIncrement ? "AUTO_INCREMENT" : "",
 												c.NotNull ? "NOT NULL" : "",
 												c.DefaultCurrentTimestamp ? "DEFAULT CURRENT_TIMESTAMP" : ""));
-			var uniques = table.Columns.Where(c => c.Unique).Select(c => c.Name);
+			var uniques = table.Columns.Where(c => c.Unique).Select(c => $"`{c.Name}`");
 			return "CREATE TABLE {0} ({1} {2})".SFormat(EscapeTableName(table.Name), string.Join(", ", columns),
 														uniques.Count() > 0
 															? ", UNIQUE({0})".SFormat(string.Join(", ", uniques))
@@ -299,7 +299,7 @@ namespace TShockAPI.DB
 			var create = CreateTable(to);
 			// combine all columns in the 'from' variable excluding ones that aren't in the 'to' variable.
 			// exclude the ones that aren't in 'to' variable because if the column is deleted, why try to import the data?
-			var columns = string.Join(", ", from.Columns.Where(c => to.Columns.Any(c2 => c2.Name == c.Name)).Select(c => c.Name));
+			var columns = string.Join(", ", from.Columns.Where(c => to.Columns.Any(c2 => c2.Name == c.Name)).Select(c => $"`{c.Name}`"));
 			var insert = "INSERT INTO {0} ({1}) SELECT {1} FROM {2}".SFormat(escapedTable, columns, tmpTable);
 			var drop = "DROP TABLE {0}".SFormat(tmpTable);
 			return "{0}; {1}; {2}; {3};".SFormat(alter, create, insert, drop);
@@ -396,7 +396,7 @@ namespace TShockAPI.DB
 			if (0 == wheres.Count)
 				return string.Empty;
 
-			return "WHERE {0}".SFormat(string.Join(", ", wheres.Select(v => v.Name + " = " + v.Value)));
+			return "WHERE {0}".SFormat(string.Join(", ", wheres.Select(v => $"{v.Name}" + " = " + v.Value)));
 		}
 	}
 }

--- a/TShockAPI/DB/RegionManager.cs
+++ b/TShockAPI/DB/RegionManager.cs
@@ -51,7 +51,7 @@ namespace TShockAPI.DB
 									 new SqlColumn("WorldID", MySqlDbType.VarChar, 50) { Unique = true },
 									 new SqlColumn("UserIds", MySqlDbType.Text),
 									 new SqlColumn("Protected", MySqlDbType.Int32),
-									 new SqlColumn("Groups", MySqlDbType.Text),
+									 new SqlColumn("`Groups`", MySqlDbType.Text),
 									 new SqlColumn("Owner", MySqlDbType.VarChar, 50),
 									 new SqlColumn("Z", MySqlDbType.Int32){ DefaultValue = "0" }
 				);

--- a/TShockAPI/DB/RegionManager.cs
+++ b/TShockAPI/DB/RegionManager.cs
@@ -51,7 +51,7 @@ namespace TShockAPI.DB
 									 new SqlColumn("WorldID", MySqlDbType.VarChar, 50) { Unique = true },
 									 new SqlColumn("UserIds", MySqlDbType.Text),
 									 new SqlColumn("Protected", MySqlDbType.Int32),
-									 new SqlColumn("`Groups`", MySqlDbType.Text),
+									 new SqlColumn("Groups", MySqlDbType.Text),
 									 new SqlColumn("Owner", MySqlDbType.VarChar, 50),
 									 new SqlColumn("Z", MySqlDbType.Int32){ DefaultValue = "0" }
 				);


### PR DESCRIPTION
Group is a reserved keyword in MySQL 8. Requires backtick.
Missed this from previous commit. Version 8 would error on table creation.