### PR TITLE
Handlegolfpacket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed placement issues with Item Frames, Teleportation Pylons, etc. (@QuiCM)
 * Doors are good now for real probably (@QuiCM, @Hakusaro, @Olink)
 * Bump default max damage received cap to 42,000 to accommodate the Empress of Light's instant kill death amount. (@hakusaro, @moisterrific, @Irethia, @Ayrawei)
+* Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 9)
 * Fixed pet licenses. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -37,6 +37,7 @@ namespace TShockAPI
 	internal sealed class Bouncer
 	{
 		internal Handlers.SendTileSquareHandler STSHandler { get; set; }
+		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; set; }
 
 		/// <summary>Constructor call initializes Bouncer and related functionality.</summary>
 		/// <returns>A new Bouncer.</returns>
@@ -44,6 +45,9 @@ namespace TShockAPI
 		{
 			STSHandler = new Handlers.SendTileSquareHandler();
 			GetDataHandlers.SendTileSquare += STSHandler.OnReceiveSendTileSquare;
+
+			LandGolfBallInCupHandler = new Handlers.LandGolfBallInCupHandler();
+			GetDataHandlers.LandGolfBallInCup += LandGolfBallInCupHandler.OnLandGolfBallInCup;
 
 			// Setup hooks
 			GetDataHandlers.GetSection += OnGetSection;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -52,7 +52,7 @@ namespace TShockAPI
 			GetDataHandlers.ReadNetModule += NetModuleHandler.OnReceive;
 
 			EmojiHandler = new Handlers.EmojiHandler();
-			GetDataHandlers.Emoji += EmojiHandler.OnReceiveEmoji;
+			GetDataHandlers.Emoji += EmojiHandler.OnReceive;
       
 			LandGolfBallInCupHandler = new Handlers.LandGolfBallInCupHandler();
 			GetDataHandlers.LandGolfBallInCup += LandGolfBallInCupHandler.OnLandGolfBallInCup;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -151,9 +151,9 @@ namespace TShockAPI
 					{ PacketTypes.CrystalInvasionStart, HandleOldOnesArmy },
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
 					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
+					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker },
 					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
-					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
-					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker }
+					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing }
 				};
 		}
 
@@ -3671,6 +3671,21 @@ namespace TShockAPI
 			return false;
 		}
 
+		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
+		{
+			int uniqueID = args.Data.ReadInt32();
+			Vector2 location = args.Data.ReadVector2();
+			int netId = args.Data.ReadInt32();
+			float npcHpPercent = args.Data.ReadSingle();
+			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
+			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
+			int coinsValue = args.Data.ReadInt32();
+			float baseValue = args.Data.ReadSingle();
+			bool spawnedFromStatus = args.Data.ReadBoolean();
+
+			return false;
+		}
+
 		private static bool HandleFishOutNPC(GetDataHandlerArgs args)
 		{
 			ushort tileX = args.Data.ReadUInt16();
@@ -3693,21 +3708,6 @@ namespace TShockAPI
 
 			if (OnFoodPlatterTryPlacing(args.Player, args.Data, tileX, tileY, itemID, prefix, stack))
 				return true;
-
-			return false;
-		}
-
-		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
-		{
-			int uniqueID = args.Data.ReadInt32();
-			Vector2 location = args.Data.ReadVector2();
-			int netId = args.Data.ReadInt32();
-			float npcHpPercent = args.Data.ReadSingle();
-			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
-			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
-			int coinsValue = args.Data.ReadInt32();
-			float baseValue = args.Data.ReadSingle();
-			bool spawnedFromStatus = args.Data.ReadBoolean();
 
 			return false;
 		}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3669,21 +3669,6 @@ namespace TShockAPI
 			return false;
 		}
 
-		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
-		{
-			int uniqueID = args.Data.ReadInt32();
-			Vector2 location = args.Data.ReadVector2();
-			int netId = args.Data.ReadInt32();
-			float npcHpPercent = args.Data.ReadSingle();
-			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
-			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
-			int coinsValue = args.Data.ReadInt32();
-			float baseValue = args.Data.ReadSingle();
-			bool spawnedFromStatus = args.Data.ReadBoolean();
-
-			return false;
-		}
-
 		private static bool HandleLandGolfBallInCup(GetDataHandlerArgs args)
 		{
 			byte playerIndex = args.Data.ReadInt8();

--- a/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
+++ b/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ID;
+
+namespace TShockAPI.Handlers
+{
+	/// <summary>
+	/// Handles client side exploits of LandGolfBallInCup packet.
+	/// </summary>
+	public class LandGolfBallInCupHandler
+	{
+		/// <summary>
+		/// List of golf ball projectile IDs.
+		/// </summary>
+		public static readonly List<int> GolfBallProjectileIDs = new List<int>()
+		{
+			ProjectileID.DirtGolfBall,
+			ProjectileID.GolfBallDyedBlack,
+			ProjectileID.GolfBallDyedBlue,
+			ProjectileID.GolfBallDyedBrown,
+			ProjectileID.GolfBallDyedCyan,
+			ProjectileID.GolfBallDyedGreen,
+			ProjectileID.GolfBallDyedLimeGreen,
+			ProjectileID.GolfBallDyedOrange,
+			ProjectileID.GolfBallDyedPink,
+			ProjectileID.GolfBallDyedPurple,
+			ProjectileID.GolfBallDyedRed,
+			ProjectileID.GolfBallDyedSkyBlue,
+			ProjectileID.GolfBallDyedTeal,
+			ProjectileID.GolfBallDyedViolet,
+			ProjectileID.GolfBallDyedYellow
+		};
+
+		/// <summary>
+		/// List of golf club item IDs
+		/// </summary>
+		public static readonly List<int> GolfClubItemIDs = new List<int>()
+		{
+			ItemID.GolfClubChlorophyteDriver,
+			ItemID.GolfClubDiamondWedge,
+			ItemID.GolfClubShroomitePutter,
+			ItemID.Fake_BambooChest,
+			ItemID.GolfClubTitaniumIron,
+			ItemID.GolfClubGoldWedge,
+			ItemID.GolfClubLeadPutter,
+			ItemID.GolfClubMythrilIron,
+			ItemID.GolfClubWoodDriver,
+			ItemID.GolfClubBronzeWedge,
+			ItemID.GolfClubRustyPutter,
+			ItemID.GolfClubStoneIron,
+			ItemID.GolfClubPearlwoodDriver,
+			ItemID.GolfClubIron,
+			ItemID.GolfClubDriver,
+			ItemID.GolfClubWedge,
+			ItemID.GolfClubPutter
+		};
+
+		/// <summary>
+		/// Invoked when a player lands a golf ball in a cup.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void OnLandGolfBallInCup(object sender, GetDataHandlers.LandGolfBallInCupEventArgs args)
+		{
+			if (args.PlayerIndex != args.Player.Index)
+			{
+				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Packet is spoofing to be player ID {args.PlayerIndex}! - From [{args.Player.Index}]{args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+
+			if (args.TileX > Main.maxTilesX || args.TileX < 0
+			   || args.TileY > Main.maxTilesY || args.TileY < 0)
+			{
+				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: X and Y position is out of world bounds! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+
+			if (!Main.tile[args.TileX, args.TileY].active() && Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
+			{
+				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Tile at packet position X:{args.TileX} Y:{args.TileY} is not a golf hole! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+
+			if (!GolfBallProjectileIDs.Contains(args.ProjectileType))
+			{
+				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Invalid golf ball projectile ID {args.ProjectileType}! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+
+			var usedGolfBall = args.Player.RecentlyCreatedProjectiles.Any(e => GolfBallProjectileIDs.Contains(e.Type));
+			var usedGolfClub = args.Player.RecentlyCreatedProjectiles.Any(e => e.Type == ProjectileID.GolfClubHelper);
+			if (!usedGolfClub && !usedGolfBall)
+			{
+				TShock.Log.ConsoleError($"GolfPacketHandler: Player did not have create a golf club projectile the last 5 seconds! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+
+			if (!GolfClubItemIDs.Contains(args.Player.SelectedItem.type))
+			{
+				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Item selected is not a golf club! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+		}
+	}
+}

--- a/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
+++ b/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
@@ -68,7 +68,7 @@ namespace TShockAPI.Handlers
 		{
 			if (args.PlayerIndex != args.Player.Index)
 			{
-				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Packet is spoofing to be player ID {args.PlayerIndex}! - From [{args.Player.Index}]{args.Player.Name}");
+				TShock.Log.ConsoleDebug($"LandGolfBallInCupHandler: Packet rejected for ID spoofing. Expected {args.PlayerIndex} , received {args.PlayerIndex} from {args.Player.Name}.");
 				args.Handled = true;
 				return;
 			}
@@ -76,21 +76,21 @@ namespace TShockAPI.Handlers
 			if (args.TileX > Main.maxTilesX || args.TileX < 0
 			   || args.TileY > Main.maxTilesY || args.TileY < 0)
 			{
-				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: X and Y position is out of world bounds! - From {args.Player.Name}");
+				TShock.Log.ConsoleDebug($"LandGolfBallInCupHandler: X and Y position is out of world bounds! - From {args.Player.Name}");
 				args.Handled = true;
 				return;
 			}
 
 			if (!Main.tile[args.TileX, args.TileY].active() && Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
 			{
-				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Tile at packet position X:{args.TileX} Y:{args.TileY} is not a golf hole! - From {args.Player.Name}");
+				TShock.Log.ConsoleDebug($"LandGolfBallInCupHandler: Tile at packet position X:{args.TileX} Y:{args.TileY} is not a golf hole! - From {args.Player.Name}");
 				args.Handled = true;
 				return;
 			}
 
 			if (!GolfBallProjectileIDs.Contains(args.ProjectileType))
 			{
-				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Invalid golf ball projectile ID {args.ProjectileType}! - From {args.Player.Name}");
+				TShock.Log.ConsoleDebug($"LandGolfBallInCupHandler: Invalid golf ball projectile ID {args.ProjectileType}! - From {args.Player.Name}");
 				args.Handled = true;
 				return;
 			}
@@ -99,14 +99,14 @@ namespace TShockAPI.Handlers
 			var usedGolfClub = args.Player.RecentlyCreatedProjectiles.Any(e => e.Type == ProjectileID.GolfClubHelper);
 			if (!usedGolfClub && !usedGolfBall)
 			{
-				TShock.Log.ConsoleError($"GolfPacketHandler: Player did not have create a golf club projectile the last 5 seconds! - From {args.Player.Name}");
+				TShock.Log.ConsoleDebug($"GolfPacketHandler: Player did not have create a golf club projectile the last 5 seconds! - From {args.Player.Name}");
 				args.Handled = true;
 				return;
 			}
 
 			if (!GolfClubItemIDs.Contains(args.Player.SelectedItem.type))
 			{
-				TShock.Log.ConsoleError($"LandGolfBallInCupHandler: Item selected is not a golf club! - From {args.Player.Name}");
+				TShock.Log.ConsoleDebug($"LandGolfBallInCupHandler: Item selected is not a golf club! - From {args.Player.Name}");
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -88,6 +88,7 @@
     <Compile Include="DB\ResearchDatastore.cs" />
     <Compile Include="DB\TileManager.cs" />
     <Compile Include="Extensions\ExceptionExt.cs" />
+    <Compile Include="Handlers\LandGolfBallInCupHandler.cs" />
     <Compile Include="Handlers\SendTileSquareHandler.cs" />
     <Compile Include="Hooks\AccountHooks.cs" />
     <Compile Include="Hooks\GeneralHooks.cs" />


### PR DESCRIPTION
Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. 