### PR TITLE
OnFishout - Fixing #1985 - Making debug messages clearer. Modifying r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Handling SyncCavernMonsterType packet to prevent an exploit where players could modify the server's cavern monster types and make the server spawn any NPCs - including bosses - onto other players.
 * Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
 * Add SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Preventing player sending invalid world position data which disconnects other players.)
+* Fix the issue where mobs could not be fished out during bloodmoon because of Bouncer checks. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1935,7 +1935,7 @@ namespace TShockAPI
 			}
 			if (!args.Player.IsInRange(args.TileX, args.TileY, 55))
 			{
-				TShock.Log.ConsoleError("Bouncer / OnFishOutNPC rejected range checks from {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected range checks from {0}", args.Player.Name);
 				args.Handled = true;
 			}
 		}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1906,11 +1906,24 @@ namespace TShockAPI
 		/// <param name="args"></param>
 		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
 		{
-			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index] != null && Main.projectile[p.Index].Name == "Bobber");
+			/// Getting recent projectiles of the player which are named Bobber. All bobbers have the same Name.
+			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].Name == "Bobber");
 
-			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type) || Main.projectile[projectile.Index] == null || !FishableNpcIDs.Contains(args.NpcID))
+			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
 			{
-				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected invalid NPC spawning from {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected for not using a fishing rod! - From {0}", args.Player.Name);
+				args.Handled = true;
+				return;
+			}
+			if (projectile.Type == 0 || projectile.Killed) /// The bobber projectile is never killed when the NPC spawns. Type can only be 0 if no recent projectile is found that is named Bobber.
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected for not finding active bobber projectile! - From {0}", args.Player.Name);
+				args.Handled = true;
+				return;
+			}
+			if (!FishableNpcIDs.Contains(args.NpcID))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected for the NPC not being on the fishable NPCs list! - From {0}", args.Player.Name);
 				args.Handled = true;
 				return;
 			}
@@ -1920,9 +1933,9 @@ namespace TShockAPI
 				args.Handled = true;
 				return;
 			}
-			if (args.Player.IsInRange(args.TileX, args.TileY, 55))
+			if (!args.Player.IsInRange(args.TileX, args.TileY, 55))
 			{
-				TShock.Log.ConsoleDebug("Bouncer / OnFishOutNPC rejected range checks from {0}", args.Player.Name);
+				TShock.Log.ConsoleError("Bouncer / OnFishOutNPC rejected range checks from {0}", args.Player.Name);
 				args.Handled = true;
 			}
 		}


### PR DESCRIPTION
…edundant check.

The actual issue was a missing `!` behind IsInRange. If a player was doing a valid fishing event, it handled the NPC spawning.
I've split up the checks to make clearer debug messages.
Main.projectile objects are never null. Bobber projectile is never killed when the FishOutNPC event occurs. The projectile type in the check can only be 0 if no recent projectile found that has the name Bobber.