### PR TITLE
Update HealOtherPlayer check to respect ignoredamagecap permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Added permissions for using Teleportation Potions, Magic Conch, and Demon Conch. (@drunderscore)
   * `tshock.tp.tppotion`, `tshock.tp.magicconch`, and `tshock.tp.demonconch` respectively.
+* Updated HealOtherPlayer damage check to make more sense by respecting `ignoredamagecap` permission. (@moisterrific)
 
 ## TShock 4.5.2
 * Added preliminary support for Terraria 1.4.2.2. (@hakusaro)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1603,7 +1603,7 @@ namespace TShockAPI
 			// Why 0.2?
 			// @bartico6: Because heal other player only happens when you are using the spectre armor with the hood,
 			// and the healing you can do with that is 20% of your damage.
-			if (amount >= TShock.Config.Settings.MaxDamage * 0.2 && !args.Player.HasPermission(Permissions.ignoredamagecap)
+			if (amount >= TShock.Config.Settings.MaxDamage * 0.2 && !args.Player.HasPermission(Permissions.ignoredamagecap))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnHealOtherPlayer 0.2 check from {0}", args.Player.Name);
 				args.Player.Disable("HealOtherPlayer cheat attempt!", DisableFlags.WriteToLogAndConsole);

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1603,15 +1603,12 @@ namespace TShockAPI
 			// Why 0.2?
 			// @bartico6: Because heal other player only happens when you are using the spectre armor with the hood,
 			// and the healing you can do with that is 20% of your damage.
-			if (amount >= TShock.Config.Settings.MaxDamage * 0.2)
+			if (amount >= TShock.Config.Settings.MaxDamage * 0.2 && !args.Player.HasPermission(Permissions.ignoredamagecap)
 			{
-				if (!args.Player.HasPermission(Permissions.ignoredamagecap)
-				{
 				TShock.Log.ConsoleDebug("Bouncer / OnHealOtherPlayer 0.2 check from {0}", args.Player.Name);
 				args.Player.Disable("HealOtherPlayer cheat attempt!", DisableFlags.WriteToLogAndConsole);
 				args.Handled = true;
 				return;
-				}
 			}
 
 			if (args.Player.HealOtherThreshold >= TShock.Config.Settings.HealOtherThreshold)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1605,10 +1605,13 @@ namespace TShockAPI
 			// and the healing you can do with that is 20% of your damage.
 			if (amount >= TShock.Config.Settings.MaxDamage * 0.2)
 			{
+				if (!args.Player.HasPermission(Permissions.ignoredamagecap)
+				{
 				TShock.Log.ConsoleDebug("Bouncer / OnHealOtherPlayer 0.2 check from {0}", args.Player.Name);
 				args.Player.Disable("HealOtherPlayer cheat attempt!", DisableFlags.WriteToLogAndConsole);
 				args.Handled = true;
 				return;
+				}
 			}
 
 			if (args.Player.HealOtherThreshold >= TShock.Config.Settings.HealOtherThreshold)


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

This fixes the issue where players with `ignoredamagecap` permission still end up getting disabled when using specific magical weapons and items with the Spectre Hood set. 

I changed the conditional so it only checks if the player is cheating if:
- they exceed the 0.2 healing check
- do not have ignore damage cap permission

?????? HAVE YOU UPDATED THE CHANGELOG? ??????
Yessir