### PR TITLE
Bouncer OnTileEdit - Code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding staff projectiles to the directionalProjectiles Dictionary to include staffs in the valid projectile creation check.
 	* Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
-* Cleaned up a check in Bouner OnTileEdit where it checks for using the respective item when placing a tile to make it clearer. This change also fixed the issue in a previous commit where valid replace action was caught. Moved the check for max tile/wall types to the beginning of the method.
+* Cleaned up a check in Bouner OnTileEdit where it checks for using the respective item when placing a tile to make it clearer. This change also fixed the issue in a previous commit where valid replace action was caught. Moved the check for max tile/wall types to the beginning of the method. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding staff projectiles to the directionalProjectiles Dictionary to include staffs in the valid projectile creation check.
 	* Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
+* Cleaned up a check in Bouner OnTileEdit where it checks for using the respective item when placing a tile to make it clearer. This change also fixed the issue in a previous commit where valid replace action was caught. Moved the check for max tile/wall types to the beginning of the method.
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -224,9 +224,11 @@ namespace TShockAPI
 
 			try
 			{
-				if (editData < 0)
+				if (editData < 0 ||
+					((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData >= Main.maxTileSets) ||
+					((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData >= Main.maxWallTypes))
 				{
-					TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (editData check) {0} {1} {2}", args.Player.Name, action, editData);
+					TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from editData out of bounds {0} {1} {2}", args.Player.Name, action, editData);
 					args.Player.SendTileSquare(tileX, tileY, 4);
 					args.Handled = true;
 					return;
@@ -342,29 +344,34 @@ namespace TShockAPI
 						return;
 					}
 
-					// If they aren't selecting the item which creates the tile or wall, they're hacking.
-					if (!(selectedItem.netID == ItemID.IceRod && editData == TileID.MagicalIceBlock) &&
-						(editData != (action == EditAction.PlaceTile ? selectedItem.createTile : selectedItem.createWall) &&
-						!(ropeCoilPlacements.ContainsKey(selectedItem.netID) && editData == ropeCoilPlacements[selectedItem.netID])))
+					/// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
+					if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock)
 					{
-						// Rather than attempting to figure out what the above if statement does, we'll just patch it
-						// Adds exception to this check to allow dirt bombs to create dirt tiles
-						if (!(selectedItem.netID == ItemID.DirtBomb && action == EditAction.PlaceTile && editData == TileID.Dirt))
+						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from using ice rod but not placing ice block {0} {1} {2}", args.Player.Name, action, editData);
+						args.Player.SendTileSquare(tileX, tileY, 4);
+						args.Handled = true;
+					}
+					/// If they aren't selecting the item which creates the tile, they're hacking.
+					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
+					{
+						/// These would get caught up in the below check because Terraria does not set their createTile field.
+						if (selectedItem.netID != ItemID.IceRod && selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb)
 						{
-							TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (ms2) {0} {1} {2}", args.Player.Name, action, editData);
+							TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile);
 							args.Player.SendTileSquare(tileX, tileY, 4);
 							args.Handled = true;
 							return;
 						}
 					}
-
-					if (editData >= ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) ? Main.maxTileSets : Main.maxWallTypes))
+					/// If they aren't selecting the item which creates the wall, they're hacking.
+					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
 					{
-						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (ms3) {0} {1} {2}", args.Player.Name, action, editData);
+						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createWall);
 						args.Player.SendTileSquare(tileX, tileY, 4);
 						args.Handled = true;
 						return;
 					}
+
 					if (action == EditAction.PlaceTile && (editData == TileID.PiggyBank || editData == TileID.Safes) && Main.ServerSideCharacter)
 					{
 						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (sscprotect) {0} {1} {2}", args.Player.Name, action, editData);


### PR DESCRIPTION
I moved the block that checks for max tile and wall types to the start of the method where it checks for the editData (type) being smaller than 0.
I merged these checks, so it gets caught under the same hood.

We had a block that was a bit chaotic and hard to understand.
I've split it up so its a bit clearer. It checks if the tile data that is being placed, comes from the item they are selecting. There were additional checks merged in it because terraria does not set the createTile of some items, so without the check it would have gotten caught as invalid placement.
I added a valid placement check for one of these, which is the Ice Rod/Iceblock placement.
Handle action if the player is using icerod but not placing ice block.
There is no need for a check here on Dirtbomb because the player only sends the projectile, the tiles are being placed by the server.