### PR TITLE
New config option for disabling Skeletron Prime bombs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed SendTileRectHandler not sending tile rect updates like Pylons/Mannequins to other clients. (@Stealownz)
+* Added a new `DisablePrimeBombs` config option (`false` by default). Highly recommended to set this to `true` in order to prevent griefing on servers doing a `for the worthy` play-through, since the prime bombs on this seed can destroy most tiles and bypass region protection. (@moisterrific)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -156,6 +156,12 @@ namespace TShockAPI.Configuration
 		/// <summary>Disables tombstone dropping during death for all players.</summary>
 		[Description("Disables tombstone dropping during death for all players.")]
 		public bool DisableTombstones = true;
+		
+		/// <summary>
+		/// Disables Skeletron Prime Bombs from spawning, useful for preventing unwanted world destruction on for the worthy seed world.
+		/// </summary>
+		[Description("Disables Skeletron Prime Bombs from spawning, useful for preventing unwanted world destruction on for the worthy seed world.")]
+		public bool DisablePrimeBombs;
 
 		/// <summary>Forces the world time to be normal, day, or night.</summary>
 		[Description("Forces the world time to be normal, day, or night.")]

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1618,13 +1618,13 @@ namespace TShockAPI
 		private void OnProjectileSetDefaults(SetDefaultsEventArgs<Projectile, int> e)
 		{
 			//tombstone fix.
-			if (e.Info == 43 || (e.Info >= 201 && e.Info <= 205) || (e.Info >= 527 && e.Info <= 531))
+			if (e.Info == ProjectileID.Tombstone || (e.Info >= ProjectileID.GraveMarker && e.Info <= ProjectileID.Obelisk) || (e.Info >= ProjectileID.RichGravestone1 && e.Info <= ProjectileID.RichGravestone5))
 				if (Config.Settings.DisableTombstones)
 					e.Object.SetDefaults(0);
-			if (e.Info == 75)
+			if (e.Info == ProjectileID.HappyBomb)
 				if (Config.Settings.DisableClownBombs)
 					e.Object.SetDefaults(0);
-			if (e.Info == 109)
+			if (e.Info == ProjectileID.SnowBallHostile)
 				if (Config.Settings.DisableSnowBalls)
 					e.Object.SetDefaults(0);
 			if (e.Info == ProjectileID.BombSkeletronPrime)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1627,6 +1627,9 @@ namespace TShockAPI
 			if (e.Info == 109)
 				if (Config.Settings.DisableSnowBalls)
 					e.Object.SetDefaults(0);
+			if (e.Info == ProjectileID.BombSkeletronPrime)
+				if (Config.Settings.DisablePrimeBombs)
+					e.Object.SetDefaults(0);
 		}
 
 		/// <summary>NetHooks_SendData - Fired when the server sends data.</summary>


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

Useful for servers doing a `for the worthy` seed play-through since the prime bombs in this world can destroy most blocks and bypass region protection. 

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
