### PR TITLE
Bouncer OnNewProjectile - Add checks on directional projectiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Installed new sprinklers!
+* Adding checks in Bouncer OnNewProjectile (@Patrikkk):
+	* For valid golf club and golf ball creation.
+	* Renamed stabProjectile to directionalProjectile for a more accurate naming.
+	* Adding staff projectiles to the directionalProjectiles Dictionary to include staffs in the valid projectile creation check.
+	* Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -717,13 +717,30 @@ namespace TShockAPI
 				return;
 			}
 
-			if (stabProjectile.ContainsKey(type))
+			/// If the projectile is a directional projectile, check if the player is holding their respected item to validate the projectile creation.
+			if (directionalProjectiles.ContainsKey(type))
 			{
-				if (stabProjectile[type] == args.Player.TPlayer.HeldItem.type)
+				if (directionalProjectiles[type] == args.Player.TPlayer.HeldItem.type)
 				{
 					args.Handled = false;
 					return;
 				}
+			}
+
+			/// If the created projectile is a golf club, check if the player is holding one of the golf club items to validate the projectile creation.
+			if (type == ProjectileID.GolfClubHelper && Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type))
+			{
+				args.Handled = false;
+				return;
+			}
+
+			/// If the created projectile is a golf ball and the player is not holding a golf club item and neither a golf ball item and neither they have had a golf club projectile created recently.
+			if (Handlers.LandGolfBallInCupHandler.GolfBallProjectileIDs.Contains(type) &&
+				!Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+				!Handlers.LandGolfBallInCupHandler.GolfBallItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+				!args.Player.RecentlyCreatedProjectiles.Any(p => p.Type == ProjectileID.GolfClubHelper))
+			{
+				TShock.Log.ConsoleDebug("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1} (golf)", args.Player.Name, type);
 			}
 
 			// Main.projHostile contains projectiles that can harm players
@@ -2118,9 +2135,33 @@ namespace TShockAPI
 			TileID.Campfire
 		};
 
-		private static Dictionary<int, int> stabProjectile = new Dictionary<int, int>()
+		/// <summary>
+		/// These projectiles have been added or modified with Terraria 1.4.
+		/// They come from normal items, but to have the directional functionality, they must be projectiles.
+		/// </summary>
+		private static Dictionary<int, int> directionalProjectiles = new Dictionary<int, int>()
 		{
-			{ ProjectileID.GladiusStab, ItemID.Gladius },
+			///Spears
+			{ ProjectileID.DarkLance, ItemID.DarkLance},
+			{ ProjectileID.Trident, ItemID.Trident},
+			{ ProjectileID.Spear, ItemID.Spear},
+			{ ProjectileID.MythrilHalberd, ItemID.MythrilHalberd},
+			{ ProjectileID.AdamantiteGlaive, ItemID.AdamantiteGlaive},
+			{ ProjectileID.CobaltNaginata, ItemID.CobaltNaginata},
+			{ ProjectileID.Gungnir, ItemID.Gungnir},
+			{ ProjectileID.MushroomSpear, ItemID.MushroomSpear},
+			{ ProjectileID.TheRottedFork, ItemID.TheRottedFork},
+			{ ProjectileID.PalladiumPike, ItemID.PalladiumPike},
+			{ ProjectileID.OrichalcumHalberd, ItemID.OrichalcumHalberd},
+			{ ProjectileID.TitaniumTrident, ItemID.TitaniumTrident},
+			{ ProjectileID.ChlorophytePartisan, ItemID.ChlorophytePartisan},
+			{ ProjectileID.NorthPoleWeapon, ItemID.NorthPole},
+			{ ProjectileID.ObsidianSwordfish, ItemID.ObsidianSwordfish},
+			{ ProjectileID.Swordfish, ItemID.Swordfish},
+			{ ProjectileID.MonkStaffT2, ItemID.MonkStaffT2},
+			{ ProjectileID.ThunderSpear, ItemID.ThunderSpear},
+			{ ProjectileID.GladiusStab, ItemID.Gladius},
+			/// ShortSwords
 			{ ProjectileID.RulerStab, ItemID.Ruler },
 			{ ProjectileID.CopperShortswordStab, ItemID.CopperShortsword },
 			{ ProjectileID.TinShortswordStab, ItemID.TinShortsword },

--- a/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
+++ b/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
@@ -59,6 +59,26 @@ namespace TShockAPI.Handlers
 			ItemID.GolfClubWedge,
 			ItemID.GolfClubPutter
 		};
+		/// <summary>
+		/// List of golf ball item IDs.
+		/// </summary>
+		public static readonly List<int> GolfBallItemIDs = new List<int>()
+		{
+			ItemID.GolfBall,
+			ItemID.GolfBallDyedBlack,
+			ItemID.GolfBallDyedBlue,
+			ItemID.GolfBallDyedBrown,
+			ItemID.GolfBallDyedCyan,
+			ItemID.GolfBallDyedGreen,
+			ItemID.GolfBallDyedLimeGreen,
+			ItemID.GolfBallDyedOrange,
+			ItemID.GolfBallDyedPink,
+			ItemID.GolfBallDyedPurple,
+			ItemID.GolfBallDyedRed,
+			ItemID.GolfBallDyedSkyBlue,
+			ItemID.GolfBallDyedTeal,
+			ItemID.GolfBallDyedViolet
+		};
 
 		/// <summary>
 		/// Invoked when a player lands a golf ball in a cup.


### PR DESCRIPTION
**This commit does not have any effect on actual gameplay as of current project state, but it does let valid projectile creation pass through instead of getting caught up in Bouncer. That catch is currently disabled for the time being, until all valid projectile creation check is added.**

Things would have get caught up in our bouncer eversince 1.4. We commented out the catch (the disable and handling) for now, but none of these new projectiles were added to let them pass.
Renaming stabProjectile to directionalProjectile. Adding staffs to directionalProjectiles
Adding check for GolfClubHelper projectile.

Left in a debug check for golfball projectile. I would want to see if the reject gets triggered in a proper server enviroment. I didn't want to handle the projectile just yet.
Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs