### PR TITLE
Fix player respawn again

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -441,12 +441,12 @@ namespace TShockAPI
 		[Description("Whether or not to log REST API connections.")]
 		public bool LogRest = false;
 
-		/// <summary>The number of seconds a player must wait before being respawned.</summary>
-		[Description("The number of seconds a player must wait before being respawned.")]
+		/// <summary>The number of seconds a player must wait before being respawned. Cannot be longer than normal value now. Use at your own risk.</summary>
+		[Description("The number of seconds a player must wait before being respawned. Cannot be longer than normal value now. Use at your own risk.")]
 		public int RespawnSeconds = 5;
 
-		/// <summary>The number of seconds a player must wait before being respawned if there is a boss nearby.</summary>
-		[Description("The number of seconds a player must wait before being respawned if there is a boss nearby.")]
+		/// <summary>The number of seconds a player must wait before being respawned if there is a boss nearby. Cannot be longer than normal value now. Use at your own risk.</summary>
+		[Description("The number of seconds a player must wait before being respawned if there is a boss nearby. Cannot be longer than normal value now. Use at your own risk.")]
 		public int RespawnBossSeconds = 10;
 
 		/// <summary>Disables a player if this number of tiles is painted within 1 second.</summary>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2065,6 +2065,10 @@ namespace TShockAPI
 
 		private static bool HandleSpawn(GetDataHandlerArgs args)
 		{
+			// Should we add a bouncer here or in Bouncer.cs to prohibit client-side reviving
+			// if (args.Player.Dead && args.Player.RespawnTimer > 0)
+			// 	return true;
+
 			byte player = args.Data.ReadInt8();
 			short spawnx = args.Data.ReadInt16();
 			short spawny = args.Data.ReadInt16();

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2065,10 +2065,6 @@ namespace TShockAPI
 
 		private static bool HandleSpawn(GetDataHandlerArgs args)
 		{
-			// Should we add a bouncer here or in Bouncer.cs to prohibit client-side reviving
-			// if (args.Player.Dead && args.Player.RespawnTimer > 0)
-			// 	return true;
-
 			byte player = args.Data.ReadInt8();
 			short spawnx = args.Data.ReadInt16();
 			short spawny = args.Data.ReadInt16();

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2065,6 +2065,11 @@ namespace TShockAPI
 
 		private static bool HandleSpawn(GetDataHandlerArgs args)
 		{
+			if (args.Player.Dead && args.Player.RespawnTimer > 0)
+			{
+				return true;
+			}
+
 			byte player = args.Data.ReadInt8();
 			short spawnx = args.Data.ReadInt16();
 			short spawny = args.Data.ReadInt16();

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1197,7 +1197,7 @@ namespace TShockAPI
 					PlayerIndex = (byte)Index,
 					TileX = (short)tilex,
 					TileY = (short)tiley,
-					RespawnTimer = respawnTimer ?? TShock.Players[Index].RespawnTimer * 60,
+					RespawnTimer = respawnTimer ?? TShock.Players[Index].TPlayer.respawnTimer,
 					PlayerSpawnContext = context,
 				};
 				msg.PackFull(ms);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -299,9 +299,10 @@ namespace TShockAPI
 		/// </summary>
 		public int RespawnTimer
 		{
-			get => TPlayer.respawnTimer;
-			set => TPlayer.respawnTimer = value;
+			get => _respawnTimer;
+			set => TPlayer.respawnTimer = (_respawnTimer = value) * 60;
 		}
+		private int _respawnTimer;
 
 		/// <summary>
 		/// Whether the player is dead or not.
@@ -1196,7 +1197,7 @@ namespace TShockAPI
 					PlayerIndex = (byte)Index,
 					TileX = (short)tilex,
 					TileY = (short)tiley,
-					RespawnTimer = respawnTimer ?? TShock.Players[Index].TPlayer.respawnTimer,
+					RespawnTimer = respawnTimer ?? TShock.Players[Index].RespawnTimer * 60,
 					PlayerSpawnContext = context,
 				};
 				msg.PackFull(ms);


### PR DESCRIPTION
Thanks to test materials provided by @hakusaro. Confirmed the desync issue has been solved.

Terraria's respawn timer's unit is frame/tick while tshock's is second. So I correct the unit.

I noticed when set respawn time longer than normal respawn time in config.json, client will send a spawn packet to revive thus our config is of no use, should we forbid this or add a permission/config or do nothing?