### PR TITLE
Fix doors in the lamest way possible (!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * The default group that gets this permission is `Guest` for the time being.
   * To add this command to your guest group, give them `tshock.synclocalarea`, with `/group addperm guest tshock.synclocalarea`.
   * This command may be removed at any time in the future (and will likely be removed when send tile square handling is fixed).
+* Fixed smart door automatic door desync and deletion issue. (@hakusaro)
 
 ## TShock 4.4.0 (Pre-release 8)
 * Update for OTAPI 2.0.0.36 and Terraria 1.4.0.4. (@hakusaro, @Patrikkk, @DeathCradle)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -560,6 +560,7 @@ namespace TShockAPI
 
 			bool changed = false;
 			bool failed = false;
+			bool doorRelated = false;
 			try
 			{
 				var tiles = new NetTile[size, size];
@@ -589,6 +590,11 @@ namespace TShockAPI
 							!args.Player.IsInRange(realx, realy))
 						{
 							continue;
+						}
+
+						if (newtile.Active && Terraria.ID.TileID.Sets.RoomNeeds.CountsAsDoor.Contains(newtile.Type))
+						{
+							doorRelated = true;
 						}
 
 						// Fixes the Flower Boots not creating flowers issue
@@ -704,7 +710,8 @@ namespace TShockAPI
 				}
 				else
 				{
-					args.Player.SendTileSquare(tileX, tileY, size);
+					if (!doorRelated)
+						args.Player.SendTileSquare(tileX, tileY, size);
 				}
 			}
 			catch


### PR DESCRIPTION
Fixes #1774.

This commit is designed to fix the clientside door desync issue. Based
on the order of events that I've been able to see, the way that door
opening works is like this:

1. Client sends a door open request.
2. Server echoes request back to client.
3. Both server and client simulate door opening.
4. The client that requests the initial door open sends a tile square to
the server for some reason.

In TShock, under all circumstances, we send a tile square back to the
client that sends one in, unless you have the
`tshock.ignore.sendtilesquare` permission. Therefore, this deviates from
Terraria behavior where a tile square is broadcast to all other players.
Rather, the tile square is sent back to the player who requested it.

This does not really solve the underlying problem or answer the question
as to why sending a tile square back to the client seems to throw it
off, but it does. I was not able to replicate the desync issue anymore
with this branch. I expect that it will be safe to keep, because the
improved logic will only happen if the tile square had no effective
changes in addition to the door changes.

Video: https://files.catbox.moe/67rp9k.mov