### PR TITLE
Projectilestruct addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * `tshock.journey.biomespreadfreeze`
   * `tshock.journey.setspawnrate`
 * Changed default thresholds for some changes in the config file to accommodate new items & changes to Terraria. (@hakusaro)
+* Store projectile type in `ProjectileStruct RecentlyCreatedProjectiles` to identify the recently created projectiles by type. Make `RecentlyCreatedProjectiles` and `ProjectileStruct` public for developers to access from plugins.
 
 ## TShock 4.4.0 (Pre-release 7 (Entangled))
 * Fixed bed spawn issues when trying to remove spawn point in SSC. (@Olink)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2398,6 +2398,7 @@ namespace TShockAPI
 					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 					{
 						Index = index,
+						Type = type,
 						CreatedAt = DateTime.Now
 					});
 				}
@@ -3770,9 +3771,10 @@ namespace TShockAPI
 			{TileID.MinecartTrack, 3}
 		};
 
-		internal struct ProjectileStruct
+		public struct ProjectileStruct
 		{
 			public int Index { get; set; }
+			public short Type { get; set; }
 			public DateTime CreatedAt { get; set; }
 			public bool Killed { get; internal set; }
 		}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3770,12 +3770,27 @@ namespace TShockAPI
 		{
 			{TileID.MinecartTrack, 3}
 		};
-
+		
+		/// <summary>
+		/// Contains brief information about a projectile
+		/// </summary>
 		public struct ProjectileStruct
 		{
+			/// <summary>
+			/// Index inside Main.projectile
+			/// </summary>
 			public int Index { get; set; }
+			/// <summary>
+			/// Projectile's type ID
+			/// </summary>
 			public short Type { get; set; }
+			/// <summary>
+			/// Time at which the projectile was created
+			/// </summary>
 			public DateTime CreatedAt { get; set; }
+			/// <summary>
+			/// Whether or not the projectile has been killed
+			/// </summary>
 			public bool Killed { get; internal set; }
 		}
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -768,7 +768,7 @@ namespace TShockAPI
 		/// Keeps track of recently created projectiles by this player. TShock.cs OnSecondUpdate() removes from this in an async task.
 		/// Projectiles older than 5 seconds are purged from this collection as they are no longer "recent."
 		/// </summary>
-		internal List<TShockAPI.GetDataHandlers.ProjectileStruct> RecentlyCreatedProjectiles = new List<TShockAPI.GetDataHandlers.ProjectileStruct>();
+		public List<TShockAPI.GetDataHandlers.ProjectileStruct> RecentlyCreatedProjectiles = new List<TShockAPI.GetDataHandlers.ProjectileStruct>();
 
 		/// <summary>
 		/// The current region this player is in, or null if none.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1653,6 +1653,7 @@ namespace TShockAPI
 								player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 								{
 									Index = e.number,
+									Type = (short)projectile.type,
 									CreatedAt = DateTime.Now
 								});
 							}


### PR DESCRIPTION
Can we store the type of recent projectile as well? This could be used in my upcoming PR regarding the golf packet where I check for recently created projectiles, and their types. Having only the index is not useful in this scenario, because the projectile can already be killed, so cannot access the Main.projectile array to get the projectile type.

Can this be public instead of internal? Developers could make good use of it, instead of having to implement their own version of RecentProjectiles in their plugins.