### PR TITLE
Permission added to REST Server Broadcast .

### DIFF
--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -247,7 +247,7 @@ namespace TShockAPI
 			Rest.RegisterRedirect("/groups/update", "/v2/groups/update");
 
 
-			Rest.Register(new SecureRestCommand("/v2/server/broadcast", ServerBroadcast));
+			Rest.Register(new SecureRestCommand("/v2/server/broadcast", ServerBroadcast, RestPermissions.restbroadcast));
 			Rest.Register(new SecureRestCommand("/v3/server/reload", ServerReload, RestPermissions.restcfg));
 			Rest.Register(new SecureRestCommand("/v2/server/off", ServerOff, RestPermissions.restmaintenance));
 			Rest.Register(new SecureRestCommand("/v3/server/rawcmd", ServerCommandV3, RestPermissions.restrawcommand));

--- a/TShockAPI/Rest/RestPermissions.cs
+++ b/TShockAPI/Rest/RestPermissions.cs
@@ -67,6 +67,9 @@ namespace Rests
 		[Description("REST user can reload configurations, save the world and set auto save settings.")]
 		public const string restcfg = "tshock.rest.cfg";
 
+		[Description("REST user can turn off / restart the server.")]
+		public const string restbroadcast = "tshock.rest.broadcast";
+
 		[Description("REST user can kick players.")]
 		public const string restkick = "tshock.rest.kick";
 

--- a/TShockAPI/Rest/RestPermissions.cs
+++ b/TShockAPI/Rest/RestPermissions.cs
@@ -67,7 +67,7 @@ namespace Rests
 		[Description("REST user can reload configurations, save the world and set auto save settings.")]
 		public const string restcfg = "tshock.rest.cfg";
 
-		[Description("REST user can can send server broadcast messages.")]
+		[Description("REST user can send server broadcast messages.")]
 		public const string restbroadcast = "tshock.rest.broadcast";
 
 		[Description("REST user can kick players.")]

--- a/TShockAPI/Rest/RestPermissions.cs
+++ b/TShockAPI/Rest/RestPermissions.cs
@@ -67,7 +67,7 @@ namespace Rests
 		[Description("REST user can reload configurations, save the world and set auto save settings.")]
 		public const string restcfg = "tshock.rest.cfg";
 
-		[Description("REST user can turn off / restart the server.")]
+		[Description("REST user can can send server broadcast messages.")]
 		public const string restbroadcast = "tshock.rest.broadcast";
 
 		[Description("REST user can kick players.")]


### PR DESCRIPTION
Nub trying this again.

**Feature:**
If a REST token is breached, there could be potential spam issues. Where each token perm could pose a potential risk, not having perms on ServerBroadcast makes it an issue if any token is breached. It also gives more control over those that have access to the token.