### PR TITLE
Change logpath to `./tshock/logs` by default

### DIFF
--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -41,7 +41,7 @@ namespace TShockAPI.Configuration
 
 		/// <summary>The path to the directory where logs should be written to.</summary>
 		[Description("The path to the directory where logs should be written to.")]
-		public string LogPath = "tshock";
+		public string LogPath = "tshock/logs";
 
 		/// <summary>Whether or not the server should output debug level messages related to system operation.</summary>
 		[Description("Whether or not the server should output debug level messages related to system operation.")]

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -68,7 +68,7 @@ namespace TShockAPI
 		/// <summary>LogFormat - This is the log format, which is never set again.</summary>
 		private static string LogFormat = LogFormatDefault;
 		/// <summary>LogPathDefault - The default log path.</summary>
-		private const string LogPathDefault = "tshock";
+		private const string LogPathDefault = "tshock/logs";
 		/// <summary>This is the log path, which is initially set to the default log path, and then to the config file log path later.</summary>
 		private static string LogPath = LogPathDefault;
 		/// <summary>LogClear - Determines whether or not the log file should be cleared on initialization.</summary>


### PR DESCRIPTION
Implements #2305, but uses `tshock/logs` as the log path, to keep  TShock stuff grouped still