### PR TITLE
Fix the Snake Charmer's Flute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## TShock 4.4.0 (Pre-release ?)
 * Fix bed spawn issues when trying to remove spawn point in SSC (@Olink)
+* Fix Snake Flute (@Olink)
 
 ## TShock 4.4.0 (Pre-release 6)
 * Updates to OTAPI 2.0.0.35 (@DeathCradle).

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3360,6 +3360,7 @@ namespace TShockAPI
 			{ ProjectileID.EbonsandBallGun, TileID.Ebonsand },
 			{ ProjectileID.PearlSandBallGun, TileID.Pearlsand },
 			{ ProjectileID.CrimsandBallGun, TileID.Crimsand },
+			{ ProjectileID.MysticSnakeCoil, TileID.MysticSnakeRope }
 		};
 
 		internal static Dictionary<int, int> ropeCoilPlacements = new Dictionary<int, int>


### PR DESCRIPTION
Since the projectile creates a tile, added MysticSnakeCoil projectile to the list of projectiles that create tiles.

This should fix #1834 