### PR TITLE
Use Cardinal for danger CI

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,7 +1,7 @@
 name: Danger
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [synchronize, edited, opened, reopened]
 jobs:
   run:
@@ -17,5 +17,5 @@ jobs:
         sudo gem install danger
     - name: Run danger
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.CARDINAL_PAT_CI_STATUS }}
       run: danger


### PR DESCRIPTION
This change uses Cardinal's PAT for GitHub Actions CI. The way this
works is very convoluted, but it makes sense in theory.

1. Cardinal is a member of the Pryaxis org, in a group called "untrusted
   robots." She has write access to Pryaxis/TShock, so she can create
status messages. This is because GitHub only allows status messages to
be created if a user has write access.

2. Cardinal has a PAT, and that PAT only has access to creating
   repository status messages.

3. Danger requires permission to post comments and update CI status.

4. Cardinal's PAT is only authorized to create repo status messages, and
   cannot privilege escalate.

5. GitHub implicitly gives everyone the ability to post comments on
   public repositories.

Thus, this really interesting and weird flow should mean that Cardinal
can post comments and update status messages, by having write access but
functionally being unable to use it.

At least, that's the theory.