### PR TITLE
Bouncer OnTileEdit - Remove person storage tile check for SSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding staff projectiles to the directionalProjectiles Dictionary to include staffs in the valid projectile creation check.
 	* Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
+* Prevent player placing the Void Vault and Defenders Forge if the server is in SSC mode.(@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 	* Adding staff projectiles to the directionalProjectiles Dictionary to include staffs in the valid projectile creation check.
 	* Adding GolfBallItemIDs list in Handlers.LandGolfBallInCupHandler.cs
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
-* Prevent player placing the Void Vault and Defenders Forge if the server is in SSC mode.(@Patrikkk)
+* Remove checks that prevented people placing personal storage tiles in SSC as the personal storage is synced with the server.(@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -365,14 +365,6 @@ namespace TShockAPI
 						args.Handled = true;
 						return;
 					}
-					if (action == EditAction.PlaceTile && personalStorageTileIDs.Contains(editData) && Main.ServerSideCharacter)
-					{
-						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (sscprotect) {0} {1} {2}", args.Player.Name, action, editData);
-						args.Player.SendErrorMessage("You cannot place this tile because server side characters are enabled.");
-						args.Player.SendTileSquare(tileX, tileY, 3);
-						args.Handled = true;
-						return;
-					}
 					if (action == EditAction.PlaceTile && (editData == TileID.Containers || editData == TileID.Containers2))
 					{
 						if (TShock.Utils.HasWorldReachedMaxChests())
@@ -2133,14 +2125,6 @@ namespace TShockAPI
 			TileID.LunarMonolith,
 			TileID.TargetDummy,
 			TileID.Campfire
-		};
-
-		private static List<int> personalStorageTileIDs = new List<int>()
-		{
-			TileID.PiggyBank,
-			TileID.Safes,
-			TileID.DefendersForge,
-			TileID.VoidVault
 		};
 
 		/// <summary>

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -365,7 +365,7 @@ namespace TShockAPI
 						args.Handled = true;
 						return;
 					}
-					if (action == EditAction.PlaceTile && (editData == TileID.PiggyBank || editData == TileID.Safes) && Main.ServerSideCharacter)
+					if (action == EditAction.PlaceTile && personalStorageTileIDs.Contains(editData) && Main.ServerSideCharacter)
 					{
 						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (sscprotect) {0} {1} {2}", args.Player.Name, action, editData);
 						args.Player.SendErrorMessage("You cannot place this tile because server side characters are enabled.");
@@ -2133,6 +2133,14 @@ namespace TShockAPI
 			TileID.LunarMonolith,
 			TileID.TargetDummy,
 			TileID.Campfire
+		};
+
+		private static List<int> personalStorageTileIDs = new List<int>()
+		{
+			TileID.PiggyBank,
+			TileID.Safes,
+			TileID.DefendersForge,
+			TileID.VoidVault
 		};
 
 		/// <summary>


### PR DESCRIPTION
We do not allow piggybank and safe to be placed if SSC is enabled.
The DefendersFroge and VoidVault have the same functionality as far as I know. So adding these two missing tiles.