### PR TITLE
Implement additional teleport permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
+* Added permissions for using Teleportation Potions, Magic Conch, and Demon Conch. (@drunderscore)
+  * `tshock.tp.tppotion`, `tshock.tp.magicconch`, and `tshock.tp.demonconch` respectively.
 
 ## TShock 4.5.2
 * Added preliminary support for Terraria 1.4.2.2. (@hakusaro)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -134,6 +134,7 @@ namespace TShockAPI
 					{ PacketTypes.Teleport, HandleTeleport },
 					{ PacketTypes.PlayerHealOther, HandleHealOther },
 					{ PacketTypes.CatchNPC, HandleCatchNpc },
+					{ PacketTypes.TeleportationPotion, HandleTeleportationPotion },
 					{ PacketTypes.CompleteAnglerQuest, HandleCompleteAnglerQuest },
 					{ PacketTypes.NumberOfAnglerQuestsCompleted, HandleNumberOfAnglerQuestsCompleted },
 					{ PacketTypes.PlaceObject, HandlePlaceObject },
@@ -3470,6 +3471,44 @@ namespace TShockAPI
 				Main.npc[npcID].active = true;
 				NetMessage.SendData((int)PacketTypes.NpcUpdate, -1, -1, NetworkText.Empty, npcID);
 				return true;
+			}
+
+			return false;
+		}
+
+		private static bool HandleTeleportationPotion(GetDataHandlerArgs args)
+		{
+			var type = args.Data.ReadByte();
+
+			void Fail(string tpItem)
+			{
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandleTeleportationPotion rejected permissions {0} {1}", args.Player.Name, type);
+				args.Player.SendErrorMessage("You do not have permission to teleport using {0}.", tpItem);
+			}
+
+			switch (type)
+			{
+				case 0: // Teleportation Potion
+					if (!args.Player.HasPermission(Permissions.tppotion))
+					{
+						Fail("Teleportation Potions");
+						return true;
+					}
+					break;
+				case 1: // Magic Conch
+					if (!args.Player.HasPermission(Permissions.magicconch))
+					{
+						Fail("the Magic Conch");
+						return true;
+					}
+					break;
+				case 2: // Demon Conch
+					if (!args.Player.HasPermission(Permissions.demonconch))
+					{
+						Fail("the Demon Conch");
+						return true;
+					}
+					break;
 			}
 
 			return false;

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -271,6 +271,15 @@ namespace TShockAPI
 
 		[Description("User can use pylons to teleport")]
 		public static readonly string pylon = "tshock.tp.pylon";
+
+		[Description("User can use Teleportation Potions.")]
+		public static readonly string tppotion = "tshock.tp.tppotion";
+
+		[Description("User can use the Magic Conch.")]
+		public static readonly string magicconch = "tshock.tp.magicconch";
+
+		[Description("User can use the Demon Conch.")]
+		public static readonly string demonconch = "tshock.tp.demonconch";
 		#endregion
 
 		#region tshock.world nodes


### PR DESCRIPTION
This adds the follows permissions to the following items:
- `tshock.tp.tppotion` - Teleportation Potion
- `tshock.tp.magicconch` - Magic Conch
- `tshock.tp.demonconch` - Demon Conch