### PR TITLE
Fishoutnpc event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed kick on hardcore death / kick on mediumcore death / ban on either from taking action against journey mode players. (@hakusaro)
 * Attempted to fix the problem with the magic mirror spawn problems. You should be able to remove your spawn point in SSC by right clicking on a bed now. (@hakusaro, @AxeelAnder)
 * Add HandleFoodPlatterTryPlacing event, which is called whenever a player places a food in a plate. Add antihack to bouncer, to prevent removing food from plates if the region is protected; To prevent placement if they are not in range; To prevent placement if the item is not placed from player hand. (@Patrikkk)
+* Add FishOutNPC event handler, which is called whenever a player fishes out an NPC using a fishing rod. Added antihack to Bouncer, to prevent unathorized and invalid mob spawning, by checking player action, NPC IDs and range. (@Patrikkk, @moisterrific)
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -67,6 +67,7 @@ namespace TShockAPI
 			GetDataHandlers.MassWireOperation += OnMassWireOperation;
 			GetDataHandlers.PlayerDamage += OnPlayerDamage;
 			GetDataHandlers.KillMe += OnKillMe;
+			GetDataHandlers.FishOutNPC += OnFishOutNPC;
 			GetDataHandlers.FoodPlatterTryPlacing += OnFoodPlatterTryPlacing;
 		}
 
@@ -2060,6 +2061,41 @@ namespace TShockAPI
 					args.Handled = true;
 					return;
 				}
+			}
+		}
+
+		/// <summary>
+		/// Called when the player fishes out an NPC.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
+		{
+			Projectile projectile = null;
+			foreach (var recentProjectile in args.Player.RecentlyCreatedProjectiles)
+			{
+				if (Main.projectile[recentProjectile.Index] != null && Main.projectile[recentProjectile.Index].Name == "Bobber")
+				{
+					projectile = Main.projectile[recentProjectile.Index];
+					break;
+				}
+			}
+			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type) || projectile == null || !FishableNpcIDs.Contains(args.NpcID))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected invalid NPC spawning from {0}", args.Player.Name);
+				args.Handled = true;
+				return;
+			}
+			if (args.NpcID == NPCID.DukeFishron && !args.Player.HasPermission(Permissions.summonboss))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected summon boss permissions from {0}", args.Player.Name);
+				args.Handled = true;
+				return;
+			}
+			if (args.Player.IsInRange(args.TileX, args.TileY, 55))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected range checks from {0}", args.Player.Name);
+				args.Handled = true;
 			}
 		}
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2071,16 +2071,9 @@ namespace TShockAPI
 		/// <param name="args"></param>
 		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
 		{
-			Projectile projectile = null;
-			foreach (var recentProjectile in args.Player.RecentlyCreatedProjectiles)
-			{
-				if (Main.projectile[recentProjectile.Index] != null && Main.projectile[recentProjectile.Index].Name == "Bobber")
-				{
-					projectile = Main.projectile[recentProjectile.Index];
-					break;
-				}
-			}
-			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type) || projectile == null || !FishableNpcIDs.Contains(args.NpcID))
+			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index] != null && Main.projectile[p.Index].Name == "Bobber");
+
+			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type) || Main.projectile[projectile.Index] == null || !FishableNpcIDs.Contains(args.NpcID))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected invalid NPC spawning from {0}", args.Player.Name);
 				args.Handled = true;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2082,13 +2082,13 @@ namespace TShockAPI
 			}
 			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type) || projectile == null || !FishableNpcIDs.Contains(args.NpcID))
 			{
-				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected invalid NPC spawning from {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected invalid NPC spawning from {0}", args.Player.Name);
 				args.Handled = true;
 				return;
 			}
 			if (args.NpcID == NPCID.DukeFishron && !args.Player.HasPermission(Permissions.summonboss))
 			{
-				TShock.Log.ConsoleDebug("Bouncer / OnFoodPlatterTryPlacing rejected summon boss permissions from {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected summon boss permissions from {0}", args.Player.Name);
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -151,6 +151,7 @@ namespace TShockAPI
 					{ PacketTypes.CrystalInvasionStart, HandleOldOnesArmy },
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
 					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
+					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
 					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing }
 				};
 		}
@@ -1861,6 +1862,45 @@ namespace TShockAPI
 				PlayerDeathReason = playerDeathReason,
 			};
 			KillMe.Invoke(null, args);
+			return args.Handled;
+		}
+
+		/// <summary>
+		/// For use in a FishOutNPC event.
+		/// </summary>
+		public class FishOutNPCEventArgs : GetDataHandledEventArgs
+		{
+			/// <summary>
+			/// The X world position of the spawning NPC.
+			/// </summary>
+			public ushort TileX { get; set; }
+			/// <summary>
+			/// The Y world position of the spawning NPC.
+			/// </summary>
+			public ushort TileY { get; set; }
+			/// <summary>
+			/// The NPC type that is being spawned.
+			/// </summary>
+			public short NpcID { get; set; }
+		}
+		/// <summary>
+		/// Called when a player fishes out an NPC.
+		/// </summary>
+		public static HandlerList<FishOutNPCEventArgs> FishOutNPC = new HandlerList<FishOutNPCEventArgs>();
+		private static bool OnFishOutNPC(TSPlayer player, MemoryStream data, ushort tileX, ushort tileY, short npcID)
+		{
+			if (FoodPlatterTryPlacing == null)
+				return false;
+
+			var args = new FishOutNPCEventArgs
+			{
+				Player = player,
+				Data = data,
+				TileX = tileX,
+				TileY = tileY,
+				NpcID = npcID
+			};
+			FishOutNPC.Invoke(null, args);
 			return args.Handled;
 		}
 
@@ -3606,6 +3646,19 @@ namespace TShockAPI
 
 			return false;
 		}
+
+		private static bool HandleFishOutNPC(GetDataHandlerArgs args)
+		{
+			ushort tileX = args.Data.ReadUInt16();
+			ushort tileY = args.Data.ReadUInt16();
+			short npcType = args.Data.ReadInt16();
+
+			if (OnFishOutNPC(args.Player, args.Data, tileX, tileY, npcType))
+				return true;
+
+			return false;
+		}
+
 		private static bool HandleFoodPlatterTryPlacing(GetDataHandlerArgs args)
 		{
 			short tileX = args.Data.ReadInt16();
@@ -3677,6 +3730,39 @@ namespace TShockAPI
 			TileID.Torches,
 			TileID.WaterCandle,
 			TileID.Womannequin,
+		};
+
+		/// <summary>
+		/// List of Fishing rod item IDs.
+		/// </summary>
+		internal static readonly List<int> FishingRodItemIDs = new List<int>()
+		{
+			ItemID.WoodFishingPole,
+			ItemID.ReinforcedFishingPole,
+			ItemID.FiberglassFishingPole,
+			ItemID.FisherofSouls,
+			ItemID.GoldenFishingRod,
+			ItemID.MechanicsRod,
+			ItemID.SittingDucksFishingRod,
+			ItemID.Fleshcatcher,
+			ItemID.HotlineFishingHook,
+			ItemID.BloodFishingRod,
+			ItemID.ScarabFishingRod
+		};
+
+		/// <summary>
+		/// List of NPC IDs that can be fished out by the player.
+		/// </summary>
+		internal static readonly List<int> FishableNpcIDs = new List<int>()
+		{
+			NPCID.EyeballFlyingFish,
+			NPCID.ZombieMerman,
+			NPCID.GoblinShark,
+			NPCID.BloodEelHead,
+			NPCID.BloodEelBody,
+			NPCID.BloodEelTail,
+			NPCID.BloodNautilus,
+			NPCID.DukeFishron
 		};
 
 		/// <summary>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1889,7 +1889,7 @@ namespace TShockAPI
 		public static HandlerList<FishOutNPCEventArgs> FishOutNPC = new HandlerList<FishOutNPCEventArgs>();
 		private static bool OnFishOutNPC(TSPlayer player, MemoryStream data, ushort tileX, ushort tileY, short npcID)
 		{
-			if (FoodPlatterTryPlacing == null)
+			if (FishOutNPC == null)
 				return false;
 
 			var args = new FishOutNPCEventArgs


### PR DESCRIPTION
Add FishOutNPC event handler, which is called whenever a player fishes out an NPC using a fishing rod. Added anti-hack to Bouncer, to prevent unauthorized and invalid mob spawning, by checking player action, NPC IDs and range.