### PR TITLE
Implement FoodPlatter placing event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * This change was implemented by (@QuiCM, @hakusaro).
 * Fixed kick on hardcore death / kick on mediumcore death / ban on either from taking action against journey mode players. (@hakusaro)
 * Attempted to fix the problem with the magic mirror spawn problems. You should be able to remove your spawn point in SSC by right clicking on a bed now. (@hakusaro, @AxeelAnder)
+* Add HandleFoodPlatterTryPlacing event, which is called whenever a player places a food in a plate. Add antihack to bouncer, to prevent removing food from plates if the region is protected; To prevent placement if they are not in range; To prevent placement if the item is not placed from player hand. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -67,6 +67,7 @@ namespace TShockAPI
 			GetDataHandlers.MassWireOperation += OnMassWireOperation;
 			GetDataHandlers.PlayerDamage += OnPlayerDamage;
 			GetDataHandlers.KillMe += OnKillMe;
+			GetDataHandlers.FoodPlatterTryPlacing += OnFoodPlatterTryPlacing;
 		}
 
 		internal void OnGetSection(object sender, GetDataHandlers.GetSectionEventArgs args)
@@ -2059,6 +2060,54 @@ namespace TShockAPI
 					args.Handled = true;
 					return;
 				}
+			}
+		}
+
+		/// <summary>
+		/// Called when a player is trying to place an item into a food plate.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		internal void OnFoodPlatterTryPlacing(object sender, GetDataHandlers.FoodPlatterTryPlacingEventArgs args)
+		{
+			if (args.Player.ItemInHand.type != args.ItemID)
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected item not placed by hand from {0}", args.Player.Name);
+				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
+				args.Handled = true;
+				return;
+			}
+			if (args.Player.IsBeingDisabled())
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected disabled from {0}", args.Player.Name);
+				Item item = new Item();
+				item.netDefaults(args.ItemID);
+				args.Player.GiveItemCheck(args.ItemID, item.Name, args.Stack, args.Prefix);
+				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
+				args.Handled = true;
+				return;
+			}
+
+			if (!args.Player.HasBuildPermission(args.TileX, args.TileY))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected permissions from {0}", args.Player.Name);
+				Item item = new Item();
+				item.netDefaults(args.ItemID);
+				args.Player.GiveItemCheck(args.ItemID, item.Name, args.Stack, args.Prefix);
+				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
+				args.Handled = true;
+				return;
+			}
+
+			if (!args.Player.IsInRange(args.TileX, args.TileY))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected range checks from {0}", args.Player.Name);
+				Item item = new Item();
+				item.netDefaults(args.ItemID);
+				args.Player.GiveItemCheck(args.ItemID, item.Name, args.Stack, args.Prefix);
+				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
+				args.Handled = true;
+				return;
 			}
 		}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -150,7 +150,8 @@ namespace TShockAPI
 					{ PacketTypes.ToggleParty, HandleToggleParty },
 					{ PacketTypes.CrystalInvasionStart, HandleOldOnesArmy },
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
-					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 }
+					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
+					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing }
 				};
 		}
 
@@ -1863,6 +1864,52 @@ namespace TShockAPI
 			return args.Handled;
 		}
 
+		public class FoodPlatterTryPlacingEventArgs : GetDataHandledEventArgs
+		{
+			/// <summary>
+			/// The X tile position of the placement action.
+			/// </summary>
+			public short TileX { get; set; }
+			/// <summary>
+			/// The Y tile position of the placement action.
+			/// </summary>
+			public short TileY { get; set; }
+			/// <summary>
+			/// The Item ID that is being placed in the plate.
+			/// </summary>
+			public short ItemID { get; set; }
+			/// <summary>
+			/// The prefix of the item that is being placed in the plate.
+			/// </summary>
+			public byte Prefix { get; set; }
+			/// <summary>
+			/// The stack of the item that is being placed in the plate.
+			/// </summary>
+			public short Stack { get; set; }
+		}
+		/// <summary>
+		/// Called when a player is placing an item in a food plate.
+		/// </summary>
+		public static HandlerList<FoodPlatterTryPlacingEventArgs> FoodPlatterTryPlacing = new HandlerList<FoodPlatterTryPlacingEventArgs>();
+		private static bool OnFoodPlatterTryPlacing(TSPlayer player, MemoryStream data, short tileX, short tileY, short itemID, byte prefix, short stack)
+		{
+			if (FoodPlatterTryPlacing == null)
+				return false;
+
+			var args = new FoodPlatterTryPlacingEventArgs
+			{
+				Player = player,
+				Data = data,
+				TileX = tileX,
+				TileY = tileY,
+				ItemID = itemID,
+				Prefix = prefix,
+				Stack = stack,
+			};
+			FoodPlatterTryPlacing.Invoke(null, args);
+			return args.Handled;
+		}
+
 		#endregion
 
 		private static bool HandlePlayerInfo(GetDataHandlerArgs args)
@@ -3559,7 +3606,19 @@ namespace TShockAPI
 
 			return false;
 		}
+		private static bool HandleFoodPlatterTryPlacing(GetDataHandlerArgs args)
+		{
+			short tileX = args.Data.ReadInt16();
+			short tileY = args.Data.ReadInt16();
+			short itemID = args.Data.ReadInt16();
+			byte prefix = args.Data.ReadInt8();
+			short stack = args.Data.ReadInt16();
 
+			if (OnFoodPlatterTryPlacing(args.Player, args.Data, tileX, tileY, itemID, prefix, stack))
+				return true;
+
+			return false;
+		}
 
 		public enum EditAction
 		{

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -31,7 +31,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\Debug\ServerPlugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -31,7 +31,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Debug\ServerPlugins\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
This is called when a player is placing a fruit (item) in a plate.
Adding checks to see if they have permission to place or replace food in the plate.
Checks if they are within range. And a check to see if they are legitimately placing the item from their hand, and not by sending a raw packet.

This PR does not fix the current issue, where removing food from a plate does not occur in item drop.