### PR TITLE
Bouncer OnTileEdit - Remove redundant Boulder placement check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
 * Fixed the issue where players were unable to place regular ropes because of the valid placement being caught in Bouncer OnTileEdit. (@Patrikkk)
 * Remove checks that prevented people placing personal storage tiles in SSC as the personal storage is synced with the server.(@Patrikkk)
+* Remove redundant Boulder placement check that prevents placing them, as it no longer crashes the server. "1.2.3: Boulders with Chests on them no longer crash the game if the boulder is hit." (@kevzhao2, @Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed an issue in the SendTileSquare handler that was rejecting valid tile objects (@QuiCM)
 * Fixed the issue where players were unable to place regular ropes because of the valid placement being caught in Bouncer OnTileEdit. (@Patrikkk)
 * Remove checks that prevented people placing personal storage tiles in SSC as the personal storage is synced with the server.(@Patrikkk)
-* Remove redundant Boulder placement check that prevents placing them, as it no longer crashes the server. "1.2.3: Boulders with Chests on them no longer crash the game if the boulder is hit." (@kevzhao2, @Patrikkk)
+* Remove redundant Boulder placement check that prevented placing chests on them, as it is no longer possible to place a chest on a boulder, so nothing crashes the server. "1.2.3: Boulders with Chests on them no longer crash the game if the boulder is hit." (@kevzhao2, @Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -377,14 +377,6 @@ namespace TShockAPI
 							args.Handled = true;
 							return;
 						}
-						if ((TShock.Utils.TilePlacementValid(tileX, tileY + 1) && Main.tile[tileX, tileY + 1].type == TileID.Boulder) ||
-							(TShock.Utils.TilePlacementValid(tileX + 1, tileY + 1) && Main.tile[tileX + 1, tileY + 1].type == TileID.Boulder))
-						{
-							TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (validplacement) {0} {1} {2}", args.Player.Name, action, editData);
-							args.Player.SendTileSquare(tileX, tileY, 3);
-							args.Handled = true;
-							return;
-						}
 					}
 				}
 				else if (action == EditAction.PlaceWire || action == EditAction.PlaceWire2 || action == EditAction.PlaceWire3)


### PR DESCRIPTION
Remove redundant Boulder placement check that prevented placing chests on them, as it is no longer possible to place a chest on a boulder in vanilla, so nothing crashes the server. "1.2.3: Boulders with Chests on them no longer crash the game if the boulder is hit."