### PR TITLE
Add NuSpec file

### DIFF
--- a/TShockAPI/tshock.nuspec
+++ b/TShockAPI/tshock.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>TShock</id>
+    <title>TShock for Terraria</title>
+    <version>4.5.3-experimental</version>
+    <authors>The TShock Team</authors>
+    <owners>Pryaxis</owners>
+    <license type="expression">GPL-3.0-or-later</license>
+    <projectUrl>https://github.com/Pryaxis/TShock</projectUrl>
+    <repository type="git" url="https://github.com/Pryaxis/TShock.git" branch="general-devel" commit="89555beb7360f9f8b24704c3e52238042db8027c" />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>TShock is a modest, conservative toolbox for Terraria serverside community management.</description>
+    <summary>TShock 4.5.3-experimental for Terraria 1.4.2.3</summary>
+    <releaseNotes>
+      Initial nuget test release ***experimental***
+    </releaseNotes>
+    <copyright>Copyright 2011-2021</copyright>
+    <tags>Terraria,OTAPI,TShock</tags>
+    <dependencies>
+    <group targetFramework=".NETFramework4.5.1">
+      <dependency id="Newtonsoft.Json" version="10.0.3" />
+      <dependency id="BCrypt.Net" version="0.1.0" />
+      <dependency id="MySql.Data" version="6.9.8" />
+      <dependency id="OTAPI" version="2.0.0.43" />
+    </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
*** Experimental ***

As of this commit this NuSpec file is hardcoded to use a sha on gen-dev.

To build/publish:

1. Build TSAPI and TShock locally.
2. `mkdir -p ./package/`
3. `cp TShockAPI/bin/Debug/TShockAPI.dll ./package/lib/net451`
4. `cp TShockAPI/bin/Debug/TShockAPI.XML ./package/lib/net451`
5. `cp TShockAPI/bin/Debug/TShockAPI.pdb ./package/lib/net451`
6. `mono ~/bin/nuget.exe pack TShockAPI/tshock.nuspec -BasePath package`

Now you have a package. To publish, log into GitHub:

    dotnet nuget add source --username urname --password \
    a_github_PAT_with_package_publish_scope \
    --store-password-in-clear-text --name github \
    "https://nuget.pkg.github.com/Pryaxis/index.json"

Next, push:

    dotnet push yourpackage.nupkg --api-key the_PAT_from_before \
    --source "github"

If you didn't get a BadRequest error it means that it's been pushed and
is going to slowly propagate out.

Weird quirks here: This is apparently pointed to a github sha but
definitely still versioned like a normal nuget package. So, no idea how
this will work in practice.

Also, GitHub documentation is terrible about how this works. No idea if
authentication is required to install packages or not. No idea if you
can add this stuff to VS directly or not. No real idea how any of this
works. Also, yes, these instructions are partially dotnet and partially
nuget, and heavily based off of @DeathCradle's workflow for OTAPI.

_this is a draft._

- [ ] Ideally this should be generated/run automatically by github actions (easy to automate in theory)
- [ ] Ideally TSAPI is a nuget package first
- [ ] Ideally sha should be stained somewhere in tshock so that we can actually identify this stuff
