### PR TITLE
Fix 1849

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
+## TShock 4.4.0 (Pre-release ?)
+* Fix bed spawn issues when trying to remove spawn point in SSC (@Olink)
+
 ## TShock 4.4.0 (Pre-release 6)
 * Updates to OTAPI 2.0.0.35 (@DeathCradle).
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2079,6 +2079,13 @@ namespace TShockAPI
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnx, spawny, respawnTimer, context))
 				return true;
 
+			if ((Main.ServerSideCharacter) && (spawnx == -1 && spawny == -1)) //this means they want to spawn to vanilla spawn
+			{
+				args.Player.sX = Main.spawnTileX;
+				args.Player.sY = Main.spawnTileY;
+				args.Player.Teleport(args.Player.sX * 16, (args.Player.sY * 16) - 48);
+			}
+
 			if ((Main.ServerSideCharacter) && (args.Player.sX > 0) && (args.Player.sY > 0) && (args.TPlayer.SpawnX > 0) && ((args.TPlayer.SpawnX != args.Player.sX) && (args.TPlayer.SpawnY != args.Player.sY)))
 			{
 


### PR DESCRIPTION
It looks like the only time the client informs the server of the spawn location is via the PlayerSpawn packet.  In SSC, understandably, we don't trust any updates from the client if we can avoid it.  In this scenario, we have code in PlayerSpawn to check for beds when they attempt to spawn, but no code to handle negative spawn locations.  The client sends -1,-1 coordinates when the player has no spawn.  We should trust this.

This should fix #1849 