### PR TITLE
Fixes some bugs with reading tiles via NetTile & SendTileSquare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed kick on hardcore death / kick on mediumcore death / ban on either from taking action against journey mode players. (@hakusaro)
 * Attempted to fix the problem with the magic mirror spawn problems. You should be able to remove your spawn point in SSC by right clicking on a bed now. (@hakusaro, @AxeelAnder)
 * Add HandleFoodPlatterTryPlacing event, which is called whenever a player places a food in a plate. Add antihack to bouncer, to prevent removing food from plates if the region is protected; To prevent placement if they are not in range; To prevent placement if the item is not placed from player hand. (@Patrikkk)
+* Fixed an offset error in NetTile that impacted SendTileSquare
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2316,6 +2316,14 @@ namespace TShockAPI
 		{
 			var player = args.Player;
 			var size = args.Data.ReadInt16();
+			
+			var changeType = TileChangeType.None;
+			bool hasChangeType = ((size & 0x7FFF) & 0x8000) != 0;
+			if (hasChangeType)
+			{
+				changeType = (TileChangeType)args.Data.ReadInt8();
+			}
+			
 			var tileX = args.Data.ReadInt16();
 			var tileY = args.Data.ReadInt16();
 			var data = args.Data;

--- a/TShockAPI/Net/NetTile.cs
+++ b/TShockAPI/Net/NetTile.cs
@@ -30,7 +30,7 @@ namespace TShockAPI.Net
 		public short FrameX { get; set; }
 		public short FrameY { get; set; }
 		public bool Lighted { get; set; }
-		public byte Wall { get; set; }
+		public ushort Wall { get; set; }
 		public byte Liquid { get; set; }
 		public byte LiquidType { get; set; }
 		public bool Wire { get; set; }
@@ -175,7 +175,7 @@ namespace TShockAPI.Net
 			}
 
 			if (HasWall)
-				stream.WriteInt8(Wall);
+				stream.WriteInt16((short)Wall);;
 
 			if (HasLiquid)
 			{
@@ -218,7 +218,7 @@ namespace TShockAPI.Net
 
 			if (flags[2])
 			{
-				Wall = stream.ReadInt8();
+				Wall = stream.ReadUInt16();
 			}
 
 			if (flags[3])


### PR DESCRIPTION
Tile.wall got updated to a ushort, but we're still reading it as a byte. This causes STS to receive junk data