### PR TITLE
Add new respawn command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Fixed SendTileRectHandler not sending tile rect updates like Pylons/Mannequins to other clients. (@Stealownz)
 * Fix some typos that have been in the repository for over a lustrum. (@Killia0)
+* Added a new `/respawn` command that lets you respawn yourself or another player. Respawning yourself requires the `tshock.respawn` permission and respawning others requires the `tshock.respawn.other` permission. The full command syntax is `/respawn [player]`. (@moisterrific)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -5666,6 +5666,11 @@ namespace TShockAPI
 									
 		private static void Respawn(CommandArgs args)
 		{
+			if (!args.Player.RealPlayer)
+			{
+				args.Player.SendErrorMessage("You can't respawn the server console!");
+				return;
+			}
 			TSPlayer playerToRespawn;
 			if (args.Parameters.Count > 0)
 			{
@@ -5681,20 +5686,14 @@ namespace TShockAPI
 					args.Player.SendErrorMessage($"Could not find any player named \"{plStr}\"");
 					return;
 				}
-				else if (players.Count > 1)
+				if (players.Count > 1)
 				{
 					args.Player.SendMultipleMatchError(players.Select(p => p.Name));
 					return;
 				}
-				else
-					playerToRespawn = players[0];
+				playerToRespawn = players[0];
 			}
-			else if (!args.Player.RealPlayer)
-			{
-				args.Player.SendErrorMessage("You can't respawn the server console!");
-				return;
-			}
-			else
+			else 
 				playerToRespawn = args.Player;
 
 			if (!playerToRespawn.Dead)
@@ -5702,8 +5701,7 @@ namespace TShockAPI
 				args.Player.SendErrorMessage($"{(playerToRespawn == args.Player ? "You" : playerToRespawn.Name)} {(playerToRespawn == args.Player ? "are" : "is")} not dead.");
 				return;
 			}
-			else
-				playerToRespawn.Spawn(PlayerSpawnContext.ReviveFromDeath);
+			playerToRespawn.Spawn(PlayerSpawnContext.ReviveFromDeath);
 
 			if (playerToRespawn != args.Player)
 			{

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -436,6 +436,12 @@ namespace TShockAPI
 
 		[Description("User can kill others.")]
 		public static readonly string kill = "tshock.kill";
+		
+		[Description("Player can respawn themselves.")]
+		public static readonly string respawn = "tshock.respawn";
+
+		[Description("Player can respawn others.")]
+		public static readonly string respawnother = "tshock.respawn.other";
 
 		[Description("Allows you to bypass the max slots for up to 5 slots above your max.")]
 		public static readonly string reservedslot = "tshock.reservedslot";


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->

Previously I used `/home` as a way to skip the respawn timer if I wanted, but that's been recently patched to check if the player is dead, I thought there might as well be an actual respawn command. 

## Command info & notes
* `/respawn [player]`
* if no player is specified, it will assume the command user is the target
* this adds two separate permissions `tshock.respawn` and `tshock.respawn.other`
* checks if the player is dead, command only works if the player is actually dead
* code is essentially the same as `/godmode`, just adapted for respawning players

I'll add the new permissions to a stock TShock group later, prob at least admin group or above