### PR TITLE
minor improvement to stock MOTD behavior

### DIFF
--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -29,7 +29,7 @@ namespace TShockAPI
 	public class FileTools
 	{
 		private const string MotdFormat =
-			"This is [c/FF0000:%map%] on [c/00FFFF:TShock for Terraria].\n[c/00FF00:Current players:] [c/FFFF00:%players%]\nType [c/FF0000:%specifier%help] for a list of commands.\n";
+			"Welcome to [c/ffff00:%map%] on [c/7ddff8:T][c/81dbf6:S][c/86d7f4:h][c/8ad3f3:o][c/8ecef1:c][c/93caef:k] for [c/55d284:T][c/62d27a:e][c/6fd16f:r][c/7cd165:r][c/89d15a:a][c/95d150:r][c/a4d145:i][c/b1d03b:a].\n[c/FFFFFF:Online player(s):] [c/FFFF00:%players%]\nType [c/55D284:%specifier%][c/62D27A:h][c/6FD16F:e][c/7CD165:l][c/89D15A:p] for a list of commands.\n";
 		/// <summary>
 		/// Path to the file containing the rules.
 		/// </summary>

--- a/TShockAPI/FileTools.cs
+++ b/TShockAPI/FileTools.cs
@@ -29,7 +29,7 @@ namespace TShockAPI
 	public class FileTools
 	{
 		private const string MotdFormat =
-			"This is [c/FF0000:%map%] on [c/00FFFF:TShock for Terraria].\n[c/00FF00:Current players:] [c/FFFF00:%players%]\nType [c/FF0000:/help] for a list of commands.\n";
+			"This is [c/FF0000:%map%] on [c/00FFFF:TShock for Terraria].\n[c/00FF00:Current players:] [c/FFFF00:%players%]\nType [c/FF0000:%specifier%help] for a list of commands.\n";
 		/// <summary>
 		/// Path to the file containing the rules.
 		/// </summary>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1509,6 +1509,7 @@ namespace TShockAPI
 
 					foo = foo.Replace("%map%", (TShock.Config.Settings.UseServerName ? TShock.Config.Settings.ServerName : Main.worldName));
 					foo = foo.Replace("%players%", String.Join(",", players));
+					foo = foo.Replace("%specifier%", TShock.Config.Settings.CommandSpecifier);
 
 					SendMessage(foo, lineColor);
 				}


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

Just in case users change the specifier, motd should also reflect any changes if they kept the `/help` line.

?????? HAVE YOU UPDATED THE CHANGELOG? ??????
such a minor change so I didn't bother