### PR TITLE
Journeymode permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   and lava, wet, honey, and dry grenades; 
   and lava, wet, honey, and dry rockets; 
   and lava, wet, honey, and dry mines. (@Olink)
+* Adding Journey mode user account permissions. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 7 (Entangled))
 * Fixed bed spawn issues when trying to remove spawn point in SSC. (@Olink)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3107,6 +3107,130 @@ namespace TShockAPI
 
 		private static bool HandleLoadNetModule(GetDataHandlerArgs args)
 		{
+			short moduleId = args.Data.ReadInt16();
+			if (moduleId == 6) // Power module.
+			{
+				short powerId = args.Data.ReadInt16();
+				switch (powerId)
+				{
+					case 0:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_timefreeze))
+							{
+								args.Player.SendErrorMessage("You have no permission to freeze the time of the server!");
+								return true;
+							}
+							break;
+						}
+					case 1:
+					case 2:
+					case 3:
+					case 4:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_timeset))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the time of the server!");
+								return true;
+							}
+							break;
+						}
+					case 5:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_godmode))
+							{
+								args.Player.SendErrorMessage("You have no permission to toggle godmode!");
+								return true;
+							}
+							break;
+						}
+					case 6:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_windstrength))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the wind strength of the server!");
+								return true;
+							}
+							break;
+						}
+					case 7:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_rainstrength))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the rain strength of the server!");
+								return true;
+							}
+							break;
+						}
+					case 8:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_timespeed))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the time speed of the server!");
+								return true;
+							}
+							break;
+						}
+					case 9:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_rainfreeze))
+							{
+								args.Player.SendErrorMessage("You have no permission to freeze the rain strength of the server!");
+								return true;
+							}
+							break;
+						}
+					case 10:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_windfreeze))
+							{
+								args.Player.SendErrorMessage("You have no permission to freeze the wind strength of the server!");
+								return true;
+							}
+							break;
+						}
+					case 11:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_placementrange))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the tile placement range of your character!");
+								return true;
+							}
+							break;
+						}
+					case 12:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_setdifficulty))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the world dificulty of the server!");
+								return true;
+							}
+							break;
+						}
+					case 13:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_biomespreadfreeze))
+							{
+								args.Player.SendErrorMessage("You have no permission to freeze the biome spread of server!");
+								return true;
+							}
+							break;
+						}
+					case 14:
+						{
+							if (!args.Player.HasPermission(Permissions.journey_setspawnrate))
+							{
+								args.Player.SendErrorMessage("You have no permission to modify the NPC spawn rate of server!");
+								return true;
+							}
+							break;
+						}
+					default:
+						{
+							return true;
+						}
+				}
+			}
+
 			// As of 1.4.x.x, this is now used for more things:
 			//	NetCreativePowersModule
 			//	NetCreativePowerPermissionsModule

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3108,12 +3108,12 @@ namespace TShockAPI
 		private static bool HandleLoadNetModule(GetDataHandlerArgs args)
 		{
 			short moduleId = args.Data.ReadInt16();
-			if (moduleId == 6) // Power module.
+			if (moduleId == (int)NetModulesTypes.CreativePowers)
 			{
-				short powerId = args.Data.ReadInt16();
+				CreativePowerTypes powerId = (CreativePowerTypes)args.Data.ReadInt16();
 				switch (powerId)
 				{
-					case 0:
+					case CreativePowerTypes.FreezeTime:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_timefreeze))
 							{
@@ -3122,10 +3122,10 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 1:
-					case 2:
-					case 3:
-					case 4:
+					case CreativePowerTypes.SetDawn:
+					case CreativePowerTypes.SetNoon:
+					case CreativePowerTypes.SetDusk:
+					case CreativePowerTypes.SetMidnight:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_timeset))
 							{
@@ -3134,7 +3134,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 5:
+					case CreativePowerTypes.Godmode:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_godmode))
 							{
@@ -3143,7 +3143,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 6:
+					case CreativePowerTypes.WindStrength:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_windstrength))
 							{
@@ -3152,7 +3152,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 7:
+					case CreativePowerTypes.RainStrength:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_rainstrength))
 							{
@@ -3161,7 +3161,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 8:
+					case CreativePowerTypes.TimeSpeed:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_timespeed))
 							{
@@ -3170,7 +3170,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 9:
+					case CreativePowerTypes.RainFreeze:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_rainfreeze))
 							{
@@ -3179,7 +3179,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 10:
+					case CreativePowerTypes.WindFreeze:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_windfreeze))
 							{
@@ -3188,7 +3188,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 11:
+					case CreativePowerTypes.IncreasePlacementRange:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_placementrange))
 							{
@@ -3197,7 +3197,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 12:
+					case CreativePowerTypes.WorldDifficulty:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_setdifficulty))
 							{
@@ -3206,7 +3206,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 13:
+					case CreativePowerTypes.BiomeSpreadFreeze:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_biomespreadfreeze))
 							{
@@ -3215,7 +3215,7 @@ namespace TShockAPI
 							}
 							break;
 						}
-					case 14:
+					case CreativePowerTypes.SetSpawnRate:
 						{
 							if (!args.Player.HasPermission(Permissions.journey_setspawnrate))
 							{
@@ -3638,6 +3638,40 @@ namespace TShockAPI
 			public int Index { get; set; }
 			public DateTime CreatedAt { get; set; }
 			public bool Killed { get; internal set; }
+		}
+
+		public enum NetModulesTypes
+		{
+			Liquid,
+			Text,
+			Ping,
+			Ambience,
+			Bestiary,
+			CreativeUnlocks,
+			CreativePowers,
+			CreativeUnlocksPlayerReport,
+			TeleportPylon,
+			Particles,
+			CreativePowerPermissions
+		}
+
+		public enum CreativePowerTypes
+		{
+			FreezeTime,
+			SetDawn,
+			SetNoon,
+			SetDusk,
+			SetMidnight,
+			Godmode,
+			WindStrength,
+			RainStrength,
+			TimeSpeed,
+			RainFreeze,
+			WindFreeze,
+			IncreasePlacementRange,
+			WorldDifficulty,
+			BiomeSpreadFreeze,
+			SetSpawnRate
 		}
 	}
 }

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -408,7 +408,7 @@ namespace TShockAPI
 		public static readonly string journey_biomespreadfreeze = "tshock.journey.biomespreadfreeze";
 
 		[Description("User can use Creative UI to set the NPC spawn rate of the world.")]
-		public static readonly string journey_setdawn = "tshock.journey.setspawnrate";
+		public static readonly string journey_setspawnrate = "tshock.journey.setspawnrate";
 		#endregion
 
 		#region Non-grouped
@@ -513,7 +513,5 @@ namespace TShockAPI
 
 			File.WriteAllText("PermissionsDescriptions.txt", sb.ToString());
 		}
-
-		public static void FromJourneyModePermission(string tshockPermission)
 	}
 }

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -31,8 +31,7 @@ namespace TShockAPI
 	/// <summary>Contains the permission nodes used in TShock.</summary>
 	public static class Permissions
 	{
-		// tshock.account nodes
-
+		#region tshock.account nodes
 		[Description("User can register account in game.")]
 		public static readonly string canregister = "tshock.account.register";
 
@@ -44,9 +43,9 @@ namespace TShockAPI
 
 		[Description("User can change password in game.")]
 		public static readonly string canchangepassword = "tshock.account.changepassword";
+		#endregion
 
-		// tshock.admin nodes
-
+		#region tshock.admin nodes
 		[Description("User can set build protection status.")]
 		public static readonly string antibuild = "tshock.admin.antibuild";
 
@@ -106,17 +105,17 @@ namespace TShockAPI
 
 		[Description("User can get other users' info.")]
 		public static readonly string userinfo = "tshock.admin.userinfo";
+		#endregion
 
-		// tshock.buff nodes
-
+		#region tshock.buff nodes
 		[Description("User can buff self.")]
 		public static readonly string buff = "tshock.buff.self";
 
 		[Description("User can buff other players.")]
 		public static readonly string buffplayer = "tshock.buff.others";
+		#endregion
 
-		// tshock.cfg nodes
-
+		#region tshock.cfg nodes
 		[Description("User is notified when an update is available, user can turn off / restart the server.")]
 		public static readonly string maintenance = "tshock.cfg.maintenance";
 
@@ -131,9 +130,9 @@ namespace TShockAPI
 
 		[Description("User can create reference files of Terraria IDs and the permission matrix in the server folder.")]
 		public static readonly string createdumps = "tshock.cfg.createdumps";
+		#endregion
 
-		// tshock.ignore nodes
-
+		#region tshock.ignore nodes
 		[Description("Prevents you from being reverted by kill tile abuse detection.")]
 		public static readonly string ignorekilltiledetection = "tshock.ignore.removetile";
 
@@ -169,9 +168,9 @@ namespace TShockAPI
 
 		[Description("Prevents you from being disabled by abnormal MP.")]
 		public static readonly string ignoremp = "tshock.ignore.mp";
+		#endregion
 
-		// tshock.item nodes
-
+		#region tshock.item nodes
 		[Description("User can give items.")]
 		public static readonly string give = "tshock.item.give";
 
@@ -180,9 +179,9 @@ namespace TShockAPI
 
 		[Description("Allows you to use banned items.")]
 		public static readonly string usebanneditem = "tshock.item.usebanned";
+		#endregion
 
-		// tshock.npc nodes
-
+		#region tshock.npc nodes
 		[Description("User can edit the max spawns.")]
 		public static readonly string maxspawns = "tshock.npc.maxspawns";
 
@@ -227,9 +226,9 @@ namespace TShockAPI
 
 		[Description("Allows a user to elevate to superadmin for 10 minutes.")]
 		public static readonly string su = "tshock.su";
+		#endregion
 
-		// tshock.tp nodes
-
+		#region tshock.tp nodes
 		[Description("User can teleport *everyone* to them.")]
 		public static readonly string tpallothers = "tshock.tp.allothers";
 
@@ -268,9 +267,9 @@ namespace TShockAPI
 
 		[Description("User can use wormhole potions.")]
 		public static readonly string wormhole = "tshock.tp.wormhole";
+		#endregion
 
-		// tshock.world nodes
-
+		#region tshock.world nodes
 		[Description("User can use the 'worldevent' command")]
 		public static readonly string manageevents = "tshock.world.events";
 
@@ -372,9 +371,9 @@ namespace TShockAPI
 
 		[Description("Player can toggle party event.")]
 		public static readonly string toggleparty = "tshock.world.toggleparty";
+		#endregion
 
-		// Non-grouped
-
+		#region Non-grouped
 		[Description("User can clear items or projectiles.")]
 		public static readonly string clear = "tshock.clear";
 
@@ -428,7 +427,7 @@ namespace TShockAPI
 
 		[Description("Player can see advanced information about any user account.")]
 		public static readonly string advaccountinfo = "tshock.accountinfo.details";
-
+		#endregion
 		/// <summary>
 		/// Lists all commands associated with a given permission
 		/// </summary>

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -373,6 +373,44 @@ namespace TShockAPI
 		public static readonly string toggleparty = "tshock.world.toggleparty";
 		#endregion
 
+		#region tshock.journey nodes
+		[Description("User can use Creative UI freeze time.")]
+		public static readonly string journey_timefreeze = "tshock.journey.time.freeze";
+
+		[Description("User can use Creative UI to set world time.")]
+		public static readonly string journey_timeset = "tshock.journey.time.set";
+
+		[Description("User can use Creative UI to set world time speed.")]
+		public static readonly string journey_timespeed = "tshock.journey.time.setspeed";
+
+		[Description("User can use Creative UI to to toggle character godmode.")]
+		public static readonly string journey_godmode = "tshock.journey.godmode";
+
+		[Description("User can use Creative UI to set world wind strength/seed.")]
+		public static readonly string journey_windstrength = "tshock.journey.wind.strength";
+
+		[Description("User can use Creative UI to stop the world wind strength from changing.")]
+		public static readonly string journey_windfreeze = "tshock.journey.wind.freeze";
+
+		[Description("User can use Creative UI to set world rain strength/seed.")]
+		public static readonly string journey_rainstrength = "tshock.journey.rain.strength";
+
+		[Description("User can use Creative UI to stop the world rain strength from changing.")]
+		public static readonly string journey_rainfreeze = "tshock.journey.rain.freeze";
+
+		[Description("User can use Creative UI to toggle increased placement range.")]
+		public static readonly string journey_placementrange = "tshock.journey.placementrange";
+
+		[Description("User can use Creative UI to set world difficulty/mode.")]
+		public static readonly string journey_setdifficulty = "tshock.journey.setdifficulty";
+
+		[Description("User can use Creative UI to stop the biome spread of the world.")]
+		public static readonly string journey_biomespreadfreeze = "tshock.journey.biomespreadfreeze";
+
+		[Description("User can use Creative UI to set the NPC spawn rate of the world.")]
+		public static readonly string journey_setdawn = "tshock.journey.setspawnrate";
+		#endregion
+
 		#region Non-grouped
 		[Description("User can clear items or projectiles.")]
 		public static readonly string clear = "tshock.clear";
@@ -475,5 +513,7 @@ namespace TShockAPI
 
 			File.WriteAllText("PermissionsDescriptions.txt", sb.ToString());
 		}
+
+		public static void FromJourneyModePermission(string tshockPermission)
 	}
 }


### PR DESCRIPTION
This is the proper way to tie TShock permissions to Journey mode creative powers.
I tried a different approach before this, where I use the vanilla permissions that are sent from server to client to limit their creative power usage.
This did not work for unknown reasons. The difference between the two approaches would have been that the first failed approach would not have been able to display messages to the player, as the block is happening in the client (buttons would not react at all unlike in this approach). And for this reason, it would have been an insecure approach, as client mods could have overwritten those client-sided permissions.
And yes... I over analyzed this simple implementation.  😅 

Please give me feedback with permission names and descriptions.