### PR TITLE
Update GetDataHandlers ExtraValue packet handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Attempted to fix the problem with the magic mirror spawn problems. You should be able to remove your spawn point in SSC by right clicking on a bed now. (@hakusaro, @AxeelAnder)
 * Added HandleFoodPlatterTryPlacing event, which is called whenever a player places a food in a plate. Add antihack to bouncer, to prevent removing food from plates if the region is protected; To prevent placement if they are not in range; To prevent placement if the item is not placed from player hand. (@Patrikkk)
 * Fixed an offset error in NetTile that impacted `SendTileSquare`. It was being read as a `byte` and not a `ushort`. (@QuiCM)
+* Fixed coins not dropping after being picked up by npcs.  The ExtraValue packet was not being read correctly. (@Olink)
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Attempted to fix the problem with the magic mirror spawn problems. You should be able to remove your spawn point in SSC by right clicking on a bed now. (@hakusaro, @AxeelAnder)
 * Added HandleFoodPlatterTryPlacing event, which is called whenever a player places a food in a plate. Add antihack to bouncer, to prevent removing food from plates if the region is protected; To prevent placement if they are not in range; To prevent placement if the item is not placed from player hand. (@Patrikkk)
 * Fixed an offset error in NetTile that impacted `SendTileSquare`. It was being read as a `byte` and not a `ushort`. (@QuiCM)
-* Fixed coins not dropping after being picked up by npcs.  The ExtraValue packet was not being read correctly. (@Olink)
+* Fixed coins not dropping after being picked up by npcs. The ExtraValue packet was not being read correctly. (@Olink)
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -151,7 +151,8 @@ namespace TShockAPI
 					{ PacketTypes.CrystalInvasionStart, HandleOldOnesArmy },
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
 					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
-					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing }
+					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
+					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker }
 				};
 		}
 
@@ -3383,24 +3384,38 @@ namespace TShockAPI
 		private static bool HandleSyncExtraValue(GetDataHandlerArgs args)
 		{
 			var npcIndex = args.Data.ReadInt16();
-			var extraValue = args.Data.ReadSingle();
+			var extraValue = args.Data.ReadInt32();
 			var position = new Vector2(args.Data.ReadSingle(), args.Data.ReadSingle());
 
-			if (position.X < 0 || position.X >= Main.maxTilesX || position.Y < 0 || position.Y >= Main.maxTilesY)
+			if (position.X < 0 || position.X >= (Main.maxTilesX * 16.0f) || position.Y < 0 || position.Y >= (Main.maxTilesY * 16.0f))
 			{
 				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected extents check {0}", args.Player.Name);
 				return true;
 			}
 
-			if (!Main.expertMode)
+			if (!Main.expertMode && !Main.masterMode)
 			{
-				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected expert mode check {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected expert/master mode check {0}", args.Player.Name);
 				return true;
 			}
 
-			if (!args.Player.IsInRange((int)position.X, (int)position.Y))
+			if (npcIndex < 0 || npcIndex >= Main.npc.Length)
 			{
-				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected range check {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected npc id out of bounds check - NPC ID: {0}", npcIndex);
+				return true;
+			}
+
+			var npc = Main.npc[npcIndex];
+			if (npc == null)
+			{
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected npc is null - NPC ID: {0}", npcIndex);
+				return true;
+			}
+
+			var distanceFromCoinPacketToNpc = Utils.Distance(position, npc.position);
+			if (distanceFromCoinPacketToNpc >= (5*16f)) //5 tile range
+			{
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSyncExtraValue rejected range check {0},{1} vs {2},{3} which is {4}", npc.position.X, npc.position.Y, position.X, position.Y, distanceFromCoinPacketToNpc);
 				return true;
 			}
 
@@ -3624,6 +3639,21 @@ namespace TShockAPI
 
 			if (OnFoodPlatterTryPlacing(args.Player, args.Data, tileX, tileY, itemID, prefix, stack))
 				return true;
+
+			return false;
+		}
+
+		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
+		{
+			int uniqueID = args.Data.ReadInt32();
+			Vector2 location = args.Data.ReadVector2();
+			int netId = args.Data.ReadInt32();
+			float npcHpPercent = args.Data.ReadSingle();
+			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
+			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
+			int coinsValue = args.Data.ReadInt32();
+			float baseValue = args.Data.ReadSingle();
+			bool spawnedFromStatus = args.Data.ReadBoolean();
 
 			return false;
 		}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1635,7 +1635,8 @@ namespace TShockAPI
 					e.Handled = true;
 					return;
 				}
-			} else if (e.MsgId == PacketTypes.ProjectileNew)
+			}
+			else if (e.MsgId == PacketTypes.ProjectileNew)
 			{
 				if (e.number >= 0 && e.number < Main.projectile.Length)
 				{
@@ -1660,7 +1661,6 @@ namespace TShockAPI
 						}
 					}
 				}
-
 			}
 		}
 


### PR DESCRIPTION
Update GetDataHandlers ExtraValue packet handling to match the network protocol.

Update the validation logic to be accurate:
  * use pixels and not tiles
  * allow master mode
  * use npc position and not player position
  
Cleanup some style inconsistencies in NetHooks_SendData.
Also added GDH for the SyncRevengeMarker packet.

Fixes #1864.