### PR TITLE
Missing parenthesis from an if logic. Fix valid Tile placement reject.

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -463,7 +463,7 @@ namespace TShockAPI
 				}
 
 				//make sure it isnt a snake coil related edit so it doesnt spam debug logs with range check failures
-				if ((action == EditAction.PlaceTile && editData != TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type != TileID.MysticSnakeRope) && !args.Player.IsInRange(tileX, tileY))
+				if (((action == EditAction.PlaceTile && editData != TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type != TileID.MysticSnakeRope)) && !args.Player.IsInRange(tileX, tileY))
 				{
 					if (action == EditAction.PlaceTile && (editData == TileID.Rope || editData == TileID.SilkRope || editData == TileID.VineRope || editData == TileID.WebRope || editData == TileID.MysticSnakeRope))
 					{


### PR DESCRIPTION
A previous PR slipped in which missed a parenthesis in an IF logic which used both AND and OR operators, which resulted in valid tile placement being rejected.
No changelog update because this issue did not get into a (pre)release and not something that should be documented.