### PR TITLE
Update Bouncer to include Sticky Dirt Bombs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
 * Add SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Preventing player sending invalid world position data which disconnects other players.)
 * Fix the issue where mobs could not be fished out during bloodmoon because of Bouncer checks. (@Patrikkk)
+* Fix sticky dirt bombs not creating dirt. (@anasypany)
 
 ## TShock 4.4.0 (Pre-release 10)
 * Fix all rope coils. (@Olink)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -54,7 +54,7 @@ namespace TShockAPI
 
 			EmojiHandler = new Handlers.EmojiHandler();
 			GetDataHandlers.Emoji += EmojiHandler.OnReceive;
-      
+
 			LandGolfBallInCupHandler = new Handlers.LandGolfBallInCupHandler();
 			GetDataHandlers.LandGolfBallInCup += LandGolfBallInCupHandler.OnReceive;
 
@@ -348,8 +348,8 @@ namespace TShockAPI
 						!(ropeCoilPlacements.ContainsKey(selectedItem.netID) && editData == ropeCoilPlacements[selectedItem.netID])))
 					{
 						// Rather than attempting to figure out what the above if statement does, we'll just patch it
-						// Adds exception to this check to allow dirt bombs to create dirt tiles
-						if (!(selectedItem.netID == ItemID.DirtBomb && action == EditAction.PlaceTile && editData == TileID.Dirt))
+						// Adds exception to this check to allow dirt bombs and sticky dirt bombs to create dirt tiles
+						if (!((selectedItem.netID == ItemID.DirtBomb || selectedItem.netID == ItemID.StickyDirtBomb) && action == EditAction.PlaceTile && editData == TileID.Dirt))
 						{
 							TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (ms2) {0} {1} {2}", args.Player.Name, action, editData);
 							args.Player.SendTileSquare(tileX, tileY, 4);
@@ -793,7 +793,8 @@ namespace TShockAPI
 				|| type == ProjectileID.StickyBomb
 				|| type == ProjectileID.StickyDynamite
 				|| type == ProjectileID.ScarabBomb
-				|| type == ProjectileID.DirtBomb))
+				|| type == ProjectileID.DirtBomb
+				|| type == ProjectileID.StickyDirtBomb))
 			{
 				//  Denotes that the player has recently set a fuse - used for cheat detection.
 				args.Player.RecentFuse = 10;


### PR DESCRIPTION
Noticed sticky dirt bombs weren't working on my server but regular dirt bombs were. Basically just added on to the [work](https://github.com/Pryaxis/TShock/commit/d610ab929b748713da393dc50cbfb153b5a51c5f) originally done by @hakusaro  on dirt bombs.

Fixes #1853 