### PR TITLE
Move netmodule handling into handlers namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
-* Your change goes here!
+* New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)
+* New permission `tshock.journey.research` to enable sharing research via item sacrifice (@QuiCM)
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -37,6 +37,7 @@ namespace TShockAPI
 	internal sealed class Bouncer
 	{
 		internal Handlers.SendTileSquareHandler STSHandler { get; set; }
+		internal Handlers.NetModules.NetModulePacketHandler NetModuleHandler { get; set; }
 
 		/// <summary>Constructor call initializes Bouncer and related functionality.</summary>
 		/// <returns>A new Bouncer.</returns>
@@ -44,6 +45,9 @@ namespace TShockAPI
 		{
 			STSHandler = new Handlers.SendTileSquareHandler();
 			GetDataHandlers.SendTileSquare += STSHandler.OnReceive;
+
+			NetModuleHandler = new Handlers.NetModules.NetModulePacketHandler();
+			GetDataHandlers.LoadNetModule += NetModuleHandler.OnReceive;
 
 			// Setup hooks
 			GetDataHandlers.GetSection += OnGetSection;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -47,7 +47,7 @@ namespace TShockAPI
 			GetDataHandlers.SendTileSquare += STSHandler.OnReceive;
 
 			NetModuleHandler = new Handlers.NetModules.NetModulePacketHandler();
-			GetDataHandlers.LoadNetModule += NetModuleHandler.OnReceive;
+			GetDataHandlers.ReadNetModule += NetModuleHandler.OnReceive;
 
 			// Setup hooks
 			GetDataHandlers.GetSection += OnGetSection;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1967,7 +1967,7 @@ namespace TShockAPI
 		/// </summary>
 		public static HandlerList<ReadNetModuleEventArgs> ReadNetModule = new HandlerList<ReadNetModuleEventArgs>();
 
-		private static bool OnLoadNetModule(TSPlayer player, MemoryStream data, NetModuleType moduleType)
+		private static bool OnReadNetModule(TSPlayer player, MemoryStream data, NetModuleType moduleType)
 		{
 			if (ReadNetModule == null)
 			{
@@ -3259,7 +3259,7 @@ namespace TShockAPI
 		{
 			short moduleId = args.Data.ReadInt16();
 
-			if (OnLoadNetModule(args.Player, args.Data, (NetModuleType)moduleId))
+			if (OnReadNetModule(args.Player, args.Data, (NetModuleType)moduleId))
 			{
 				return true;
 			}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1954,7 +1954,7 @@ namespace TShockAPI
 		/// <summary>
 		/// Used when a net module is loaded
 		/// </summary>
-		public class LoadNetModuleEventArgs : GetDataHandledEventArgs
+		public class ReadNetModuleEventArgs : GetDataHandledEventArgs
 		{
 			/// <summary>
 			/// The type of net module being loaded
@@ -1963,25 +1963,25 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Called when a net module is loaded
+		/// Called when a net module is received
 		/// </summary>
-		public static HandlerList<LoadNetModuleEventArgs> LoadNetModule = new HandlerList<LoadNetModuleEventArgs>();
+		public static HandlerList<ReadNetModuleEventArgs> ReadNetModule = new HandlerList<ReadNetModuleEventArgs>();
 
 		private static bool OnLoadNetModule(TSPlayer player, MemoryStream data, NetModuleType moduleType)
 		{
-			if (LoadNetModule == null)
+			if (ReadNetModule == null)
 			{
 				return false;
 			}
 
-			var args = new LoadNetModuleEventArgs
+			var args = new ReadNetModuleEventArgs
 			{
 				Player = player,
 				Data = data,
 				ModuleType = moduleType
 			};
 
-			LoadNetModule.Invoke(null, args);
+			ReadNetModule.Invoke(null, args);
 			return args.Handled;
 		}
 
@@ -2242,11 +2242,10 @@ namespace TShockAPI
 
 			else if ((Main.ServerSideCharacter) && (args.Player.sX > 0) && (args.Player.sY > 0) && (args.TPlayer.SpawnX > 0) && ((args.TPlayer.SpawnX != args.Player.sX) && (args.TPlayer.SpawnY != args.Player.sY)))
 			{
-
 				args.Player.sX = args.TPlayer.SpawnX;
 				args.Player.sY = args.TPlayer.SpawnY;
 
-				if (((Main.tile[args.Player.sX, args.Player.sY - 1].active() && Main.tile[args.Player.sX, args.Player.sY - 1].type == 79)) && (WorldGen.StartRoomCheck(args.Player.sX, args.Player.sY - 1)))
+				if (((Main.tile[args.Player.sX, args.Player.sY - 1].active() && Main.tile[args.Player.sX, args.Player.sY - 1].type == TileID.Beds)) && (WorldGen.StartRoomCheck(args.Player.sX, args.Player.sY - 1)))
 				{
 					args.Player.Teleport(args.Player.sX * 16, (args.Player.sY * 16) - 48);
 					TShock.Log.ConsoleDebug("GetDataHandlers / HandleSpawn force teleport phase 1 {0}", args.Player.Name);
@@ -2255,7 +2254,7 @@ namespace TShockAPI
 
 			else if ((Main.ServerSideCharacter) && (args.Player.sX > 0) && (args.Player.sY > 0))
 			{
-				if (((Main.tile[args.Player.sX, args.Player.sY - 1].active() && Main.tile[args.Player.sX, args.Player.sY - 1].type == 79)) && (WorldGen.StartRoomCheck(args.Player.sX, args.Player.sY - 1)))
+				if (((Main.tile[args.Player.sX, args.Player.sY - 1].active() && Main.tile[args.Player.sX, args.Player.sY - 1].type == TileID.Beds)) && (WorldGen.StartRoomCheck(args.Player.sX, args.Player.sY - 1)))
 				{
 					args.Player.Teleport(args.Player.sX * 16, (args.Player.sY * 16) - 48);
 					TShock.Log.ConsoleDebug("GetDataHandlers / HandleSpawn force teleport phase 2 {0}", args.Player.Name);

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1959,7 +1959,7 @@ namespace TShockAPI
 			/// <summary>
 			/// The type of net module being loaded
 			/// </summary>
-			public NetModulesTypes ModuleType { get; set; }
+			public NetModuleType ModuleType { get; set; }
 		}
 
 		/// <summary>
@@ -1967,7 +1967,7 @@ namespace TShockAPI
 		/// </summary>
 		public static HandlerList<LoadNetModuleEventArgs> LoadNetModule = new HandlerList<LoadNetModuleEventArgs>();
 
-		private static bool OnLoadNetModule(TSPlayer player, MemoryStream data, NetModulesTypes moduleType)
+		private static bool OnLoadNetModule(TSPlayer player, MemoryStream data, NetModuleType moduleType)
 		{
 			if (LoadNetModule == null)
 			{
@@ -3260,7 +3260,7 @@ namespace TShockAPI
 		{
 			short moduleId = args.Data.ReadInt16();
 
-			if (OnLoadNetModule(args.Player, args.Data, (NetModulesTypes)moduleId))
+			if (OnLoadNetModule(args.Player, args.Data, (NetModuleType)moduleId))
 			{
 				return true;
 			}
@@ -3779,7 +3779,7 @@ namespace TShockAPI
 			public bool Killed { get; internal set; }
 		}
 
-		public enum NetModulesTypes
+		public enum NetModuleType
 		{
 			Liquid,
 			Text,

--- a/TShockAPI/Handlers/NetModules/AmbienceHandler.cs
+++ b/TShockAPI/Handlers/NetModules/AmbienceHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Rejects ambience new modules from clients
+	/// </summary>
+	internal class AmbienceHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// No deserialization needed. This should never be received by the server
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+		}
+
+		/// <summary>
+		/// This should never be received by the server
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			rejectPacket = true;
+		}
+	}
+}

--- a/TShockAPI/Handlers/NetModules/AmbienceHandler.cs
+++ b/TShockAPI/Handlers/NetModules/AmbienceHandler.cs
@@ -5,7 +5,7 @@ namespace TShockAPI.Handlers.NetModules
 	/// <summary>
 	/// Rejects ambience new modules from clients
 	/// </summary>
-	internal class AmbienceHandler : INetModuleHandler
+	public class AmbienceHandler : INetModuleHandler
 	{
 		/// <summary>
 		/// No deserialization needed. This should never be received by the server

--- a/TShockAPI/Handlers/NetModules/BestiaryHandler.cs
+++ b/TShockAPI/Handlers/NetModules/BestiaryHandler.cs
@@ -5,7 +5,7 @@ namespace TShockAPI.Handlers.NetModules
 	/// <summary>
 	/// Rejects client->server bestiary net modules as the client should never send this to the server
 	/// </summary>
-	internal class BestiaryHandler : INetModuleHandler
+	public class BestiaryHandler : INetModuleHandler
 	{
 		/// <summary>
 		/// No deserialization needed. This should never be received by the server

--- a/TShockAPI/Handlers/NetModules/BestiaryHandler.cs
+++ b/TShockAPI/Handlers/NetModules/BestiaryHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Rejects client->server bestiary net modules as the client should never send this to the server
+	/// </summary>
+	internal class BestiaryHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// No deserialization needed. This should never be received by the server
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+		}
+
+		/// <summary>
+		/// This should never be received by the server
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			rejectPacket = true;
+		}
+	}
+}

--- a/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Streams;
+using static TShockAPI.GetDataHandlers;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Provides handling for the Creative Power net module. Checks permissions on all creative powers
+	/// </summary>
+	public class CreativePowerHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// The power type being activated
+		/// </summary>
+		public CreativePowerTypes PowerType { get; set; }
+
+		/// <summary>
+		/// Reads the power type from the stream
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+			PowerType = (CreativePowerTypes)data.ReadInt16();
+		}
+
+		/// <summary>
+		/// Determines if the player has permission to use the power type
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			if (!CheckPermission(PowerType, player))
+			{
+				rejectPacket = true;
+				return;
+			}
+
+			rejectPacket = false;
+		}
+
+		/// <summary>
+		/// Determines if a player has permission to use a specific creative power
+		/// </summary>
+		/// <param name="powerType"></param>
+		/// <param name="player"></param>
+		/// <returns></returns>
+		public static bool CheckPermission(CreativePowerTypes powerType, TSPlayer player)
+		{
+			if (!PowerToPermissionMap.ContainsKey(powerType))
+			{
+				TShock.Log.ConsoleDebug("CreativePowerHandler received permission check request for unknown creative power");
+				return false;
+			}
+
+			string permission = PowerToPermissionMap[powerType];
+
+			if (!player.HasPermission(permission))
+			{
+				player.SendErrorMessage("You do not have permission to {0}.", PermissionToDescriptionMap[permission]);
+				return false;
+			}
+
+			return true;
+		}
+
+
+		/// <summary>
+		/// Maps creative powers to permission nodes
+		/// </summary>
+		public static Dictionary<CreativePowerTypes, string> PowerToPermissionMap = new Dictionary<CreativePowerTypes, string>
+		{
+			{ CreativePowerTypes.FreezeTime,              Permissions.journey_timefreeze		},
+			{ CreativePowerTypes.SetDawn,                 Permissions.journey_timeset			},
+			{ CreativePowerTypes.SetNoon,                 Permissions.journey_timeset			},
+			{ CreativePowerTypes.SetDusk,                 Permissions.journey_timeset			},
+			{ CreativePowerTypes.SetMidnight,             Permissions.journey_timeset			},
+			{ CreativePowerTypes.Godmode,                 Permissions.journey_godmode			},
+			{ CreativePowerTypes.WindStrength,            Permissions.journey_windstrength		},
+			{ CreativePowerTypes.RainStrength,            Permissions.journey_rainstrength		},
+			{ CreativePowerTypes.TimeSpeed,               Permissions.journey_timespeed			},
+			{ CreativePowerTypes.RainFreeze,              Permissions.journey_rainfreeze		},
+			{ CreativePowerTypes.WindFreeze,              Permissions.journey_windfreeze		},
+			{ CreativePowerTypes.IncreasePlacementRange,  Permissions.journey_placementrange	},
+			{ CreativePowerTypes.WorldDifficulty,         Permissions.journey_setdifficulty		},
+			{ CreativePowerTypes.BiomeSpreadFreeze,       Permissions.journey_biomespreadfreeze },
+			{ CreativePowerTypes.SetSpawnRate,            Permissions.journey_setspawnrate		},
+		};
+
+		/// <summary>
+		/// Maps journey mode permission nodes to descriptions of what the permission allows
+		/// </summary>
+		public static Dictionary<string, string> PermissionToDescriptionMap = new Dictionary<string, string>
+		{
+			{ Permissions.journey_timefreeze,			"freeze the time of the server"						},
+			{ Permissions.journey_timeset,				"modify the time of the server"						},
+			{ Permissions.journey_timeset,				"modify the time of the server"						},
+			{ Permissions.journey_timeset,				"modify the time of the server"						},
+			{ Permissions.journey_timeset,				"modify the time of the server"						},
+			{ Permissions.journey_godmode,				"toggle godmode"									},
+			{ Permissions.journey_windstrength,			"modify the wind strength of the server"			},
+			{ Permissions.journey_rainstrength,			"modify the rain strength of the server"			},
+			{ Permissions.journey_timespeed,			"modify the time speed of the server"				},
+			{ Permissions.journey_rainfreeze,			"freeze the rain strength of the server"			},
+			{ Permissions.journey_windfreeze,			"freeze the wind strength of the server"			},
+			{ Permissions.journey_placementrange,		"modify the tile placement range of your character" },
+			{ Permissions.journey_setdifficulty,		"modify the world difficulty of the server"			},
+			{ Permissions.journey_biomespreadfreeze,	"freeze the biome spread of the server"				},
+			{ Permissions.journey_setspawnrate,			"modify the NPC spawn rate of the server"			},
+		};
+	}
+}

--- a/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
@@ -31,7 +31,7 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="rejectPacket"></param>
 		public void HandlePacket(TSPlayer player, out bool rejectPacket)
 		{
-			if (!CheckPermission(PowerType, player))
+			if (!HasPermission(PowerType, player))
 			{
 				rejectPacket = true;
 				return;
@@ -46,7 +46,7 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="powerType"></param>
 		/// <param name="player"></param>
 		/// <returns></returns>
-		public static bool CheckPermission(CreativePowerTypes powerType, TSPlayer player)
+		public static bool HasPermission(CreativePowerTypes powerType, TSPlayer player)
 		{
 			if (!PowerToPermissionMap.ContainsKey(powerType))
 			{

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -1,0 +1,75 @@
+﻿using System.IO;
+using System.IO.Streams;
+using Terraria.GameContent.NetModules;
+using Terraria.Net;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Handles creative unlock requests
+	/// </summary>
+	public class CreativeUnlocksHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// An unknown field. If this does not have a value of '0' the packet should be rejected.
+		/// </summary>
+		public byte UnknownField { get; set; }
+		/// <summary>
+		/// ID of the item being sacrificed
+		/// </summary>
+		public ushort ItemId { get; set; }
+		/// <summary>
+		/// Stack size of the item being sacrificed
+		/// </summary>
+		public ushort Amount { get; set; }
+
+		/// <summary>
+		/// Reads the unlock data from the stream
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+			UnknownField = data.ReadInt8();
+			if (UnknownField == 0)
+			{
+				ItemId = data.ReadUInt16();
+				Amount = data.ReadUInt16();
+			}
+		}
+
+		/// <summary>
+		/// Determines if the unlock is valid and the player has permission to perform the unlock.
+		/// Syncs unlock status if the packet is accepted
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			if (UnknownField != 0)
+			{
+				TShock.Log.ConsoleDebug(
+					"CreativeUnlocksNetModuleHandler received non-vanilla unlock request. Random field value: {0} from {1}",
+					UnknownField,
+					player.Name
+				);
+
+				rejectPacket = true;
+				return;
+			}
+
+			if (!player.HasPermission(Permissions.journey_contributeresearch))
+			{
+				player.SendErrorMessage("You do not have permission to contribute research.");
+				rejectPacket = true;
+				return;
+			}
+
+			var totalSacrificed = TShock.ResearchDatastore.SacrificeItem(ItemId, Amount, player);
+
+			var response = NetCreativeUnlocksModule.SerializeItemSacrifice(ItemId, totalSacrificed);
+			NetManager.Instance.Broadcast(response);
+
+			rejectPacket = false;
+		}
+	}
+}

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.IO.Streams;
+using Terraria;
 using Terraria.GameContent.NetModules;
 using Terraria.Net;
 
@@ -45,6 +46,17 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="rejectPacket"></param>
 		public void HandlePacket(TSPlayer player, out bool rejectPacket)
 		{
+			if (!Main.GameModeInfo.IsJourneyMode)
+			{
+				TShock.Log.ConsoleDebug(
+					"NetModuleHandler received attempt to unlock sacrifice while not in journey mode from",
+					player.Name
+				);
+
+				rejectPacket = true;
+				return;
+			}
+
 			if (UnknownField != 0)
 			{
 				TShock.Log.ConsoleDebug(

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -30,6 +30,9 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="data"></param>
 		public void Deserialize(MemoryStream data)
 		{
+			// For whatever reason Terraria writes '0' to the stream at the beginning of this packet.
+			// If this value is not 0 then its been crafted by a non-vanilla client.
+			// We don't actually know why the 0 is written, so we're just going to call this UnknownField for now
 			UnknownField = data.ReadInt8();
 			if (UnknownField == 0)
 			{

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -48,7 +48,7 @@ namespace TShockAPI.Handlers.NetModules
 			if (UnknownField != 0)
 			{
 				TShock.Log.ConsoleDebug(
-					"CreativeUnlocksNetModuleHandler received non-vanilla unlock request. Random field value: {0} from {1}",
+					"CreativeUnlocksHandler received non-vanilla unlock request. Random field value: {0} but should be 0 from {1}",
 					UnknownField,
 					player.Name
 				);

--- a/TShockAPI/Handlers/NetModules/INetModuleHandler.cs
+++ b/TShockAPI/Handlers/NetModules/INetModuleHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Describes a handler for a net module
+	/// </summary>
+	public interface INetModuleHandler
+	{
+		/// <summary>
+		/// Reads the net module's data from the given stream
+		/// </summary>
+		/// <param name="data"></param>
+		void Deserialize(MemoryStream data);
+
+		/// <summary>
+		/// Provides handling for the packet and determines if it should be accepted or rejected
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		void HandlePacket(TSPlayer player, out bool rejectPacket);
+	}
+}

--- a/TShockAPI/Handlers/NetModules/LiquidHandler.cs
+++ b/TShockAPI/Handlers/NetModules/LiquidHandler.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Handles the NetLiquidModule. Rejects all incoming net liquid requests, as clients should never send them
+	/// </summary>
+	public class LiquidHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// Does nothing. We should not deserialize this data
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+			// No need to deserialize
+		}
+
+		/// <summary>
+		/// Rejects the packet. Clients should not send this to us
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			rejectPacket = true;
+		}
+	}
+}

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -1,4 +1,6 @@
-﻿using Terraria;
+﻿using System;
+using System.Collections.Generic;
+using Terraria;
 using static TShockAPI.GetDataHandlers;
 
 namespace TShockAPI.Handlers.NetModules
@@ -9,6 +11,19 @@ namespace TShockAPI.Handlers.NetModules
 	public class NetModulePacketHandler : IPacketHandler<LoadNetModuleEventArgs>
 	{
 		/// <summary>
+		/// Maps net module types to handlers for the net module type. Add to or edit this dictionary to customise handling
+		/// </summary>
+		public static Dictionary<NetModulesTypes, Type> NetModulesToHandlersMap = new Dictionary<NetModulesTypes, Type>
+		{
+			{ NetModulesTypes.CreativePowers,               typeof(CreativePowerHandler)    },
+			{ NetModulesTypes.CreativeUnlocksPlayerReport,  typeof(CreativeUnlocksHandler)  },
+			{ NetModulesTypes.TeleportPylon,                typeof(PylonHandler)            },
+			{ NetModulesTypes.Liquid,                       typeof(LiquidHandler)           },
+			{ NetModulesTypes.Bestiary,                     typeof(BestiaryHandler)         },
+			{ NetModulesTypes.Ambience,                     typeof(AmbienceHandler)         }
+		};
+
+		/// <summary>
 		/// Invoked when a load net module packet is received. This method picks a <see cref="INetModuleHandler"/> based on the
 		/// net module type being loaded, then forwards the data to the chosen handler to process
 		/// </summary>
@@ -18,61 +33,25 @@ namespace TShockAPI.Handlers.NetModules
 		{
 			INetModuleHandler handler;
 
-			switch (args.ModuleType)
+			if (NetModulesToHandlersMap.ContainsKey(args.ModuleType))
 			{
-				case NetModulesTypes.CreativePowers:
-					{
-						handler = new CreativePowerHandler();
-						break;
-					}
-
-				case NetModulesTypes.CreativeUnlocksPlayerReport:
-					{
-						if (!Main.GameModeInfo.IsJourneyMode)
-						{
-							TShock.Log.ConsoleDebug(
-								"NetModuleHandler received attempt to unlock sacrifice while not in journey mode from",
-								args.Player.Name
-							);
-
-							args.Handled = true;
-							return;
-						}
-
-						handler = new CreativeUnlocksHandler();
-						break;
-					}
-				case NetModulesTypes.TeleportPylon:
-					{
-						handler = new PylonHandler();
-						break;
-					}
-				case NetModulesTypes.Liquid:
-					{
-						handler = new LiquidHandler();
-						break;
-					}
-				case NetModulesTypes.Bestiary:
-					{
-						handler = new BestiaryHandler();
-						break;
-					}
-				default:
-					{
-						// As of 1.4.x.x, this is now used for more things:
-						//	NetCreativePowersModule
-						//	NetCreativePowerPermissionsModule
-						//	NetLiquidModule
-						//	NetParticlesModule
-						//	NetPingModule
-						//	NetTeleportPylonModule
-						//	NetTextModule
-						// I (particles) have disabled the original return here, which means that we need to
-						// handle this more. In the interm, this unbreaks parts of vanilla. Originally
-						// we just blocked this because it was a liquid exploit.
-						args.Handled = false;
-						return;
-					}
+				handler = (INetModuleHandler)Activator.CreateInstance(NetModulesToHandlersMap[args.ModuleType]);
+			}
+			else
+			{
+				// As of 1.4.x.x, this is now used for more things:
+				//	NetCreativePowersModule
+				//	NetCreativePowerPermissionsModule
+				//	NetLiquidModule
+				//	NetParticlesModule
+				//	NetPingModule
+				//	NetTeleportPylonModule
+				//	NetTextModule
+				// I (particles) have disabled the original return here, which means that we need to
+				// handle this more. In the interm, this unbreaks parts of vanilla. Originally
+				// we just blocked this because it was a liquid exploit.
+				args.Handled = false;
+				return;
 			}
 
 			handler.Deserialize(args.Data);

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Terraria;
+﻿using Terraria;
 using static TShockAPI.GetDataHandlers;
 
 namespace TShockAPI.Handlers.NetModules
@@ -46,6 +45,11 @@ namespace TShockAPI.Handlers.NetModules
 				case NetModulesTypes.TeleportPylon:
 					{
 						handler = new PylonHandler();
+						break;
+					}
+				case NetModulesTypes.Liquid:
+					{
+						handler = new LiquidHandler();
 						break;
 					}
 				default:

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -13,14 +13,14 @@ namespace TShockAPI.Handlers.NetModules
 		/// <summary>
 		/// Maps net module types to handlers for the net module type. Add to or edit this dictionary to customise handling
 		/// </summary>
-		public static Dictionary<NetModulesTypes, Type> NetModulesToHandlersMap = new Dictionary<NetModulesTypes, Type>
+		public static Dictionary<NetModuleType, Type> NetModulesToHandlersMap = new Dictionary<NetModuleType, Type>
 		{
-			{ NetModulesTypes.CreativePowers,               typeof(CreativePowerHandler)    },
-			{ NetModulesTypes.CreativeUnlocksPlayerReport,  typeof(CreativeUnlocksHandler)  },
-			{ NetModulesTypes.TeleportPylon,                typeof(PylonHandler)            },
-			{ NetModulesTypes.Liquid,                       typeof(LiquidHandler)           },
-			{ NetModulesTypes.Bestiary,                     typeof(BestiaryHandler)         },
-			{ NetModulesTypes.Ambience,                     typeof(AmbienceHandler)         }
+			{ NetModuleType.CreativePowers,               typeof(CreativePowerHandler)    },
+			{ NetModuleType.CreativeUnlocksPlayerReport,  typeof(CreativeUnlocksHandler)  },
+			{ NetModuleType.TeleportPylon,                typeof(PylonHandler)            },
+			{ NetModuleType.Liquid,                       typeof(LiquidHandler)           },
+			{ NetModuleType.Bestiary,                     typeof(BestiaryHandler)         },
+			{ NetModuleType.Ambience,                     typeof(AmbienceHandler)         }
 		};
 
 		/// <summary>

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -8,7 +8,7 @@ namespace TShockAPI.Handlers.NetModules
 	/// <summary>
 	/// Handles packet 82 - Load Net Module packets
 	/// </summary>
-	public class NetModulePacketHandler : IPacketHandler<LoadNetModuleEventArgs>
+	public class NetModulePacketHandler : IPacketHandler<ReadNetModuleEventArgs>
 	{
 		/// <summary>
 		/// Maps net module types to handlers for the net module type. Add to or edit this dictionary to customise handling
@@ -29,7 +29,7 @@ namespace TShockAPI.Handlers.NetModules
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
-		public void OnReceive(object sender, LoadNetModuleEventArgs args)
+		public void OnReceive(object sender, ReadNetModuleEventArgs args)
 		{
 			INetModuleHandler handler;
 
@@ -39,17 +39,8 @@ namespace TShockAPI.Handlers.NetModules
 			}
 			else
 			{
-				// As of 1.4.x.x, this is now used for more things:
-				//	NetCreativePowersModule
-				//	NetCreativePowerPermissionsModule
-				//	NetLiquidModule
-				//	NetParticlesModule
-				//	NetPingModule
-				//	NetTeleportPylonModule
-				//	NetTextModule
-				// I (particles) have disabled the original return here, which means that we need to
-				// handle this more. In the interm, this unbreaks parts of vanilla. Originally
-				// we just blocked this because it was a liquid exploit.
+				// We don't have handlers for NetModuleType.Ping and NetModuleType.Particles.
+				// These net modules are fairly innocuous and can be processed normally by the game
 				args.Handled = false;
 				return;
 			}

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -52,6 +52,11 @@ namespace TShockAPI.Handlers.NetModules
 						handler = new LiquidHandler();
 						break;
 					}
+				case NetModulesTypes.Bestiary:
+					{
+						handler = new BestiaryHandler();
+						break;
+					}
 				default:
 					{
 						// As of 1.4.x.x, this is now used for more things:

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Terraria;
+using static TShockAPI.GetDataHandlers;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Handles packet 82 - Load Net Module packets
+	/// </summary>
+	public class NetModulePacketHandler : IPacketHandler<LoadNetModuleEventArgs>
+	{
+		/// <summary>
+		/// Invoked when a load net module packet is received. This method picks a <see cref="INetModuleHandler"/> based on the
+		/// net module type being loaded, then forwards the data to the chosen handler to process
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void OnReceive(object sender, LoadNetModuleEventArgs args)
+		{
+			INetModuleHandler handler;
+
+			switch (args.ModuleType)
+			{
+				case NetModulesTypes.CreativePowers:
+					{
+						handler = new CreativePowerHandler();
+						break;
+					}
+
+				case NetModulesTypes.CreativeUnlocksPlayerReport:
+					{
+						if (!Main.GameModeInfo.IsJourneyMode)
+						{
+							TShock.Log.ConsoleDebug(
+								"NetModuleHandler received attempt to unlock sacrifice while not in journey mode from",
+								args.Player.Name
+							);
+
+							args.Handled = true;
+							return;
+						}
+
+						handler = new CreativeUnlocksHandler();
+						break;
+					}
+				case NetModulesTypes.TeleportPylon:
+					{
+						handler = new PylonHandler();
+						break;
+					}
+				default:
+					{
+						// As of 1.4.x.x, this is now used for more things:
+						//	NetCreativePowersModule
+						//	NetCreativePowerPermissionsModule
+						//	NetLiquidModule
+						//	NetParticlesModule
+						//	NetPingModule
+						//	NetTeleportPylonModule
+						//	NetTextModule
+						// I (particles) have disabled the original return here, which means that we need to
+						// handle this more. In the interm, this unbreaks parts of vanilla. Originally
+						// we just blocked this because it was a liquid exploit.
+						args.Handled = false;
+						return;
+					}
+			}
+
+			handler.Deserialize(args.Data);
+			handler.HandlePacket(args.Player, out bool rejectPacket);
+
+			args.Handled = rejectPacket;
+		}
+	}
+}

--- a/TShockAPI/Handlers/NetModules/PylonHandler.cs
+++ b/TShockAPI/Handlers/NetModules/PylonHandler.cs
@@ -1,0 +1,62 @@
+﻿using System.IO;
+using System.IO.Streams;
+using Terraria.GameContent;
+using static Terraria.GameContent.NetModules.NetTeleportPylonModule;
+
+namespace TShockAPI.Handlers.NetModules
+{
+	/// <summary>
+	/// Handles a pylon net module
+	/// </summary>
+	public class PylonHandler : INetModuleHandler
+	{
+		/// <summary>
+		/// Event occuring
+		/// </summary>
+		public SubPacketType PylonEventType { get; set; }
+		/// <summary>
+		/// Tile X coordinate of the pylon
+		/// </summary>
+		public short TileX { get; set; }
+		/// <summary>
+		/// Tile Y coordinate of the pylon
+		/// </summary>
+		public short TileY { get; set; }
+		/// <summary>
+		/// Type of Pylon
+		/// </summary>
+		public TeleportPylonType PylonType { get; set; }
+
+		/// <summary>
+		/// Reads the pylon data from the net module
+		/// </summary>
+		/// <param name="data"></param>
+		public void Deserialize(MemoryStream data)
+		{
+			PylonEventType = (SubPacketType)data.ReadInt8();
+			TileX = data.ReadInt16();
+			TileY = data.ReadInt16();
+			PylonType = (TeleportPylonType)data.ReadInt8();
+		}
+
+		/// <summary>
+		/// Rejects a pylon teleport request if the player does not have permission
+		/// </summary>
+		/// <param name="player"></param>
+		/// <param name="rejectPacket"></param>
+		public void HandlePacket(TSPlayer player, out bool rejectPacket)
+		{
+			if (PylonEventType == SubPacketType.PlayerRequestsTeleport)
+			{
+				if (!player.HasPermission(Permissions.pylon))
+				{
+					rejectPacket = true;
+					player.SendErrorMessage("You do not have permission to teleport with pylons.");
+					return;
+				}
+			}
+
+			rejectPacket = false;
+		}
+	}
+}

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -267,6 +267,9 @@ namespace TShockAPI
 
 		[Description("User can use wormhole potions.")]
 		public static readonly string wormhole = "tshock.tp.wormhole";
+
+		[Description("User can use pylons to teleport")]
+		public static readonly string pylon = "tshock.tp.pylon";
 		#endregion
 
 		#region tshock.world nodes
@@ -409,6 +412,9 @@ namespace TShockAPI
 
 		[Description("User can use Creative UI to set the NPC spawn rate of the world.")]
 		public static readonly string journey_setspawnrate = "tshock.journey.setspawnrate";
+
+		[Description("User can contribute research by sacrificing items")]
+		public static readonly string journey_contributeresearch = "tshock.journey.research";
 		#endregion
 
 		#region Non-grouped

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -89,6 +89,7 @@
     <Compile Include="DB\TileManager.cs" />
     <Compile Include="Extensions\ExceptionExt.cs" />
     <Compile Include="Handlers\IPacketHandler.cs" />
+    <Compile Include="Handlers\NetModules\AmbienceHandler.cs" />
     <Compile Include="Handlers\NetModules\BestiaryHandler.cs" />
     <Compile Include="Handlers\NetModules\CreativePowerHandler.cs" />
     <Compile Include="Handlers\NetModules\CreativeUnlocksHandler.cs" />

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -89,6 +89,11 @@
     <Compile Include="DB\TileManager.cs" />
     <Compile Include="Extensions\ExceptionExt.cs" />
     <Compile Include="Handlers\IPacketHandler.cs" />
+    <Compile Include="Handlers\NetModules\CreativePowerHandler.cs" />
+    <Compile Include="Handlers\NetModules\CreativeUnlocksHandler.cs" />
+    <Compile Include="Handlers\NetModules\INetModuleHandler.cs" />
+    <Compile Include="Handlers\NetModules\NetModulePacketHandler.cs" />
+    <Compile Include="Handlers\NetModules\PylonHandler.cs" />
     <Compile Include="Handlers\SendTileSquareHandler.cs" />
     <Compile Include="Hooks\AccountHooks.cs" />
     <Compile Include="Hooks\GeneralHooks.cs" />
@@ -213,7 +218,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_BuildAction="Both" BuildVersion_BuildVersioningStyle="None.None.None.MonthAndDayStamp" BuildVersion_StartDate="2011/6/17" BuildVersion_IncrementBeforeBuild="False" />
+      <UserProperties BuildVersion_IncrementBeforeBuild="False" BuildVersion_StartDate="2011/6/17" BuildVersion_BuildVersioningStyle="None.None.None.MonthAndDayStamp" BuildVersion_BuildAction="Both" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Handlers\NetModules\CreativePowerHandler.cs" />
     <Compile Include="Handlers\NetModules\CreativeUnlocksHandler.cs" />
     <Compile Include="Handlers\NetModules\INetModuleHandler.cs" />
+    <Compile Include="Handlers\NetModules\LiquidHandler.cs" />
     <Compile Include="Handlers\NetModules\NetModulePacketHandler.cs" />
     <Compile Include="Handlers\NetModules\PylonHandler.cs" />
     <Compile Include="Handlers\SendTileSquareHandler.cs" />

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -89,6 +89,7 @@
     <Compile Include="DB\TileManager.cs" />
     <Compile Include="Extensions\ExceptionExt.cs" />
     <Compile Include="Handlers\IPacketHandler.cs" />
+    <Compile Include="Handlers\NetModules\BestiaryHandler.cs" />
     <Compile Include="Handlers\NetModules\CreativePowerHandler.cs" />
     <Compile Include="Handlers\NetModules\CreativeUnlocksHandler.cs" />
     <Compile Include="Handlers\NetModules\INetModuleHandler.cs" />


### PR DESCRIPTION
Moves the existing netmodule handling into new namespace `TShock.Handlers.NetModules`.
Adds a new netmodule handler for the Teleport Pylon net module, along with a new permission `tshock.tp.pylon` to enable/disable pylon teleports.
Also adds new netmodule handlers for all the netmodules we should process or instantly reject.
As far as I am aware the only unhandled modules are now the NetAmbienceModule and NetPingModule. Both could potentially be abused via spam, but are otherwise 'safe'