### PR TITLE
Fix snake charmer's flute and block npc spawnrate change permission error on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming changes
-* Fixed various bugs related to Snake Charmer's Flute. (@rustly)
-	The entirety of the snake now places.
-	The old snake now removes when placing a new snake.
-	Players are no longer disabled for breaking TilePlace/TileKill thresholds when modifying snakes.
+* Fixed various bugs related to Snake Charmer's Flute. (@rustly)  
+	The entirety of the snake now places.  
+	The old snake now removes when placing a new snake.   
+	Players are no longer disabled for breaking TilePlace/TileKill thresholds when modifying snakes.  
 * Prevented players from seeing the npc spawnrate change permission error on join. (@rustly)
 * Installed new sprinklers!
 * Organized parameters by category and relevance in the `config.json` file. (@kubedzero)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming changes
-* Snake charmer's flute should function normally now.
-* Prevented players from seeing the npc spawnrate change permission error on join.
+* Fixed various bugs related to Snake Charmer's Flute. (@rustly)
+	The entirety of the snake now places.
+	The old snake now removes when placing a new snake.
+	Players are no longer disabled for breaking TilePlace/TileKill thresholds when modifying snakes.
+* Prevented players from seeing the npc spawnrate change permission error on join. (@rustly)
 * Installed new sprinklers!
 * Organized parameters by category and relevance in the `config.json` file. (@kubedzero)
 * Fix multiple holes in Bouncer OnTileData. (@Patrikkk, @hakusaro)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed various bugs related to Snake Charmer's Flute. (@rustly)  
-	The entirety of the snake now places.  
-	The old snake now removes when placing a new snake.   
-	Players are no longer disabled for breaking TilePlace/TileKill thresholds when modifying snakes.  
+	* The entirety of the snake now places.  
+	* The old snake now removes when placing a new snake.   
+	* Players are no longer disabled for breaking TilePlace/TileKill thresholds when modifying snakes.  
 * Prevented players from seeing the npc spawnrate change permission error on join. (@rustly)
 * Installed new sprinklers!
 * Organized parameters by category and relevance in the `config.json` file. (@kubedzero)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This is the rolling changelog for TShock for Terraria. Use past tense when adding new entries; sign your name off when you add or change something. This should primarily be things like user changes, not necessarily codebase changes unless it's really relevant or large.
 
 ## Upcoming changes
+* Snake charmer's flute should function normally now.
+* Prevented players from seeing the npc spawnrate change permission error on join.
 * Installed new sprinklers!
 * Organized parameters by category and relevance in the `config.json` file. (@kubedzero)
 * Fix multiple holes in Bouncer OnTileData. (@Patrikkk, @hakusaro)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -295,7 +295,8 @@ namespace TShockAPI
 					}
 					// If the tile is a pickaxe tile and they aren't selecting a pickaxe, they're hacking.
 					// Item frames can be modified without pickaxe tile.
-					else if (tile.type != TileID.ItemFrame
+					//also add an exception for snake coils, they can be removed when the player places a new one or after x amount of time
+					else if (tile.type != TileID.ItemFrame && tile.type != TileID.MysticSnakeRope
 						&& !Main.tileAxe[tile.type] && !Main.tileHammer[tile.type] && tile.wall == 0 && args.Player.TPlayer.mount.Type != 8 && selectedItem.pick == 0 && !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0)
 					{
 						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (pick) {0} {1} {2}", args.Player.Name, action, editData);
@@ -465,7 +466,8 @@ namespace TShockAPI
 					return;
 				}
 
-				if (!args.Player.IsInRange(tileX, tileY))
+				//make sure it isnt a snake coil related edit so it doesnt spam debug logs with range check failures
+				if ((action == EditAction.PlaceTile && editData != TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type != TileID.MysticSnakeRope) && !args.Player.IsInRange(tileX, tileY))
 				{
 					if (action == EditAction.PlaceTile && (editData == TileID.Rope || editData == TileID.SilkRope || editData == TileID.VineRope || editData == TileID.WebRope || editData == TileID.MysticSnakeRope))
 					{
@@ -536,23 +538,27 @@ namespace TShockAPI
 					return;
 				}
 
-				if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
+				//snake coil can allow massive amounts of tile edits so it gets an exception
+				if (!((action == EditAction.PlaceTile && editData == TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type == TileID.MysticSnakeRope)))
 				{
-					args.Player.TilePlaceThreshold++;
-					var coords = new Vector2(tileX, tileY);
-					lock (args.Player.TilesCreated)
-						if (!args.Player.TilesCreated.ContainsKey(coords))
-							args.Player.TilesCreated.Add(coords, Main.tile[tileX, tileY]);
-				}
+					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && !args.Player.HasPermission(Permissions.ignoreplacetiledetection))
+					{
+						args.Player.TilePlaceThreshold++;
+						var coords = new Vector2(tileX, tileY);
+						lock (args.Player.TilesCreated)
+							if (!args.Player.TilesCreated.ContainsKey(coords))
+								args.Player.TilesCreated.Add(coords, Main.tile[tileX, tileY]);
+					}
 
-				if ((action == EditAction.KillTile  || action == EditAction.KillTileNoItem || action == EditAction.ReplaceTile ||  action == EditAction.KillWall || action == EditAction.ReplaceWall) && Main.tileSolid[Main.tile[tileX, tileY].type] &&
-					!args.Player.HasPermission(Permissions.ignorekilltiledetection))
-				{
-					args.Player.TileKillThreshold++;
-					var coords = new Vector2(tileX, tileY);
-					lock (args.Player.TilesDestroyed)
-						if (!args.Player.TilesDestroyed.ContainsKey(coords))
-							args.Player.TilesDestroyed.Add(coords, Main.tile[tileX, tileY]);
+					if ((action == EditAction.KillTile || action == EditAction.KillTileNoItem || action == EditAction.ReplaceTile || action == EditAction.KillWall || action == EditAction.ReplaceWall) && Main.tileSolid[Main.tile[tileX, tileY].type] &&
+						!args.Player.HasPermission(Permissions.ignorekilltiledetection))
+					{
+						args.Player.TileKillThreshold++;
+						var coords = new Vector2(tileX, tileY);
+						lock (args.Player.TilesDestroyed)
+							if (!args.Player.TilesDestroyed.ContainsKey(coords))
+								args.Player.TilesDestroyed.Add(coords, Main.tile[tileX, tileY]);
+					}
 				}
 				args.Handled = false;
 				return;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -467,7 +467,7 @@ namespace TShockAPI
 
 				if (!args.Player.IsInRange(tileX, tileY))
 				{
-					if (action == EditAction.PlaceTile && (editData == TileID.Rope || editData == TileID.SilkRope || editData == TileID.VineRope || editData == TileID.WebRope))
+					if (action == EditAction.PlaceTile && (editData == TileID.Rope || editData == TileID.SilkRope || editData == TileID.VineRope || editData == TileID.WebRope || editData == TileID.MysticSnakeRope))
 					{
 						args.Handled = false;
 						return;
@@ -1644,7 +1644,8 @@ namespace TShockAPI
 			if ((type != TileID.Rope
 					|| type != TileID.SilkRope
 					|| type != TileID.VineRope
-					|| type != TileID.WebRope)
+					|| type != TileID.WebRope
+					|| type != TileID.MysticSnakeRope)
 					&& !args.Player.IsInRange(x, y))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnPlaceObject rejected range checks from {0}", args.Player.Name);

--- a/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativePowerHandler.cs
@@ -56,6 +56,13 @@ namespace TShockAPI.Handlers.NetModules
 
 			string permission = PowerToPermissionMap[powerType];
 
+			//prevent being told about the spawnrate permission on join until relogic fixes
+			if (!player.HasReceivedNPCPermissionError && powerType == CreativePowerTypes.SetSpawnRate)
+			{
+				player.HasReceivedNPCPermissionError = true;
+				return false;
+			}
+
 			if (!player.HasPermission(permission))
 			{
 				player.SendErrorMessage("You do not have permission to {0}.", PermissionToDescriptionMap[permission]);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -112,6 +112,11 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Used in preventing players from seeing the npc spawnrate permission error on join.
+		/// </summary>
+		internal bool HasReceivedNPCPermissionError { get; set; }
+
+		/// <summary>
 		/// The amount of tiles that the player has killed in the last second.
 		/// </summary>
 		public int TileKillThreshold { get; set; }


### PR DESCRIPTION
yes i updated the changelog patrikk
adds various exceptions for tile edits related to snake charmer's flute
prevents players from seeing the npc spawnrate permission error when joining by a bool check
unless im mistaken it fixes #1834. at least it has in my testing
