### PR TITLE
Fix torchflags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed ridiculous typo in `GetDataHandlers` which caused TShock to read the wrong field in the packet for `usingBiomeTorches`. (@hakusaro, @Arthri)
+* Fixed torchgod settings to include whether or not torchgod has been fought by the player before and respect `usingBiomeTorches` setting. (@Quinci135)
 
 ## TShock 4.5.3
 * Added permissions for using Teleportation Potions, Magic Conch, and Demon Conch. (@drunderscore)

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -56,7 +56,9 @@ namespace TShockAPI.DB
 									 new SqlColumn("skinColor", MySqlDbType.Int32),
 									 new SqlColumn("eyeColor", MySqlDbType.Int32),
 									 new SqlColumn("questsCompleted", MySqlDbType.Int32),
-									 new SqlColumn("unlockedBiomeTorch",  MySqlDbType.Int32)
+									 new SqlColumn("usingBiomeTorches", MySqlDbType.Int32),
+									 new SqlColumn("happyFunTorchTime", MySqlDbType.Int32),
+									 new SqlColumn("unlockedBiomeTorches", MySqlDbType.Int32)
 				);
 			var creator = new SqlTableCreator(db,
 			                                  db.GetSqlType() == SqlType.Sqlite
@@ -109,7 +111,9 @@ namespace TShockAPI.DB
 						playerData.skinColor = TShock.Utils.DecodeColor(reader.Get<int?>("skinColor"));
 						playerData.eyeColor = TShock.Utils.DecodeColor(reader.Get<int?>("eyeColor"));
 						playerData.questsCompleted = reader.Get<int>("questsCompleted");
-						playerData.unlockedBiomeTorches = reader.Get<int>("unlockedBiomeTorch");
+						playerData.usingBiomeTorches = reader.Get<int>("usingBiomeTorches");
+						playerData.happyFunTorchTime = reader.Get<int>("happyFunTorchTime");
+						playerData.unlockedBiomeTorches = reader.Get<int>("unlockedBiomeTorches");
 						return playerData;
 					}
 				}
@@ -176,8 +180,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, unlockedBiomeTorch) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21);",
-						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.unlockedBiomeTorches ? 1 : 0);
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23);",
+						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0);
 					return true;
 				}
 				catch (Exception ex)
@@ -190,8 +194,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, unlockedBiomeTorch = @21 WHERE Account = @5;",
-						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0);
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23 WHERE Account = @5;",
+						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0);
 					return true;
 				}
 				catch (Exception ex)
@@ -246,7 +250,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, unlockedBiomeTorch) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21);",
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23);",
 						player.Account.ID,
 						playerData.health,
 						playerData.maxHealth,
@@ -268,6 +272,8 @@ namespace TShockAPI.DB
 						TShock.Utils.EncodeColor(playerData.skinColor),
 						TShock.Utils.EncodeColor(playerData.eyeColor),
 						playerData.questsCompleted,
+						playerData.usingBiomeTorches,
+						playerData.happyFunTorchTime,
 						playerData.unlockedBiomeTorches);
 					return true;
 				}
@@ -281,7 +287,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, unlockedBiomeTorch = @21 WHERE Account = @5;",
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23 WHERE Account = @5;",
 						playerData.health,
 						playerData.maxHealth,
 						playerData.mana,
@@ -303,6 +309,8 @@ namespace TShockAPI.DB
 						TShock.Utils.EncodeColor(playerData.eyeColor),
 						playerData.questsCompleted,
 						playerData.extraSlot ?? 0,
+						playerData.usingBiomeTorches,
+						playerData.happyFunTorchTime,
 						playerData.unlockedBiomeTorches);
 					return true;
 				}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2305,8 +2305,9 @@ namespace TShockAPI
 					args.Player.TPlayer.hideVisibleAccessory[i+8] = hideVisual2[i];
 				args.Player.TPlayer.hideMisc = hideMisc;
 				args.Player.TPlayer.extraAccessory = extraSlot;
-				args.Player.TPlayer.unlockedBiomeTorches = unlockedBiomeTorches;
 				args.Player.TPlayer.UsingBiomeTorches = usingBiomeTorches;
+				args.Player.TPlayer.happyFunTorchTime = happyFunTorchTime;
+				args.Player.TPlayer.unlockedBiomeTorches = unlockedBiomeTorches;
 
 				NetMessage.SendData((int)PacketTypes.PlayerInfo, -1, args.Player.Index, NetworkText.FromLiteral(args.Player.Name), args.Player.Index);
 				return true;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -49,6 +49,8 @@ namespace TShockAPI
 		public Color? eyeColor;
 		public bool[] hideVisuals;
 		public int questsCompleted;
+		public int usingBiomeTorches;
+		public int happyFunTorchTime = 1;
 		public int unlockedBiomeTorches;
 
 		public PlayerData(TSPlayer player)
@@ -115,6 +117,8 @@ namespace TShockAPI
 			this.skinColor = player.TPlayer.skinColor;
 			this.eyeColor = player.TPlayer.eyeColor;
 			this.questsCompleted = player.TPlayer.anglerQuestsFinished;
+			this.usingBiomeTorches = player.TPlayer.UsingBiomeTorches ? 1 : 0;
+			this.happyFunTorchTime = player.TPlayer.happyFunTorchTime ? 1 : 0;
 			this.unlockedBiomeTorches = player.TPlayer.unlockedBiomeTorches ? 1 : 0;
 
 			Item[] inventory = player.TPlayer.inventory;
@@ -210,6 +214,9 @@ namespace TShockAPI
 			player.sY = this.spawnY;
 			player.TPlayer.hairDye = this.hairDye;
 			player.TPlayer.anglerQuestsFinished = this.questsCompleted;
+			player.TPlayer.UsingBiomeTorches = this.usingBiomeTorches == 1;
+			player.TPlayer.happyFunTorchTime = this.happyFunTorchTime == 1;
+			player.TPlayer.unlockedBiomeTorches = this.unlockedBiomeTorches == 1;
 
 			if (extraSlot != null)
 				player.TPlayer.extraAccessory = extraSlot.Value == 1 ? true : false;
@@ -236,12 +243,6 @@ namespace TShockAPI
 				player.TPlayer.hideVisibleAccessory = this.hideVisuals;
 			else
 				player.TPlayer.hideVisibleAccessory = new bool[player.TPlayer.hideVisibleAccessory.Length];
-
-			if (this.unlockedBiomeTorches != null)
-			{
-				player.TPlayer.unlockedBiomeTorches = this.unlockedBiomeTorches == 1 ? true : false;
-				player.TPlayer.UsingBiomeTorches = this.unlockedBiomeTorches == 1 ? true : false;
-			}
 
 			for (int i = 0; i < NetItem.MaxInventory; i++)
 			{

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -50,7 +50,7 @@ namespace TShockAPI
 		public bool[] hideVisuals;
 		public int questsCompleted;
 		public int usingBiomeTorches;
-		public int happyFunTorchTime = 1;
+		public int happyFunTorchTime;
 		public int unlockedBiomeTorches;
 
 		public PlayerData(TSPlayer player)


### PR DESCRIPTION
Migrated from https://github.com/Quinci135/TShock/commit/8ac4d2e68518d5fd337f1fe5a8a1859420701c22
`UsingBiomeTorches`: Whether or not the player has the torchgod biometorches ability enabled
`HappyFunTorchTime`: Whether or not the player has fought the torchgod before (for logic that checks for torchgod spawning)
`unlockedBiomeTorches`: Whether or not the player has the torchgod biome torches ability unlocked