### PR TITLE
Add door debug visualizer to Bouncer

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -526,6 +526,88 @@ namespace TShockAPI
 			int tileX = args.TileX;
 			int tileY = args.TileY;
 
+			int startX = tileX;
+			int startY = tileY;
+
+			var tiles = new NetTile[size, size];
+			for (int x = 0; x < size; x++)
+			{
+				for (int y = 0; y < size; y++)
+				{
+					tiles[x, y] = new NetTile(args.Data);
+				}
+			}
+
+			if (TShock.Config.DebugLogs)
+			{
+				char pad = '0';
+				for (int y = 0; y < size; y++)
+				{
+					int realY = y + startY;
+					for (int x = 0; x < size; x++)
+					{
+						int realX = x + startX;
+						ushort type = Main.tile[realX, realY].type;
+						string type2;
+						switch (type)
+						{
+							case 10:
+								type2 = "[X]";
+								break;
+							case 11:
+								type2 = "[ ]";
+								break;
+							default:
+								type2 = type.ToString();
+								break;
+						}
+						Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
+					}
+					Console.Write(" -> ");
+					for (int x = 0; x < size; x++)
+					{
+						int realX = x + startX;
+						if (tiles[x, y].Active)
+						{
+							ushort type = tiles[x, y].Type;
+							string type2;
+							switch (type)
+							{
+								case 10:
+									type2 = "{X}";
+									break;
+								case 11:
+									type2 = "{ }";
+									break;
+								default:
+									type2 = type.ToString();
+									break;
+							}
+							Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
+						}
+						else
+						{
+							ushort type = Main.tile[realX, realY].type;
+							string type2;
+							switch (type)
+							{
+								case 10:
+									type2 = "[X]";
+									break;
+								case 11:
+									type2 = "[ ]";
+									break;
+								default:
+									type2 = type.ToString();
+									break;
+							}
+							Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
+						}
+					}
+					Console.Write("\n");
+				}
+			}
+
 			if (args.Player.HasPermission(Permissions.allowclientsideworldedit))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / SendTileSquare accepted clientside world edit from {0}", args.Player.Name);
@@ -562,15 +644,6 @@ namespace TShockAPI
 			bool failed = false;
 			try
 			{
-				var tiles = new NetTile[size, size];
-				for (int x = 0; x < size; x++)
-				{
-					for (int y = 0; y < size; y++)
-					{
-						tiles[x, y] = new NetTile(args.Data);
-					}
-				}
-
 				for (int x = 0; x < size; x++)
 				{
 					int realx = tileX + x;
@@ -707,9 +780,11 @@ namespace TShockAPI
 					args.Player.SendTileSquare(tileX, tileY, size);
 				}
 			}
-			catch
+			catch(Exception e)
 			{
 				args.Player.SendTileSquare(tileX, tileY, size);
+				Console.WriteLine(e.Message);
+				Console.WriteLine(e.StackTrace);
 				failed = true;
 			}
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -548,19 +548,7 @@ namespace TShockAPI
 					{
 						int realX = x + startX;
 						ushort type = Main.tile[realX, realY].type;
-						string type2;
-						switch (type)
-						{
-							case 10:
-								type2 = "[X]";
-								break;
-							case 11:
-								type2 = "[ ]";
-								break;
-							default:
-								type2 = type.ToString();
-								break;
-						}
+						string type2 = type.ToString();
 						Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
 					}
 					Console.Write(" -> ");
@@ -570,37 +558,13 @@ namespace TShockAPI
 						if (tiles[x, y].Active)
 						{
 							ushort type = tiles[x, y].Type;
-							string type2;
-							switch (type)
-							{
-								case 10:
-									type2 = "{X}";
-									break;
-								case 11:
-									type2 = "{ }";
-									break;
-								default:
-									type2 = type.ToString();
-									break;
-							}
+							string type2 = type.ToString();
 							Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
 						}
 						else
 						{
 							ushort type = Main.tile[realX, realY].type;
-							string type2;
-							switch (type)
-							{
-								case 10:
-									type2 = "[X]";
-									break;
-								case 11:
-									type2 = "[ ]";
-									break;
-								default:
-									type2 = type.ToString();
-									break;
-							}
+							string type2 = type.ToString();
 							Console.Write((type2.ToString()).PadLeft(3, pad) + " ");
 						}
 					}


### PR DESCRIPTION
This is my own take on a STS debug visualizer. It pads and prints things
nicely so that it looks like the game representation and might be
helpful for other people. Obviously this is like very low priority, but
I wanted to save it off in the event that someone other than me likes
it.

It looks like this:
![Screen Shot 0002-05-31 at 00 00 24](https://user-images.githubusercontent.com/532647/83346501-c9756500-a2d1-11ea-94c5-2716d7e6870f.png)

It shows the current server state as well as the new server state after the change and highlights doors as open spaces with curly braces indicating that the door is "active."