### PR TITLE
Move emoji player index check into IllegalPerSe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed torchgod settings to include whether or not torchgod has been fought by the player before and respect `usingBiomeTorches` setting. (@Quinci135)
 * Fixed /worldmode not synchronising data to players after updating the world state (@bartico6, @Arthri)
 * Added `OnSendNetData` hook to TSAPI, which enables developers to intercept traffic being sent from the server to clients. (@Stealownz)
+* Moved the emoji player index check into a new class of handlers called `IllegalPerSe`, which is designed to help isolate parts of TShock and make it so that "protocol violations" are treated separately from heuristic based anti-cheat checks. (@hakusaro)
 
 ## TShock 4.5.3
 * Added permissions for using Teleportation Potions, Magic Conch, and Demon Conch. (@drunderscore)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -36,14 +36,14 @@ namespace TShockAPI
 	/// <summary>Bouncer is the TShock anti-hack and anti-cheat system.</summary>
 	internal sealed class Bouncer
 	{
-		internal Handlers.SendTileRectHandler STSHandler { get; set; }
-		internal Handlers.NetModules.NetModulePacketHandler NetModuleHandler { get; set; }
-		internal Handlers.EmojiHandler EmojiHandler { get; set; }
-		internal Handlers.IllegalPerSe.EmojiPlayerMismatch EmojiPlayerMismatch { get; set; }
-		internal Handlers.DisplayDollItemSyncHandler DisplayDollItemSyncHandler { get; set; }
-		internal Handlers.RequestTileEntityInteractionHandler RequestTileEntityInteractionHandler { get; set; }
-		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; set; }
-		internal Handlers.SyncTilePickingHandler SyncTilePickingHandler { get; set; }
+		internal Handlers.SendTileRectHandler STSHandler { get; private set; }
+		internal Handlers.NetModules.NetModulePacketHandler NetModuleHandler { get; private set; }
+		internal Handlers.EmojiHandler EmojiHandler { get; private set; }
+		internal Handlers.IllegalPerSe.EmojiPlayerMismatch EmojiPlayerMismatch { get; private set; }
+		internal Handlers.DisplayDollItemSyncHandler DisplayDollItemSyncHandler { get; private set; }
+		internal Handlers.RequestTileEntityInteractionHandler RequestTileEntityInteractionHandler { get; private set; }
+		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; private set; }
+		internal Handlers.SyncTilePickingHandler SyncTilePickingHandler { get; private set; }
 
 		/// <summary>Constructor call initializes Bouncer and related functionality.</summary>
 		/// <returns>A new Bouncer.</returns>

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -39,6 +39,7 @@ namespace TShockAPI
 		internal Handlers.SendTileRectHandler STSHandler { get; set; }
 		internal Handlers.NetModules.NetModulePacketHandler NetModuleHandler { get; set; }
 		internal Handlers.EmojiHandler EmojiHandler { get; set; }
+		internal Handlers.IllegalPerSe.EmojiPlayerMismatch EmojiPlayerMismatch { get; set; }
 		internal Handlers.DisplayDollItemSyncHandler DisplayDollItemSyncHandler { get; set; }
 		internal Handlers.RequestTileEntityInteractionHandler RequestTileEntityInteractionHandler { get; set; }
 		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; set; }
@@ -53,6 +54,9 @@ namespace TShockAPI
 
 			NetModuleHandler = new Handlers.NetModules.NetModulePacketHandler();
 			GetDataHandlers.ReadNetModule += NetModuleHandler.OnReceive;
+
+			EmojiPlayerMismatch = new Handlers.IllegalPerSe.EmojiPlayerMismatch();
+			GetDataHandlers.Emoji += EmojiPlayerMismatch.OnReceive;
 
 			EmojiHandler = new Handlers.EmojiHandler();
 			GetDataHandlers.Emoji += EmojiHandler.OnReceive;

--- a/TShockAPI/Handlers/EmojiHandler.cs
+++ b/TShockAPI/Handlers/EmojiHandler.cs
@@ -3,24 +3,17 @@
 namespace TShockAPI.Handlers
 {
 	/// <summary>
-	/// Handles emoji packets and checks for validity and permissions
+	/// Handles emoji packets and checks for permissions
 	/// </summary>
 	public class EmojiHandler : IPacketHandler<EmojiEventArgs>
 	{
 		/// <summary>
-		/// Invoked when an emoji is sent in chat. Rejects the emoji packet if the player is spoofing IDs or does not have emoji permissions
+		/// Invoked when an emoji is sent in chat. Rejects the emoji packet if the player does not have emoji permissions
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
 		public void OnReceive(object sender, EmojiEventArgs args)
 		{
-			if (args.PlayerIndex != args.Player.Index)
-			{
-				TShock.Log.ConsoleError($"EmojiHandler: Emoji packet rejected for ID spoofing. Expected {args.Player.Index}, received {args.PlayerIndex} from {args.Player.Name}.");
-				args.Handled = true;
-				return;
-			}
-
 			if (!args.Player.HasPermission(Permissions.sendemoji))
 			{
 				args.Player.SendErrorMessage("You do not have permission to send emotes!");

--- a/TShockAPI/Handlers/IllegalPerSe/EmojiPlayerMismatch.cs
+++ b/TShockAPI/Handlers/IllegalPerSe/EmojiPlayerMismatch.cs
@@ -1,0 +1,25 @@
+using static TShockAPI.GetDataHandlers;
+
+namespace TShockAPI.Handlers.IllegalPerSe
+{
+	/// <summary>
+	/// Rejects emoji packets with mismatched identifiers
+	/// </summary>
+	public class EmojiPlayerMismatch : IPacketHandler<EmojiEventArgs>
+	{
+		/// <summary>
+		/// Invoked on emoji send. Rejects packets that are impossible.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		public void OnReceive(object sender, EmojiEventArgs args)
+		{
+			if (args.PlayerIndex != args.Player.Index)
+			{
+				TShock.Log.ConsoleError($"IllegalPerSe: Emoji packet rejected for ID spoofing. Expected {args.Player.Index}, received {args.PlayerIndex} from {args.Player.Name}.");
+				args.Handled = true;
+				return;
+			}
+		}
+	}
+}

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Handlers\RequestTileEntityInteractionHandler.cs" />
     <Compile Include="Handlers\SendTileRectHandler.cs" />
     <Compile Include="Handlers\SyncTilePickingHandler.cs" />
+    <Compile Include="Handlers\IllegalPerSe\EmojiPlayerMismatch.cs" />
     <Compile Include="Hooks\AccountHooks.cs" />
     <Compile Include="Hooks\GeneralHooks.cs" />
     <Compile Include="Hooks\PlayerHooks.cs" />


### PR DESCRIPTION
This is the first commit in a pattern that I'd like to follow. The
concept is that we specifically create handlers for things that are
"illegal per se." That is, there are no possible situations (in the
current protocol) where a packet of this type is received from a client.
In this case, I moved the emoji handler out of the Handler just for
emoji, since it seemed like an obvious case.

The rule of thumb is simple: if something is illegal per se, there
should be no possible way in the vanilla client to achieve this result.
If a player sends this combination of packets they *must* be hacking.
Not that there is a 99.9% chance they're hacking, but that there is a
100% unambiguous chance that they're hacking.

Something is illegal per se if it can only be created by a hacked
client. If there's a crashing bug that a normal player can do with a
complex series of vanilla events, that is not illegal per se.

The goal of this namespace and class of handlers is to handle exactly
one type of protocol violation, and remove the packet accordingly. If it
is ever reported that the packet can be sent from a vanilla client, the
check must be removed as it is no longer a per se violation of the
protocol.
