### PR TITLE
Fixed a bug that allowed projectiles out of bounds to be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added a notification message and silent command support for permanently changing a target player's user group. Now players who received a group change will be notified of their new group if they are currently online. (@moisterrific, @QuiCM)
 * Changed the TSPlayer IP method to return the loopback IP if RealPlayer is false. (@Rozen4334)
 * Fixed a bug that caused sundials to be ignored all the time, instead of only when the player has no permission or time is frozen. (@Rozen4334)
+* Fixed a bug in Bouncer's `OnNewProjectile` handler that allowed projectile indexes equal to `Main.maxProjectiles` (which would be out of bounds of `Main.projectiles`) to be created. (@drunderscore)
 
 ## TShock 4.5.5
 * Changed the world autosave message so that it no longer warns of a "potential lag spike." (@hakusaro)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -790,7 +790,7 @@ namespace TShockAPI
 			short type = args.Type;
 			int index = args.Index;
 
-			if (index > Main.maxProjectiles)
+			if (index >= Main.maxProjectiles)
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnNewProjectile rejected from above projectile limit from {0}", args.Player.Name);
 				args.Player.RemoveProjectile(ident, owner);


### PR DESCRIPTION
Because the out of bounds check did not check equality (only greater than-ness), a projectile index of `1000` (the current `Main.maxProjectiles` value) would be allowed, which is out of bounds of `Main.projectiles`.