### PR TITLE
Add HandleSyncCavernMonsterType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
-* Your change goes here!
+* Handling SyncCavernMonsterType packet to prevent an exploit where players could modify the server's cavern monster types and make the server spawn any NPCs - including bosses - onto other players.
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -151,9 +151,10 @@ namespace TShockAPI
 					{ PacketTypes.CrystalInvasionStart, HandleOldOnesArmy },
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
 					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
+					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker },
 					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
 					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
-					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker }
+					{ PacketTypes.SyncCavernMonsterType, HandleSyncCavernMonsterType }
 				};
 		}
 
@@ -3671,6 +3672,21 @@ namespace TShockAPI
 			return false;
 		}
 
+		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
+		{
+			int uniqueID = args.Data.ReadInt32();
+			Vector2 location = args.Data.ReadVector2();
+			int netId = args.Data.ReadInt32();
+			float npcHpPercent = args.Data.ReadSingle();
+			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
+			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
+			int coinsValue = args.Data.ReadInt32();
+			float baseValue = args.Data.ReadSingle();
+			bool spawnedFromStatus = args.Data.ReadBoolean();
+
+			return false;
+		}
+
 		private static bool HandleFishOutNPC(GetDataHandlerArgs args)
 		{
 			ushort tileX = args.Data.ReadUInt16();
@@ -3697,19 +3713,10 @@ namespace TShockAPI
 			return false;
 		}
 
-		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
+		private static bool HandleSyncCavernMonsterType(GetDataHandlerArgs args)
 		{
-			int uniqueID = args.Data.ReadInt32();
-			Vector2 location = args.Data.ReadVector2();
-			int netId = args.Data.ReadInt32();
-			float npcHpPercent = args.Data.ReadSingle();
-			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
-			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
-			int coinsValue = args.Data.ReadInt32();
-			float baseValue = args.Data.ReadSingle();
-			bool spawnedFromStatus = args.Data.ReadBoolean();
-
-			return false;
+			TShock.Log.ConsoleDebug($"HandleSyncCavernMonsterType: Player is trying to modify NPC cavernMonsterType; this is a crafted packet! - From {args.Player.Name}");
+			return true;
 		}
 
 		public enum EditAction

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -152,7 +152,7 @@ namespace TShockAPI
 					{ PacketTypes.PlayerHurtV2, HandlePlayerDamageV2 },
 					{ PacketTypes.PlayerDeathV2, HandlePlayerKillMeV2 },
 					{ PacketTypes.Emoji, HandleEmoji },
-          { PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker },
+					{ PacketTypes.SyncRevengeMarker, HandleSyncRevengeMarker },
 					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
 					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
 					{ PacketTypes.SyncCavernMonsterType, HandleSyncCavernMonsterType }
@@ -3603,7 +3603,7 @@ namespace TShockAPI
 			return false;
 		}
     
-    private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
+		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
 		{
 			int uniqueID = args.Data.ReadInt32();
 			Vector2 location = args.Data.ReadVector2();
@@ -3615,7 +3615,7 @@ namespace TShockAPI
 			float baseValue = args.Data.ReadSingle();
 			bool spawnedFromStatus = args.Data.ReadBoolean();
       
-      return false;
+			return false;
 		}
 
 		private static bool HandleFishOutNPC(GetDataHandlerArgs args)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3715,6 +3715,7 @@ namespace TShockAPI
 
 		private static bool HandleSyncCavernMonsterType(GetDataHandlerArgs args)
 		{
+			args.Player.Kick("Exploit attempt detected!");
 			TShock.Log.ConsoleDebug($"HandleSyncCavernMonsterType: Player is trying to modify NPC cavernMonsterType; this is a crafted packet! - From {args.Player.Name}");
 			return true;
 		}


### PR DESCRIPTION
This packet is never sent from the client to the server in a normal scenario. Although with modded clients, a packet can be sent to modify the cavernMonsterType of the server world and have the world spawn defined NPC types. Can be used to have the server randomly spawn bosses on players in caverns.
Is it okay to have this simple handling in GetDataHandlers? A separate class felt like an overkill.

Moved the HandleSyncRevengeMarker packet handler to it's "correct" position, so I won't have merge issues between my last PR. As I've mentioned there, we have the Packets in their numerical order.