### PR TITLE
Bouncer OnTileEdit - Add tile replace action to tileban check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Installed new sprinklers!
-* Fix issue where players could replace tiles with banned tiles without permission. (@Patrikkk)
+* Fix multiple holes in Bouncer OnTileData. (@Patrikkk, @hakusaro)
+	* Issue where players could replace tiles with banned tiles without permission. 
+	* Including replace action in TilePlace threshold incrementation, so players cannot bypass the threshold while replacing tiles/walls.
+	* Including check for maxTileSets when player is replacing tiles, so players cannot send invalid tile data through the replace tile action.
+	* Including a check for ReplaceWall when the tile is a Breakable/CutTile.
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Installed new sprinklers!
+* Fix issue where players could replace tiles with banned tiles without permission. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -259,7 +259,7 @@ namespace TShockAPI
 				int lastKilledProj = args.Player.LastKilledProjectile;
 				ITile tile = Main.tile[tileX, tileY];
 
-				if (action == EditAction.PlaceTile)
+				if (action == EditAction.PlaceTile || action == EditAction.ReplaceTile)
 				{
 					if (TShock.TileBans.TileIsBanned(editData, args.Player))
 					{

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -330,7 +330,7 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.PlaceTile || action == EditAction.PlaceWall)
+				else if (action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall)
 				{
 					if ((action == EditAction.PlaceTile && TShock.Config.PreventInvalidPlaceStyle) &&
 						(MaxPlaceStyles.ContainsKey(editData) && style > MaxPlaceStyles[editData]) &&
@@ -437,7 +437,7 @@ namespace TShockAPI
 				}
 				if (TShock.Config.AllowCutTilesAndBreakables && Main.tileCut[tile.type])
 				{
-					if (action == EditAction.KillWall)
+					if (action == EditAction.KillWall || action == EditAction.ReplaceWall)
 					{
 						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from sts allow cut from {0} {1} {2}", args.Player.Name, action, editData);
 						args.Player.SendTileSquare(tileX, tileY, 1);
@@ -536,7 +536,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
+				if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
 				{
 					args.Player.TilePlaceThreshold++;
 					var coords = new Vector2(tileX, tileY);
@@ -545,7 +545,7 @@ namespace TShockAPI
 							args.Player.TilesCreated.Add(coords, Main.tile[tileX, tileY]);
 				}
 
-				if ((action == EditAction.KillTile || action == EditAction.KillTileNoItem || action == EditAction.KillWall) && Main.tileSolid[Main.tile[tileX, tileY].type] &&
+				if ((action == EditAction.KillTile  || action == EditAction.KillTileNoItem || action == EditAction.ReplaceTile ||  action == EditAction.KillWall || action == EditAction.ReplaceWall) && Main.tileSolid[Main.tile[tileX, tileY].type] &&
 					!args.Player.HasPermission(Permissions.ignorekilltiledetection))
 				{
 					args.Player.TileKillThreshold++;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -358,7 +358,7 @@ namespace TShockAPI
 						}
 					}
 
-					if (editData >= (action == EditAction.PlaceTile ? Main.maxTileSets : Main.maxWallTypes))
+					if (editData >= ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) ? Main.maxTileSets : Main.maxWallTypes))
 					{
 						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (ms3) {0} {1} {2}", args.Player.Name, action, editData);
 						args.Player.SendTileSquare(tileX, tileY, 4);
@@ -536,7 +536,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if ((action == EditAction.PlaceTile || action == EditAction.PlaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
+				if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
 				{
 					args.Player.TilePlaceThreshold++;
 					var coords = new Vector2(tileX, tileY);


### PR DESCRIPTION
Tiny change, but a pressing matter. My smallest PR ever? hahah.
Referencing #2017 , as this patches the tile replace bypass issue that is mentioned.