### PR TITLE
Command.cs - Multiple minor changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed the issue where players were unable to place regular ropes because of the valid placement being caught in Bouncer OnTileEdit. (@Patrikkk)
 * Remove checks that prevented people placing personal storage tiles in SSC as the personal storage is synced with the server.(@Patrikkk)
 * Cleaned up a check in Bouner OnTileEdit where it checks for using the respective item when placing a tile to make it clearer. This change also fixed the issue in a previous commit where valid replace action was caught. Moved the check for max tile/wall types to the beginning of the method. (@Patrikkk)
+* Multiple modifications in Command.cs (@Patrikkk)
+	* `/itemban` - `/projban` - `/tileban` - Added a `default:` case to the commands so an invalid subcommand promts the player to enter the help subcommand to get more information on valid subcommands. (@Patrikkk)
+	* `/world` - Renamed to /worldinfo to be more accurate to it's function. Command now displays the world's `Seed`. Reformatted the world information so each line isn't repeatedly starting with "World". (@Patrikkk)
+	* `/who` - Changed the display format of the online players when the `-i` flag is used. From `PlayerName (ID: 0, ID: 0)` to `PlayerName (Index: 0, Account ID: 0)` for clarification. (@Patrikkk)
 
 ## TShock 4.4.0 (Pre-release 11)
 * New permission `tshock.tp.pylon` to enable teleporting via Teleportation Pylons (@QuiCM)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -521,7 +521,7 @@ namespace TShockAPI
 			{
 				HelpText = "Changes the wind speed."
 			});
-			add(new Command(Permissions.worldinfo, WorldInfo, "world")
+			add(new Command(Permissions.worldinfo, WorldInfo, "worldinfo")
 			{
 				HelpText = "Shows information about the current world."
 			});
@@ -1155,9 +1155,11 @@ namespace TShockAPI
 
 		private static void WorldInfo(CommandArgs args)
 		{
-			args.Player.SendInfoMessage("World name: " + (TShock.Config.UseServerName ? TShock.Config.ServerName : Main.worldName));
-			args.Player.SendInfoMessage("World size: {0}x{1}", Main.maxTilesX, Main.maxTilesY);
-			args.Player.SendInfoMessage("World ID: " + Main.worldID);
+			args.Player.SendInfoMessage("Information of the currently running world");
+			args.Player.SendInfoMessage("Name: " + (TShock.Config.UseServerName ? TShock.Config.ServerName : Main.worldName));
+			args.Player.SendInfoMessage("Size: {0}x{1}", Main.maxTilesX, Main.maxTilesY);
+			args.Player.SendInfoMessage("ID: " + Main.worldID);
+			args.Player.SendInfoMessage("Seed: " + WorldGen.currentWorldSeed);
 		}
 
 		#endregion
@@ -3749,6 +3751,14 @@ namespace TShockAPI
 					}
 					#endregion
 					return;
+				default:
+					#region Default
+					{
+						args.Player.SendErrorMessage("Invalid subcommand! Type {0}itemban help for more information on valid subcommands.", Specifier);
+					}
+					#endregion
+					return;
+
 			}
 		}
 		#endregion Item Management
@@ -3919,6 +3929,13 @@ namespace TShockAPI
 					}
 					#endregion
 					return;
+				default:
+					#region Default
+					{
+						args.Player.SendErrorMessage("Invalid subcommand! Type {0}projban help for more information on valid subcommands.", Specifier);
+					}
+					#endregion
+					return;
 			}
 		}
 		#endregion Projectile Management
@@ -4085,6 +4102,13 @@ namespace TShockAPI
 								FooterFormat = "Type {0}tileban list {{0}} for more.".SFormat(Specifier),
 								NothingToDisplayString = "There are currently no banned tiles."
 							});
+					}
+					#endregion
+					return;
+				default:
+					#region Default
+					{
+						args.Player.SendErrorMessage("Invalid subcommand! Type {0}tileban help for more information on valid subcommands.", Specifier);
 					}
 					#endregion
 					return;
@@ -5066,7 +5090,7 @@ namespace TShockAPI
 				{
 					if (displayIdsRequested)
 					{
-						players.Add(String.Format("{0} (ID: {1}{2})", ply.Name, ply.Index, ply.Account != null ? ", ID: " + ply.Account.ID : ""));
+						players.Add(String.Format("{0} (Index: {1}{2})", ply.Name, ply.Index, ply.Account != null ? ", Account ID: " + ply.Account.ID : ""));
 					}
 					else
 					{


### PR DESCRIPTION
`/itemban` - `/projban` - `/tileban` - Added a `default:` case to the commands so an invalid subcommand prompts the player to enter the help subcommand to get more information on valid subcommands. 

 `/world` - Renamed to /worldinfo to be more accurate to it's function. Command now displays the world's `Seed`. Reformatted the world information so each line isn't repeatedly starting with "World". 

 `/who` - Changed the display format of the online players when the `-i` flag is used. From `PlayerName (ID: 0, ID: 0)` to `PlayerName (Index: 0, Account ID: 0)` for clarification.