### PR TITLE
Remove mentions of a superadmin group during /setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Update player spawn related things to 1.4. `Terraria.Player.Spawn` method now has a required argument, `PlayerSpawnContext context`. (@AxeelAnder)
 * Make sqlite db path configurable. (@AxeelAnder)
+* Removed mentions of the superadmin group during the setup process. (@ColinBohn)
 
 ## TShock 4.4.0 (Pre-release 4)
 * Debug logging now provides ConsoleDebug and ILog has been updated to support the concept of debug logs. Debug logs are now controlled by `config.json` instead of by preprocessor debug flag. (@hakusaro)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -224,7 +224,7 @@ namespace TShockAPI
 			add(new Command(SetupToken, "setup")
 			{
 				AllowServer = false,
-				HelpText = "Used to authenticate as superadmin when first setting up TShock."
+				HelpText = "Used to authenticate yourself as owner when first setting up TShock."
 			});
 			add(new Command(Permissions.user, ManageUsers, "user")
 			{
@@ -5006,12 +5006,12 @@ namespace TShockAPI
 				}
 			}
 
-			// If the user account is already a superadmin (permanent), disable the system
+			// If the user account is already authenticated, disable the system
 			if (args.Player.IsLoggedIn && args.Player.tempGroup == null)
 			{
 				args.Player.SendSuccessMessage("Your new account has been verified, and the {0}setup system has been turned off.", Specifier);
 				args.Player.SendSuccessMessage("You can always use the {0}user command to manage players.", Specifier);
-				args.Player.SendSuccessMessage("The setup system will remain disabled as long as a superadmin exists (even if you delete setup.lock).");
+				args.Player.SendSuccessMessage("The setup system will remain disabled as long as user accounts exist (even if you delete setup.lock).");
 				args.Player.SendSuccessMessage("Share your server, talk with other admins, and more on GitHub! -- https://tshock.co/");
 				args.Player.SendSuccessMessage("Thank you for using TShock for Terraria!");
 				FileTools.CreateFile(Path.Combine(TShock.SavePath, "setup.lock"));

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -846,7 +846,7 @@ namespace TShockAPI
 
 				if (File.Exists(Path.Combine(SavePath, "setup-code.txt")))
 				{
-					Log.ConsoleInfo("A superadmin account has been detected in the user database, but setup-code.txt is still present.");
+					Log.ConsoleInfo("User accounts have been detected in the database, but setup-code.txt is still present.");
 					Log.ConsoleInfo("TShock will now disable the initial setup system and remove setup-code.txt as it is no longer needed.");
 					File.Delete(Path.Combine(SavePath, "setup-code.txt"));
 				}


### PR DESCRIPTION
Small messaging changes around the /setup command to discourage use of the superadmin group.