### PR TITLE
Add martians to validEvents response message

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1970,7 +1970,8 @@ namespace TShockAPI
 			"snowmen",
 			"pirates",
 			"pumpkinmoon",
-			"frostmoon"
+			"frostmoon",
+                      "martians"
 		};
 
 		private static void ManageWorldEvent(CommandArgs args)


### PR DESCRIPTION
very minor fix not rly worth updating the change log for

fixes https://github.com/Pryaxis/TShock/issues/2013 - Martians missing from list of valid event parameters. 