### PR TITLE
Change DebugLogs to true by default

### DIFF
--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -525,7 +525,7 @@ namespace TShockAPI
 		public bool ShowBackupAutosaveMessages = true;
 
 		[Description("Whether or not the server should output debug level messages related to system operation.")]
-		public bool DebugLogs = false;
+		public bool DebugLogs = true;
 
 		[Description("Determines the range in tiles that a bomb can affect tiles from detonation point.")]
 		public int BombExplosionRadius = 5;


### PR DESCRIPTION
Given that this is a pre-release and it no longer makes the CLI unreadable I think it should be on by default to make troubleshooting easier.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

didn't bother updating the changelog since it's such a minor change