### PR TITLE
Fix ban system conversion issue with MySQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * This could be you!
 
+## TShock 4.5.0.1
+* Fixed typo in conversion from old to new ban system for MySQL hosted ban databases. (@DeathCradle)
+
 ## TShock 4.5.0
 * Updated OTAPI and TSAPI to Terraria 1.4.2.1. (@Stealownz, @DeathCradle)
 * Updated TShock with preliminary protocol support for Terraria 1.4.2.1. (@Stealownz)

--- a/TShockAPI/DB/BanManager.cs
+++ b/TShockAPI/DB/BanManager.cs
@@ -107,7 +107,7 @@ namespace TShockAPI.DB
 			int res;
 			if (database.GetSqlType() == SqlType.Mysql)
 			{
-				res = database.QueryScalar<int>("SELECT COUNT(name) FROM information_schema.tables WHERE table_schema = @0 and table_name = 'Bans'", TShock.Config.Settings.MySqlDbName);
+				res = database.QueryScalar<int>("SELECT COUNT(table_name) FROM information_schema.tables WHERE table_schema = @0 and table_name = 'Bans'", TShock.Config.Settings.MySqlDbName);
 			}
 			else
 			{

--- a/TShockAPI/Properties/AssemblyInfo.cs
+++ b/TShockAPI/Properties/AssemblyInfo.cs
@@ -53,5 +53,5 @@ using System.Runtime.InteropServices;
 // Also, be sure to release on github with the exact assembly version tag as below
 // so that the update manager works correctly (via the Github releases api and mimic)
 
-[assembly: AssemblyVersion("4.5.0")]
-[assembly: AssemblyFileVersion("4.5.0")]
+[assembly: AssemblyVersion("4.5.0.1")]
+[assembly: AssemblyFileVersion("4.5.0.1")]


### PR DESCRIPTION
DeathCradle spotted a typo in the ban converter and identified that the
issue is likely because we used table_name in some, but not all, of the
conversion SQL.