### PR TITLE
Fix config file access errors when starting up multiple TShock servers at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Added Gravedigger's Shovel support. (@Zennos)
+* You can now start up multiple TShock servers at once without getting a startup error. (@ZakFahey)
 
 ## TShock 4.4.0 (Pre-release 12)
 * Fixed various bugs related to Snake Charmer's Flute. (@rustly)  

--- a/TShockAPI/ConfigFile.cs
+++ b/TShockAPI/ConfigFile.cs
@@ -602,14 +602,21 @@ namespace TShockAPI
 		/// Reads a configuration file from a given path
 		/// </summary>
 		/// <param name="path">string path</param>
-		/// <returns>ConfigFile object</returns>
-		public static ConfigFile Read(string path)
+		/// <param name="path">The path to the config file</param>
+		/// <param name="anyMissingFields">
+		/// Whether the config object has any new files in it, meaning that the config file has to be
+		/// overwritten.
+		/// </param>
+		public static ConfigFile Read(string path, out bool anyMissingFields)
 		{
 			if (!File.Exists(path))
+			{
+				anyMissingFields = true;
 				return new ConfigFile();
+			}
 			using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
 			{
-				return Read(fs);
+				return Read(fs, out anyMissingFields);
 			}
 		}
 
@@ -617,14 +624,17 @@ namespace TShockAPI
 		/// Reads the configuration file from a stream
 		/// </summary>
 		/// <param name="stream">stream</param>
+		/// <param name="anyMissingFields">
+		/// Whether the config object has any new fields in it, meaning that the config file has to be
+		/// overwritten.
+		/// </param>
 		/// <returns>ConfigFile object</returns>
-		public static ConfigFile Read(Stream stream)
+		public static ConfigFile Read(Stream stream, out bool anyMissingFields)
 		{
 			using (var sr = new StreamReader(stream))
 			{
-				var cf = JsonConvert.DeserializeObject<ConfigFile>(sr.ReadToEnd());
-				if (ConfigRead != null)
-					ConfigRead(cf);
+				var cf = FileTools.LoadConfigAndCheckForMissingFields<ConfigFile>(sr.ReadToEnd(), out anyMissingFields);
+				ConfigRead?.Invoke(cf);
 				return cf;
 			}
 		}

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -389,7 +389,7 @@ namespace TShockAPI.DB
 						}
 
 						// Read the config file to prevent the possible loss of any unsaved changes
-						TShock.Config = ConfigFile.Read(FileTools.ConfigPath);
+						TShock.Config = ConfigFile.Read(FileTools.ConfigPath, out bool writeConfig);
 						if (TShock.Config.DefaultGuestGroupName == oldGroup.Name)
 						{
 							TShock.Config.DefaultGuestGroupName = newGroup.Name;
@@ -399,7 +399,10 @@ namespace TShockAPI.DB
 						{
 							TShock.Config.DefaultRegistrationGroupName = newGroup.Name;
 						}
-						TShock.Config.Write(FileTools.ConfigPath);
+						if (writeConfig)
+						{
+							TShock.Config.Write(FileTools.ConfigPath);
+						}
 
 						// We also need to check if any users belong to the old group and automatically apply changes
 						using (var command = db.CreateCommand())

--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -108,7 +108,10 @@ namespace TShockAPI
 				TShock.Config = ConfigFile.Read(ConfigPath);
 				// Add all the missing config properties in the json file
 			}
-			TShock.Config.Write(ConfigPath);
+			else
+			{
+				TShock.Config.Write(ConfigPath);
+			}
 
 			if (File.Exists(ServerSideCharacterConfigPath))
 			{
@@ -127,8 +130,8 @@ namespace TShockAPI
 							new NetItem(-16, 1, 0)
 						}
 				};
+				TShock.ServerSideCharacterConfig.Write(ServerSideCharacterConfigPath);
 			}
-			TShock.ServerSideCharacterConfig.Write(ServerSideCharacterConfigPath);
 		}
 
 		/// <summary>

--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -16,9 +16,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using TShockAPI.ServerSideCharacters;
 
 namespace TShockAPI
@@ -103,23 +107,26 @@ namespace TShockAPI
 			CreateIfNot(MotdPath, MotdFormat);
 						
 			CreateIfNot(WhitelistPath);
+			bool writeConfig = true; // Default to true if the file doesn't exist
 			if (File.Exists(ConfigPath))
 			{
-				TShock.Config = ConfigFile.Read(ConfigPath);
-				// Add all the missing config properties in the json file
+				TShock.Config = ConfigFile.Read(ConfigPath, out writeConfig);
 			}
-			else
+			if (writeConfig)
 			{
+				// Add all the missing config properties in the json file
 				TShock.Config.Write(ConfigPath);
 			}
 
+			bool writeSSCConfig = true; // Default to true if the file doesn't exist
 			if (File.Exists(ServerSideCharacterConfigPath))
 			{
-				TShock.ServerSideCharacterConfig = ServerSideConfig.Read(ServerSideCharacterConfigPath);
-				// Add all the missing config properties in the json file
+				TShock.ServerSideCharacterConfig =
+					ServerSideConfig.Read(ServerSideCharacterConfigPath, out writeSSCConfig);
 			}
-			else
+			if (writeSSCConfig)
 			{
+				// Add all the missing config properties in the json file
 				TShock.ServerSideCharacterConfig = new ServerSideConfig
 				{
 					StartingInventory =
@@ -165,6 +172,31 @@ namespace TShockAPI
 				}
 				return true;
 			}
+		}
+
+		/// <summary>
+		/// Parse some json text and also return whether any fields are missing from the json
+		/// </summary>
+		/// <typeparam name="T">The type of the config file object</typeparam>
+		/// <param name="json">The json text to parse</param>
+		/// <param name="anyMissingFields">Whether any fields are missing from the config</param>
+		/// <returns>The config object</returns>
+		internal static T LoadConfigAndCheckForMissingFields<T>(string json, out bool anyMissingFields)
+		{
+			JObject jObject = JObject.Parse(json);
+
+			anyMissingFields = false;
+			var configFields = new HashSet<string>(typeof(T).GetFields()
+				.Where(field => !field.IsStatic)
+				.Select(field => field.Name));
+			var jsonFields = new HashSet<string>(jObject
+				.Children()
+				.Select(field => field as JProperty)
+				.Where(field => field != null)
+				.Select(field => field.Name));
+			anyMissingFields = !configFields.SetEquals(jsonFields);
+
+			return jObject.ToObject<T>();
 		}
 	}
 }

--- a/TShockAPI/ServerSideCharacters/ServerSideConfig.cs
+++ b/TShockAPI/ServerSideCharacters/ServerSideConfig.cs
@@ -46,13 +46,22 @@ namespace TShockAPI.ServerSideCharacters
 		[Description("The starting default inventory for new SSC.")] 
 		public List<NetItem> StartingInventory = new List<NetItem>();
 
-		public static ServerSideConfig Read(string path)
+		/// <summary>
+		/// Reads a server-side configuration file from a given path
+		/// </summary>
+		/// <param name="path">The path to the config file</param>
+		/// <param name="anyMissingFields">
+		/// Whether the config object has any new fields in it, meaning that the config file has to be
+		/// overwritten.
+		/// </param>
+		/// <returns>ConfigFile object</returns>
+		public static ServerSideConfig Read(string path, out bool anyMissingFields)
 		{
 			using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
 			using (var reader = new StreamReader(fileStream))
 			{
 				string txt = reader.ReadToEnd();
-				var config = JsonConvert.DeserializeObject<ServerSideConfig>(txt);
+				var config = FileTools.LoadConfigAndCheckForMissingFields<ServerSideConfig>(txt, out anyMissingFields);
 				return config;
 			}
 		}

--- a/TShockAPI/ServerSideCharacters/ServerSideConfig.cs
+++ b/TShockAPI/ServerSideCharacters/ServerSideConfig.cs
@@ -48,7 +48,8 @@ namespace TShockAPI.ServerSideCharacters
 
 		public static ServerSideConfig Read(string path)
 		{
-			using (var reader = new StreamReader(path))
+			using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+			using (var reader = new StreamReader(fileStream))
 			{
 				string txt = reader.ReadToEnd();
 				var config = JsonConvert.DeserializeObject<ServerSideConfig>(txt);


### PR DESCRIPTION
Use case would be multi-server networks. This commit ensures that sscconfig.json is read with FileShare.Read enabled and stops writing to config.json and sscconfig.json on server load immediately after reading it if the file already exists, which is a no-op since neither of the config files have changed at that point.