### PR TITLE
Introduce `SoftcoreOnly` config option to allow only softcore characters to connect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed SendTileRectHandler not sending tile rect updates like Pylons/Mannequins to other clients. (@Stealownz)
+* Introduced `SoftcoreOnly` config option to allow only softcore characters to connect. (@drunderscore)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -133,6 +133,10 @@ namespace TShockAPI.Configuration
 		[Description("Prevents softcore players from connecting.")]
 		public bool MediumcoreOnly;
 
+		/// <summary>Prevents non-softcore players from connecting.</summary>
+		[Description("Prevents non-softcore players from connecting.")]
+		public bool SoftcoreOnly;
+
 		/// <summary>Disables any placing, or removal of blocks.</summary>
 		[Description("Disables any placing, or removal of blocks.")]
 		public bool DisableBuild;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2364,6 +2364,12 @@ namespace TShockAPI
 				NetMessage.SendData((int)PacketTypes.PlayerInfo, -1, args.Player.Index, NetworkText.FromLiteral(args.Player.Name), args.Player.Index);
 				return true;
 			}
+			if (TShock.Config.Settings.SoftcoreOnly && difficulty != 0)
+			{
+				TShock.Log.ConsoleDebug("GetDataHandlers / HandlePlayerInfo rejected softcore required");
+				args.Player.Kick("You need to join with a softcore player.", true, true);
+				return true;
+			}
 			if (TShock.Config.Settings.MediumcoreOnly && difficulty < 1)
 			{
 				TShock.Log.ConsoleDebug("GetDataHandlers / HandlePlayerInfo rejected mediumcore required");


### PR DESCRIPTION
Introduce a configuration option, similar to `MediumcoreOnly` and `HardcoreOnly`, to only allow softcore characters to connect.