### PR TITLE
Fixes 1872

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)
 * Fixed /wind command. (@AxeelAnder)
 * Fixed NPC buff bouncer. (@AxeelAnder)
-* Fixed lava, wet, and honey bombs. (@Olink)
+* Fixed lava, wet, honey bombs; and lava, wet, and honey rockets. (@Olink)
 
 ## TShock 4.4.0 (Pre-release 7 (Entangled))
 * Fixed bed spawn issues when trying to remove spawn point in SSC. (@Olink)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)
 * Fixed /wind command. (@AxeelAnder)
 * Fixed NPC buff bouncer. (@AxeelAnder)
-* Fix fluid bombs. (@Olink)
+* Fixed lava, wet, and honey bombs. (@Olink)
 
 ## TShock 4.4.0 (Pre-release 7 (Entangled))
 * Fixed bed spawn issues when trying to remove spawn point in SSC. (@Olink)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)
 * Fixed /wind command. (@AxeelAnder)
 * Fixed NPC buff bouncer. (@AxeelAnder)
+* Fix fluid bombs. (@Olink)
 
 ## TShock 4.4.0 (Pre-release 7 (Entangled))
 * Fixed bed spawn issues when trying to remove spawn point in SSC. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1307,11 +1307,11 @@ namespace TShockAPI
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
 				var keys = projectileCreatesLiquid.Where(k => k.Value == type).Select(k => k.Key);
-				var recentBombs = args.Player.RecentlyCreatedProjectiles.Where(keys.Contains(Main.projectile[p.Index].type));
-				wasThereABombNearby = recentBombs.Any(r => (args.TileX > (Main.projectile[r.Index].position.X / 16.0f) - 32
-									&& args.TileX < (Main.projectile[r.Index].position.X / 16.0f) + 32)
-									&& (args.TileY > (Main.projectile[r.Index].position.Y / 16.0f) - 32
-									&& args.TileY < (Main.projectile[r.Index].position.Y / 16.0f) + 32));
+				var recentBombs = args.Player.RecentlyCreatedProjectiles.Where(p => keys.Contains(Main.projectile[p.Index].type));
+				wasThereABombNearby = recentBombs.Any(r => (args.TileX > (Main.projectile[r.Index].position.X / 16.0f) - 16
+									&& args.TileX < (Main.projectile[r.Index].position.X / 16.0f) + 16)
+									&& (args.TileY > (Main.projectile[r.Index].position.Y / 16.0f) - 16
+									&& args.TileY < (Main.projectile[r.Index].position.Y / 16.0f) + 16));
 			}
 
 			// Liquid anti-cheat

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1295,10 +1295,10 @@ namespace TShockAPI
 			{
 				var keys = projectileCreatesLiquid.Where(k => k.Value == type).Select(k => k.Key);
 				var recentBombs = args.Player.RecentlyCreatedProjectiles.Where(p => keys.Contains(Main.projectile[p.Index].type));
-				wasThereABombNearby = recentBombs.Any(r => (args.TileX > (Main.projectile[r.Index].position.X / 16.0f) - 16
-									&& args.TileX < (Main.projectile[r.Index].position.X / 16.0f) + 16)
-									&& (args.TileY > (Main.projectile[r.Index].position.Y / 16.0f) - 16
-									&& args.TileY < (Main.projectile[r.Index].position.Y / 16.0f) + 16));
+				wasThereABombNearby = recentBombs.Any(r => (args.TileX > (Main.projectile[r.Index].position.X / 16.0f) - TShock.Config.BombExplosionRadius
+									&& args.TileX < (Main.projectile[r.Index].position.X / 16.0f) + TShock.Config.BombExplosionRadius)
+									&& (args.TileY > (Main.projectile[r.Index].position.Y / 16.0f) - TShock.Config.BombExplosionRadius
+									&& args.TileY < (Main.projectile[r.Index].position.Y / 16.0f) + TShock.Config.BombExplosionRadius));
 			}
 
 			// Liquid anti-cheat

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1303,7 +1303,7 @@ namespace TShockAPI
 			}
 
 			bool wasThereABombNearby = false;
-
+// The +/- 16 is compensation for maximum detonation distance, but it might be possible to drop to 5 and be conservative
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
 				var keys = projectileCreatesLiquid.Where(k => k.Value == type).Select(k => k.Key);

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -527,7 +527,7 @@ namespace TShockAPI
 		[Description("Whether or not the server should output debug level messages related to system operation.")]
 		public bool DebugLogs = false;
 
-		[Description("Determines the range in tiles that a bomb can affect tiles.")]
+		[Description("Determines the range in tiles that a bomb can affect tiles from detonation point.")]
 		public int BombExplosionRadius = 5;
 
 		/// <summary>

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -527,6 +527,9 @@ namespace TShockAPI
 		[Description("Whether or not the server should output debug level messages related to system operation.")]
 		public bool DebugLogs = false;
 
+		[Description("Determines the range in tiles that a bomb can affect tiles.")]
+		public int BombExplosionRadius = 5;
+
 		/// <summary>
 		/// Reads a configuration file from a given path
 		/// </summary>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2322,6 +2322,18 @@ namespace TShockAPI
 			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player))
 				return true;
 
+			if (projectileCreatesLiquid.ContainsKey(type))
+			{
+				lock (args.Player.RecentlyCreatedProjectiles)
+				{
+					args.Player.RecentlyCreatedProjectiles.Add(new ProjectileStruct()
+					{
+						Index = ident,
+						CreatedAt = DateTime.Now
+					});
+				}
+			}
+
 			return false;
 		}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3465,8 +3465,11 @@ namespace TShockAPI
 		internal static Dictionary<int, LiquidType> projectileCreatesLiquid = new Dictionary<int, LiquidType>
 		{
 			{ProjectileID.LavaBomb, LiquidType.Lava},
+			{ProjectileID.LavaRocket, LiquidType.Lava },
 			{ProjectileID.WetBomb, LiquidType.Water},
-			{ProjectileID.HoneyBomb, LiquidType.Honey}
+			{ProjectileID.WetRocket, LiquidType.Water },
+			{ProjectileID.HoneyBomb, LiquidType.Honey},
+			{ProjectileID.HoneyRocket, LiquidType.Honey }
 		};
 
 		internal static Dictionary<int, int> ropeCoilPlacements = new Dictionary<int, int>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2386,6 +2386,10 @@ namespace TShockAPI
 			}
 
 			args.Player.LastKilledProjectile = type;
+			lock (args.Player.RecentlyCreatedProjectiles)
+			{
+				args.Player.RecentlyCreatedProjectiles.ForEach(s => { if (s.Index == index) { s.Killed = true; } });
+			}
 
 			return false;
 		}
@@ -3446,6 +3450,13 @@ namespace TShockAPI
 			{ ProjectileID.MysticSnakeCoil, TileID.MysticSnakeRope }
 		};
 
+		internal static Dictionary<int, LiquidType> projectileCreatesLiquid = new Dictionary<int, LiquidType>
+		{
+			{ProjectileID.LavaBomb, LiquidType.Lava},
+			{ProjectileID.WetBomb, LiquidType.Water},
+			{ProjectileID.HoneyBomb, LiquidType.Honey}
+		};
+
 		internal static Dictionary<int, int> ropeCoilPlacements = new Dictionary<int, int>
 		{
 			{ItemID.RopeCoil, TileID.Rope},
@@ -3461,5 +3472,12 @@ namespace TShockAPI
 		{
 			{TileID.MinecartTrack, 3}
 		};
+
+		internal struct ProjectileStruct
+		{
+			public int Index { get; set; }
+			public DateTime CreatedAt { get; set; }
+			public bool Killed { get; internal set; }
+		}
 	}
 }

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -765,6 +765,12 @@ namespace TShockAPI
 		public int LastKilledProjectile = 0;
 
 		/// <summary>
+		/// Keeps track of recently created projectiles by this player.  TShock.cs OnSecondUpdate() removes from this in an async task.
+		/// Projectiles older than 5 seconds are purged from this collection as they are no longer "recent".
+		/// </summary>
+		internal List<TShockAPI.GetDataHandlers.ProjectileStruct> RecentlyCreatedProjectiles = new List<TShockAPI.GetDataHandlers.ProjectileStruct>();
+
+		/// <summary>
 		/// The current region this player is in, or null if none.
 		/// </summary>
 		public Region CurrentRegion = null;

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -765,8 +765,8 @@ namespace TShockAPI
 		public int LastKilledProjectile = 0;
 
 		/// <summary>
-		/// Keeps track of recently created projectiles by this player.  TShock.cs OnSecondUpdate() removes from this in an async task.
-		/// Projectiles older than 5 seconds are purged from this collection as they are no longer "recent".
+		/// Keeps track of recently created projectiles by this player. TShock.cs OnSecondUpdate() removes from this in an async task.
+		/// Projectiles older than 5 seconds are purged from this collection as they are no longer "recent."
 		/// </summary>
 		internal List<TShockAPI.GetDataHandlers.ProjectileStruct> RecentlyCreatedProjectiles = new List<TShockAPI.GetDataHandlers.ProjectileStruct>();
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -44,7 +44,6 @@ using Microsoft.Xna.Framework;
 using TShockAPI.Sockets;
 using TShockAPI.CLI;
 using TShockAPI.Localization;
-using System.Threading.Tasks;
 
 namespace TShockAPI
 {
@@ -1065,19 +1064,9 @@ namespace TShockAPI
 						}
 					}
 				}
-
-				Task.Run(() =>
-				{
-					if (player != null && player.TPlayer.whoAmI >= 0)
-					{
-						var threshold = DateTime.Now.AddSeconds(-5);
-						lock (player.RecentlyCreatedProjectiles)
-						{
-							player.RecentlyCreatedProjectiles = player.RecentlyCreatedProjectiles.Where(s => s.CreatedAt > threshold).ToList();
-						}
-					}
-				});
 			}
+
+			Bouncer.OnSecondUpdate();
 			Utils.SetConsoleTitle(false);
 		}
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -44,6 +44,7 @@ using Microsoft.Xna.Framework;
 using TShockAPI.Sockets;
 using TShockAPI.CLI;
 using TShockAPI.Localization;
+using System.Threading.Tasks;
 
 namespace TShockAPI
 {
@@ -1064,6 +1065,18 @@ namespace TShockAPI
 						}
 					}
 				}
+
+				Task.Run(() =>
+				{
+					if (player != null && player.TPlayer.whoAmI >= 0)
+					{
+						var threshold = DateTime.Now.AddSeconds(-5);
+						lock (player.RecentlyCreatedProjectiles)
+						{
+							player.RecentlyCreatedProjectiles = player.RecentlyCreatedProjectiles.Where(s => s.CreatedAt > threshold).ToList();
+						}
+					}
+				});
 			}
 			Utils.SetConsoleTitle(false);
 		}


### PR DESCRIPTION
In order to track fluid bombs/rockets, we now track all recently created projectiles that we track for fluid creation.  If a bomb exists near where fluid is being created, we allow it.

Fixes #1872
Fixes #1884
Fixes #1885
Fixes #1886
Fixes #1888
Fixes #1889
Fixes #1893