### PR TITLE
Add permission check for summoning Empress of Light + ForceTime check for using Enchanted Sundial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Correct rejection message in LandGolfBallInCupHandler to output the proper expected player id. (@drunderscore)
 * Clarified the error mesage that the console is presented if a rate-limit is reached over REST to indicate that "tokens" actually refers to rate-limit tokens, and not auth tokens, and added a hint as to what config setting determines this. (@hakusaro, @patsore)
 * Fixed an issue where, when the console was redirected, input was disabled and commands didn't work, in TSAPI. You can now pass `-disable-commands` to disable the input thread, but by default, it will be enabled. Fixes [#1450](https://github.com/Pryaxis/TShock/issues/1450). (@DeathCradle, @QuiCM)
+* Added `summonboss` permission check for Prismatic Lacewing. Players who do not have said permission will be unable to kill this critter, as it will summon the Empress of Light. (@moisterrific)
+* Added `ForceTime` config setting check for Enchanted Sundial usage. If `ForceTime` is set to anything other than `normal`, Sundial use will be rejected as this would lead to very janky game behavior. (@moisterrific)
 
 ## TShock 4.5.4
 * Fixed ridiculous typo in `GetDataHandlers` which caused TShock to read the wrong field in the packet for `usingBiomeTorches`. (@hakusaro, @Arthri)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Correct rejection message in LandGolfBallInCupHandler to output the proper expected player id. (@drunderscore)
 * Clarified the error mesage that the console is presented if a rate-limit is reached over REST to indicate that "tokens" actually refers to rate-limit tokens, and not auth tokens, and added a hint as to what config setting determines this. (@hakusaro, @patsore)
 * Fixed an issue where, when the console was redirected, input was disabled and commands didn't work, in TSAPI. You can now pass `-disable-commands` to disable the input thread, but by default, it will be enabled. Fixes [#1450](https://github.com/Pryaxis/TShock/issues/1450). (@DeathCradle, @QuiCM)
-* Added `summonboss` permission check for Prismatic Lacewing. Players who do not have said permission will be unable to kill this critter, as it will summon the Empress of Light. (@moisterrific)
-* Added `ForceTime` config setting check for Enchanted Sundial usage. If `ForceTime` is set to anything other than `normal`, Sundial use will be rejected as this would lead to very janky game behavior. (@moisterrific)
+* Added `summonboss` permission check for Prismatic Lacewing. Players who do not have said permission will be unable to kill this critter, as it will summon the Empress of Light. Also added support for the `AnonymousBossInvasions` config option, if this is set to `false` it will now broadcast the name of the player who summoned her. (@moisterrific)
+* Added `ForceTime` config setting check for Enchanted Sundial usage. If `ForceTime` is set to anything other than `normal`, Sundial use will be rejected as this would lead to very janky game behavior. Additionally, players with `cfgreload` permission will be advised  to change it back to `normal` in order to use sundial. (@moisterrific, @bartico6)
 
 ## TShock 4.5.4
 * Fixed ridiculous typo in `GetDataHandlers` which caused TShock to read the wrong field in the packet for `usingBiomeTorches`. (@hakusaro, @Arthri)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2813,12 +2813,21 @@ namespace TShockAPI
 				return true;
 			}
 			
-			if (Main.npc[id].netID == NPCID.EmpressButterfly && !args.Player.HasPermission(Permissions.summonboss))
+			if (Main.npc[id].netID == NPCID.EmpressButterfly)
 			{
-				args.Player.SendErrorMessage("You do not have permission to summon the Empress of Light.");
-				args.Player.SendData(PacketTypes.NpcUpdate, "", id);
-				TShock.Log.ConsoleDebug($"GetDataHandlers / HandleNpcStrike rejected EoL summon from {args.Player.Name}");
-				return true;
+				if (!args.Player.HasPermission(Permissions.summonboss))
+				{
+					args.Player.SendErrorMessage("You do not have permission to summon the Empress of Light.");
+					args.Player.SendData(PacketTypes.NpcUpdate, "", id);
+					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleNpcStrike rejected EoL summon from {args.Player.Name}");
+					return true;
+				}
+				else if (!TShock.Config.Settings.AnonymousBossInvasions)
+				{
+					TShock.Utils.Broadcast(string.Format($"{args.Player.Name} summoned the Empress of Light!"), 175, 75, 255);
+				}
+				else
+					TShock.Utils.SendLogs(string.Format($"{args.Player.Name} summoned the Empress of Light!"), Color.PaleVioletRed, args.Player);
 			}
 			return false;
 		}
@@ -3214,14 +3223,18 @@ namespace TShockAPI
 				{
 					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission {args.Player.Name}");
 					args.Player.SendErrorMessage("You do not have permission to use the Enchanted Sundial.");
-					return true;
 				}
 				else if (TShock.Config.Settings.ForceTime != "normal")
 				{
-					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission (ForceTime) { args.Player.Name}");
-					args.Player.SendErrorMessage($"You must set ForceTime to normal via config to use the Enchanted Sundial.");
-					return true;
+					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission (ForceTime) {args.Player.Name}");
+					if (!args.Player.HasPermission(Permissions.cfgreload))
+					{
+						args.Player.SendErrorMessage("You cannot use the Enchanted Sundial because time is stopped.");
+					}
+					else
+						args.Player.SendErrorMessage("You must set ForceTime to normal via config to use the Enchanted Sundial.");
 				}
+				return true;
 			}
 
 			return false;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2809,10 +2809,17 @@ namespace TShockAPI
 			{
 				args.Player.SendErrorMessage("You do not have permission to hurt Town NPCs.");
 				args.Player.SendData(PacketTypes.NpcUpdate, "", id);
-				TShock.Log.ConsoleDebug("GetDataHandlers / HandleNpcStrike rejected npc strike {0}", args.Player.Name);
+				TShock.Log.ConsoleDebug($"GetDataHandlers / HandleNpcStrike rejected npc strike {args.Player.Name}");
 				return true;
 			}
-
+			
+			if (Main.npc[id].netID == NPCID.EmpressButterfly && !args.Player.HasPermission(Permissions.summonboss))
+			{
+				args.Player.SendErrorMessage("You do not have permission to summon the Empress of Light.");
+				args.Player.SendData(PacketTypes.NpcUpdate, "", id);
+				TShock.Log.ConsoleDebug($"GetDataHandlers / HandleNpcStrike rejected EoL summon from {args.Player.Name}");
+				return true;
+			}
 			return false;
 		}
 
@@ -3201,11 +3208,20 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (type == 3 && !args.Player.HasPermission(Permissions.usesundial))
+			if (type == 3)
 			{
-				TShock.Log.ConsoleDebug("GetDataHandlers / HandleSpecial rejected enchanted sundial permission {0}", args.Player.Name);
-				args.Player.SendErrorMessage("You do not have permission to use the Enchanted Sundial.");
-				return true;
+				if (!args.Player.HasPermission(Permissions.usesundial))
+				{
+					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission {args.Player.Name}");
+					args.Player.SendErrorMessage("You do not have permission to use the Enchanted Sundial.");
+					return true;
+				}
+				else if (TShock.Config.Settings.ForceTime != "normal")
+				{
+					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission (ForceTime) { args.Player.Name}");
+					args.Player.SendErrorMessage($"You must set ForceTime to normal via config to use the Enchanted Sundial.");
+					return true;
+				}
 			}
 
 			return false;


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

Players without `summonboss` permission should not be able to kill Prismatic Lacewing because this summon the Empress of Light. (Also we won't have to worry about other ways to get around this since EoL can ONLY be summoned if the critter was killed by players)

As for **Enchanted Sundial**, without this check, the game would try to fast forward time and TShock will keep trying to set it back to day (or night), so just use your imagination on how janky this would look lol

?????? HAVE YOU UPDATED THE CHANGELOG? ??????
yes