### PR TITLE
Fix return for sundial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a new `/respawn` command that lets you respawn yourself or another player. Respawning yourself requires the `tshock.respawn` permission and respawning others requires the `tshock.respawn.other` permission. The full command syntax is `/respawn [player]`. (@moisterrific)
 * Added a notification message and silent command support for permanently changing a target player's user group. Now players who received a group change will be notified of their new group if they are currently online. (@moisterrific, @QuiCM)
 * Changed the TSPlayer IP method to return the loopback IP if RealPlayer is false. (@Rozen4334)
-* Changed return result in ` HandleSpecial ` to fix problem where using sundial would be ignored and return true even if succesfully passing checks. (@Rozen4334)
+* Fixed a bug that caused sundials to be ignored all the time, instead of only when the player has no permission or time is frozen. (@Rozen4334)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a new `/respawn` command that lets you respawn yourself or another player. Respawning yourself requires the `tshock.respawn` permission and respawning others requires the `tshock.respawn.other` permission. The full command syntax is `/respawn [player]`. (@moisterrific)
 * Added a notification message and silent command support for permanently changing a target player's user group. Now players who received a group change will be notified of their new group if they are currently online. (@moisterrific, @QuiCM)
 * Changed the TSPlayer IP method to return the loopback IP if RealPlayer is false. (@Rozen4334)
-* Changed return in ` HandleSpecial ` (GetDataHandlers) to fix Sundial problem. (@Rozen4334)
+* Changed return result in ` HandleSpecial ` to fix problem where using sundial would be ignored and return true even if succesfully passing checks. (@Rozen4334)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a new `/respawn` command that lets you respawn yourself or another player. Respawning yourself requires the `tshock.respawn` permission and respawning others requires the `tshock.respawn.other` permission. The full command syntax is `/respawn [player]`. (@moisterrific)
 * Added a notification message and silent command support for permanently changing a target player's user group. Now players who received a group change will be notified of their new group if they are currently online. (@moisterrific, @QuiCM)
 * Changed the TSPlayer IP method to return the loopback IP if RealPlayer is false. (@Rozen4334)
+* Changed return in ` HandleSpecial ` (GetDataHandlers) to fix Sundail problem. (@Rozen4334)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a new `/respawn` command that lets you respawn yourself or another player. Respawning yourself requires the `tshock.respawn` permission and respawning others requires the `tshock.respawn.other` permission. The full command syntax is `/respawn [player]`. (@moisterrific)
 * Added a notification message and silent command support for permanently changing a target player's user group. Now players who received a group change will be notified of their new group if they are currently online. (@moisterrific, @QuiCM)
 * Changed the TSPlayer IP method to return the loopback IP if RealPlayer is false. (@Rozen4334)
-* Changed return in ` HandleSpecial ` (GetDataHandlers) to fix Sundail problem. (@Rozen4334)
+* Changed return in ` HandleSpecial ` (GetDataHandlers) to fix Sundial problem. (@Rozen4334)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3240,6 +3240,7 @@ namespace TShockAPI
 				{
 					TShock.Log.ConsoleDebug($"GetDataHandlers / HandleSpecial rejected enchanted sundial permission {args.Player.Name}");
 					args.Player.SendErrorMessage("You do not have permission to use the Enchanted Sundial.");
+					return true;
 				}
 				else if (TShock.Config.Settings.ForceTime != "normal")
 				{
@@ -3250,8 +3251,8 @@ namespace TShockAPI
 					}
 					else
 						args.Player.SendErrorMessage("You must set ForceTime to normal via config to use the Enchanted Sundial.");
+					return true;
 				}
-				return true;
 			}
 
 			return false;


### PR DESCRIPTION
Fixed a bug in the handler that handles sundial usage.
This change adjusts the (unintentional) logic from:
* Sundials can never be used

To:
* Sundials can only be used when:
  - The user has permission
  - Time is not frozen