### PR TITLE
Update /godmode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed server crash from `/v2/players/list` & other parameterised REST endpoints. (@QuiCM, reported by @ATFGK)
 * Added handling to the PlayerChat hook event. (@QuiCM - Thanks for the suggestion @Arthri)
 * Changed the spawnboss command to support silent command specifiers. (@QuiCM, suggested by @nojomyth-dev)
+* Updated /godmode to use Journey Mode's Godmode power instead of healing on damage. (requested by @tlworks, backported by @bartico6, implemented preemptive bugfix for creative powers mentioned by @Stealownz)
 
 ## TShock 4.5.0.1
 * Fixed conversion from old to new ban system for MySQL hosted ban databases. (@DeathCradle, @ATFGK)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -37,6 +37,8 @@ using OTAPI.Tile;
 using TShockAPI.Localization;
 using System.Text.RegularExpressions;
 using Terraria.DataStructures;
+using Terraria.GameContent.Creative;
+using static Terraria.GameContent.Creative.CreativePowers;
 
 namespace TShockAPI
 {
@@ -6444,6 +6446,10 @@ namespace TShockAPI
 			}
 
 			playerToGod.GodMode = !playerToGod.GodMode;
+
+			var god_power = CreativePowerManager.Instance.GetPower<GodmodePower>();
+
+			god_power.SetEnabledState(playerToGod.Index, playerToGod.GodMode);
 
 			if (playerToGod == args.Player)
 			{

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -6469,6 +6469,8 @@ namespace TShockAPI
 			var godPower = CreativePowerManager.Instance.GetPower<CreativePowers.GodmodePower>();
 
 			godPower.SetEnabledState(args.Player.Index, false);
+
+			args.Player.SendSuccessMessage("Journey Godmode has been disabled on your character.");
 		}
 
 		#endregion Cheat Comamnds

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -545,6 +545,11 @@ namespace TShockAPI
 			{
 				HelpText = "Toggles godmode on a player."
 			});
+			add(new Command("", ForceUngod, "ungodme")
+			{
+				HelpText = "Removes godmode from your character.",
+				AllowServer = false
+			});
 			add(new Command(Permissions.heal, Heal, "heal")
 			{
 				HelpText = "Heals a player in HP and MP."
@@ -6450,15 +6455,20 @@ namespace TShockAPI
 
 			godPower.SetEnabledState(playerToGod.Index, playerToGod.GodMode);
 
-			if (playerToGod == args.Player)
-			{
-				args.Player.SendSuccessMessage(string.Format("You are {0} in god mode.", args.Player.GodMode ? "now" : "no longer"));
-			}
-			else
+			if (playerToGod != args.Player)
 			{
 				args.Player.SendSuccessMessage(string.Format("{0} is {1} in god mode.", playerToGod.Name, playerToGod.GodMode ? "now" : "no longer"));
-				playerToGod.SendSuccessMessage(string.Format("You are {0} in god mode.", playerToGod.GodMode ? "now" : "no longer"));
 			}
+
+			playerToGod.SendSuccessMessage(string.Format("You are {0} in god mode.", args.Player.GodMode ? "now" : "no longer"));
+			playerToGod.SendInfoMessage("Please make sure to disable godmode using /ungodme before disconnecting, otherwise your character may remain in godmode indefinitely, including singleplayer.");
+		}
+
+		private static void ForceUngod(CommandArgs args)
+		{
+			var godPower = CreativePowerManager.Instance.GetPower<CreativePowers.GodmodePower>();
+
+			godPower.SetEnabledState(args.Player.Index, false);
 		}
 
 		#endregion Cheat Comamnds

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -38,7 +38,6 @@ using TShockAPI.Localization;
 using System.Text.RegularExpressions;
 using Terraria.DataStructures;
 using Terraria.GameContent.Creative;
-using static Terraria.GameContent.Creative.CreativePowers;
 
 namespace TShockAPI
 {
@@ -6447,9 +6446,9 @@ namespace TShockAPI
 
 			playerToGod.GodMode = !playerToGod.GodMode;
 
-			var god_power = CreativePowerManager.Instance.GetPower<GodmodePower>();
+			var godPower = CreativePowerManager.Instance.GetPower<CreativePowers.GodmodePower>();
 
-			god_power.SetEnabledState(playerToGod.Index, playerToGod.GodMode);
+			godPower.SetEnabledState(playerToGod.Index, playerToGod.GodMode);
 
 			if (playerToGod == args.Player)
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2571,10 +2571,6 @@ namespace TShockAPI
 				args.Player.PlayerData.maxHealth = max;
 			}
 
-			if (args.Player.GodMode && (cur < max))
-			{
-				args.Player.Heal(args.TPlayer.statLifeMax2);
-			}
 			return false;
 		}
 
@@ -3732,12 +3728,6 @@ namespace TShockAPI
 
 			if (OnPlayerDamage(args.Player, args.Data, id, direction, dmg, pvp, crit, playerDeathReason))
 				return true;
-
-			if (TShock.Players[id].GodMode)
-			{
-				TShock.Log.ConsoleDebug("GetDataHandlers / HandlePlayerDamageV2 rejected (god mode on) {0}", args.Player.Name);
-				TShock.Players[id].Heal(args.TPlayer.statLifeMax);
-			}
 
 			return false;
 		}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -44,6 +44,7 @@ using TShockAPI.Sockets;
 using TShockAPI.CLI;
 using TShockAPI.Localization;
 using TShockAPI.Configuration;
+using Terraria.GameContent.Creative;
 
 namespace TShockAPI
 {
@@ -1215,6 +1216,23 @@ namespace TShockAPI
 			}
 
 			Players[args.Who] = null;
+
+			//Reset toggle creative powers to default, preventing potential power transfer & desync on another user occupying this slot later.
+
+			foreach(var kv in CreativePowerManager.Instance._powersById)
+			{
+				var power = kv.Value;
+
+				//No need to reset sliders - those are reset manually by the game, most likely an oversight that toggles don't receive this treatment.
+
+				if (power is CreativePowers.APerPlayerTogglePower toggle)
+				{
+					if (toggle._perPlayerIsEnabled[args.Who] == toggle._defaultToggleState)
+						continue;
+
+					toggle.SetEnabledState(args.Who, toggle._defaultToggleState);
+				}
+			}
 
 			if (tsplr.ReceivedInfo)
 			{


### PR DESCRIPTION
- Previous Bouncer checks for GodMode (namely, Hurt) were removed.
- The command now uses the GodmodePower from core Terraria
- The toggle powers (which this command will now make use of) are now
  reset on disconnect to prevent accidentally "gifting" godmode to an
  unsuspecting player.

I'm the original copyright owner for the code in this commit (it is a backport from Frostspark.Server, which I am the sole author of, as mentioned in #2209)

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->