### PR TITLE
Handlesynctilepicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding EmojiHandler to handle an exploit. Adding `tshock.sendemoji` permission and checks. Added this permission to guest group by default.
 * Handling SyncCavernMonsterType packet to prevent an exploit where players could modify the server's cavern monster types and make the server spawn any NPCs - including bosses - onto other players.
 * Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
-* Add SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Prevent player sending invalid world position data to kick players. Prevent player ID spoofing)
+* Add SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Preventing player sending invalid world position data which disconnects other players.)
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming Changes
-* Your change goes here!
+* Add SyncTilePicking event. This is called when a player damages a tile.
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding EmojiHandler to handle an exploit. Adding `tshock.sendemoji` permission and checks. Added this permission to guest group by default.
 * Handling SyncCavernMonsterType packet to prevent an exploit where players could modify the server's cavern monster types and make the server spawn any NPCs - including bosses - onto other players.
 * Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
-* Add SyncTilePicking event. This is called when a player damages a tile.
+* Add SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Prevent player sending invalid world position data to kick players. Prevent player ID spoofing)
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -40,6 +40,7 @@ namespace TShockAPI
 		internal Handlers.NetModules.NetModulePacketHandler NetModuleHandler { get; set; }
 		internal Handlers.EmojiHandler EmojiHandler { get; set; }
 		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; set; }
+		internal Handlers.SyncTilePickingHandler SyncTilePickingHandler { get; set; }
 
 		/// <summary>Constructor call initializes Bouncer and related functionality.</summary>
 		/// <returns>A new Bouncer.</returns>
@@ -56,6 +57,9 @@ namespace TShockAPI
       
 			LandGolfBallInCupHandler = new Handlers.LandGolfBallInCupHandler();
 			GetDataHandlers.LandGolfBallInCup += LandGolfBallInCupHandler.OnReceive;
+
+			SyncTilePickingHandler = new Handlers.SyncTilePickingHandler();
+			GetDataHandlers.SyncTilePicking += SyncTilePickingHandler.OnReceive;
 
 			// Setup hooks
 			GetDataHandlers.GetSection += OnGetSection;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3696,35 +3696,6 @@ namespace TShockAPI
 
 			return false;
 		}
-    
-		private static bool HandleSyncRevengeMarker(GetDataHandlerArgs args)
-		{
-			int uniqueID = args.Data.ReadInt32();
-			Vector2 location = args.Data.ReadVector2();
-			int netId = args.Data.ReadInt32();
-			float npcHpPercent = args.Data.ReadSingle();
-			int npcTypeAgainstDiscouragement = args.Data.ReadInt32(); //tfw the argument is Type Against Discouragement
-			int npcAiStyleAgainstDiscouragement = args.Data.ReadInt32(); //see ^
-			int coinsValue = args.Data.ReadInt32();
-			float baseValue = args.Data.ReadSingle();
-			bool spawnedFromStatus = args.Data.ReadBoolean();
-      
-			return false;
-		}
-
-		private static bool HandleLandGolfBallInCup(GetDataHandlerArgs args)
-		{
-			byte playerIndex = args.Data.ReadInt8();
-			ushort tileX = args.Data.ReadUInt16();
-			ushort tileY = args.Data.ReadUInt16();
-			ushort hits = args.Data.ReadUInt16();
-			ushort projectileType = args.Data.ReadUInt16();
-
-			if (OnLandGolfBallInCup(args.Player, args.Data, playerIndex, tileX, tileY, hits, projectileType))
-				return true;
-
-			return false;
-		}
 
 		private static bool HandleSyncTilePicking(GetDataHandlerArgs args)
 		{
@@ -3750,6 +3721,20 @@ namespace TShockAPI
 			int coinsValue = args.Data.ReadInt32();
 			float baseValue = args.Data.ReadSingle();
 			bool spawnedFromStatus = args.Data.ReadBoolean();
+      
+			return false;
+		}
+
+		private static bool HandleLandGolfBallInCup(GetDataHandlerArgs args)
+		{
+			byte playerIndex = args.Data.ReadInt8();
+			ushort tileX = args.Data.ReadUInt16();
+			ushort tileY = args.Data.ReadUInt16();
+			ushort hits = args.Data.ReadUInt16();
+			ushort projectileType = args.Data.ReadUInt16();
+
+			if (OnLandGolfBallInCup(args.Player, args.Data, playerIndex, tileX, tileY, hits, projectileType))
+				return true;
 
 			return false;
 		}

--- a/TShockAPI/Handlers/SyncTilePickingHandler.cs
+++ b/TShockAPI/Handlers/SyncTilePickingHandler.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using static TShockAPI.GetDataHandlers;
+
+namespace TShockAPI.Handlers
+{
+	class SyncTilePickingHandler : IPacketHandler<SyncTilePickingEventArgs>
+	{
+		/// <summary>
+		/// Invoked when player damages a tile.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void OnReceive(object sender, SyncTilePickingEventArgs args)
+		{
+			if (args.PlayerIndex != args.Player.Index)
+			{
+				TShock.Log.ConsoleDebug($"SyncTilePickingHandler: SyncTilePicking packet rejected for ID spoofing. Expected {args.Player.Index}, received {args.PlayerIndex} from {args.Player.Name}.");
+				args.Handled = true;
+				return;
+			}
+
+			if (args.TileX > Main.maxTilesX || args.TileX < 0
+			   || args.TileY > Main.maxTilesY || args.TileY < 0)
+			{
+				TShock.Log.ConsoleDebug($"SyncTilePickingHandler: X and Y position is out of world bounds! - From {args.Player.Name}");
+				args.Handled = true;
+				return;
+			}
+		}
+	}
+}

--- a/TShockAPI/Handlers/SyncTilePickingHandler.cs
+++ b/TShockAPI/Handlers/SyncTilePickingHandler.cs
@@ -11,19 +11,12 @@ namespace TShockAPI.Handlers
 	class SyncTilePickingHandler : IPacketHandler<SyncTilePickingEventArgs>
 	{
 		/// <summary>
-		/// Invoked when player damages a tile.
+		/// Invoked when player damages a tile. Rejects the packet if its out of world bounds.
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
 		public void OnReceive(object sender, SyncTilePickingEventArgs args)
 		{
-			if (args.PlayerIndex != args.Player.Index)
-			{
-				TShock.Log.ConsoleDebug($"SyncTilePickingHandler: SyncTilePicking packet rejected for ID spoofing. Expected {args.Player.Index}, received {args.PlayerIndex} from {args.Player.Name}.");
-				args.Handled = true;
-				return;
-			}
-
 			if (args.TileX > Main.maxTilesX || args.TileX < 0
 			   || args.TileY > Main.maxTilesY || args.TileY < 0)
 			{

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Handlers\EmojiHandler.cs" />
     <Compile Include="Handlers\LandGolfBallInCupHandler.cs" />
     <Compile Include="Handlers\SendTileSquareHandler.cs" />
+    <Compile Include="Handlers\SyncTilePickingHandler.cs" />
     <Compile Include="Hooks\AccountHooks.cs" />
     <Compile Include="Hooks\GeneralHooks.cs" />
     <Compile Include="Hooks\PlayerHooks.cs" />


### PR DESCRIPTION
Handling this newly added packet, which is sent to the server whenever a player damages a tile which is then forwarded to the clients. Nothing gets executed server-side, it only sends out the packet back to other clients. In the client, there was no check for X and Y and it resulted in getting disconnected with `Buffer header overload` something. 