### PR TITLE
FishOutNPC - Fix some rods not fishing out NPCs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added LandGolfBallInCup event which is accessible for developers to work with, as well as LandGolfBallInCup handler to handle exploits where players could send direct packets to trigger and imitate golf ball cup landing anywhere in the game world. Added two public lists in Handlers.LandGolfBallInCupHandler: GolfBallProjectileIDs and GolfClubItemIDs. (@Patrikkk)
 * Added SyncTilePicking event. This is called when a player damages a tile. Implementing SyncTilePickingHandler and patching tile damaging related exploits. (Preventing player sending invalid world position data which disconnects other players.)
 * Fixed the issue where mobs could not be fished out during bloodmoon because of Bouncer checks. (@Patrikkk)
+	*Fixed the issue where certain fishing rods could not fish out NPCs due to a Bouncer check. (@Patrikkk)
 * Update for OTAPI 2.0.0.37 and Terraria 1.4.0.5. (@hakusaro, @Patrikkk)
 * Adding missing PlayerInfo data in GetDataHandler. (@Patrikkk)
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1906,8 +1906,8 @@ namespace TShockAPI
 		/// <param name="args"></param>
 		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
 		{
-			/// Getting recent projectiles of the player which are named Bobber. All bobbers have the same Name.
-			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].Name == "Bobber");
+			/// Getting recent projectiles of the player and selecting the first that is a bobber.
+			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].bobber);
 
 			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
 			{


### PR DESCRIPTION
I was wrong, not all bobbers are named "Bobber".
Just found that Projectile now has an extra field which determines if the given type is a bobber. This field is set in Projectile.SetDefaults method in the following logic
`((type >= 360 && type <= 366) || type == 381 || type == 382 || type == 760 || type == 775)`
I think it is reasonable to use the bobber field, as it would be updateproof too.
Tested and working. Fixes the issue mentioned in  #1985 