### PR TITLE
Adding additional FoodPlatter event check. Modifying range check.

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2070,7 +2070,7 @@ namespace TShockAPI
 		/// <param name="args"></param>
 		internal void OnFoodPlatterTryPlacing(object sender, GetDataHandlers.FoodPlatterTryPlacingEventArgs args)
 		{
-			if (args.Player.ItemInHand.type != args.ItemID)
+			if ((args.Player.SelectedItem.type != args.ItemID && args.Player.ItemInHand.type != args.ItemID))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected item not placed by hand from {0}", args.Player.Name);
 				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
@@ -2099,12 +2099,9 @@ namespace TShockAPI
 				return;
 			}
 
-			if (!args.Player.IsInRange(args.TileX, args.TileY))
+			if (!args.Player.IsInRange(args.TileX, args.TileY, range: 10)) // To my knowledge, max legit tile reach with accessories.
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected range checks from {0}", args.Player.Name);
-				Item item = new Item();
-				item.netDefaults(args.ItemID);
-				args.Player.GiveItemCheck(args.ItemID, item.Name, args.Stack, args.Prefix);
 				args.Player.SendTileSquare(args.TileX, args.TileY, 1);
 				args.Handled = true;
 				return;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2099,7 +2099,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (!args.Player.IsInRange(args.TileX, args.TileY, range: 10)) // To my knowledge, max legit tile reach with accessories.
+			if (!args.Player.IsInRange(args.TileX, args.TileY, range: 13)) // To my knowledge, max legit tile reach with accessories.
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected range checks from {0}", args.Player.Name);
 				args.Player.SendTileSquare(args.TileX, args.TileY, 1);


### PR DESCRIPTION
There are two ways to place food into a plate. One is by having it in hand (mouse) and right-clicking, the other is by having the item selected in the... "inventory bar"(?) and right-clicking the plate.

Tested range, if the player is outside the range, they should not get their item back.