### PR TITLE
Fix Linux guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
+* Updated Linux guide. (@NezbednikSK)
 * Fixed SendTileRectHandler not sending tile rect updates like Pylons/Mannequins to other clients. (@Stealownz)
 * Introduced `SoftcoreOnly` config option to allow only softcore characters to connect. (@drunderscore)
 * Fixed some typos that have been in the repository for over a lustrum. (@Killia0)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ You need to re-run the patcher any time `OTAPI` updates. You need to rebuild `Te
 
 1. Verify that non-zero modifications ran successfully. Then, build the Terraria Server API executable.
 
-          $ cd ./../../../
+          $ cd ../../../../
           $ xbuild ./TerrariaServerAPI/TerrariaServerAPI/TerrariaServerAPI.csproj \
                 /p:Configuration=$BUILD_MODE
 
@@ -220,13 +220,13 @@ You need to re-run the patcher any time `OTAPI` updates. You need to rebuild `Te
 
 ##### TShock
 
-1. Perform a NuGet restore in `TShockAPI` folder that contains `TShockAPI.sln`.
+1. Perform a NuGet restore in the folder that contains `TShock.sln`.
 
           $ mono ~/bin/nuget.exe restore
 
 1. Build TShock in the `BUILD_MODE` you set earlier.
 
-          $ xbuild ./TShockAPI.sln /p:Configuration=$BUILD_MODE
+          $ xbuild ./TShock.sln /p:Configuration=$BUILD_MODE
 
 You're done!
 


### PR DESCRIPTION
It was missing a dot (didn't navigate to the root of the folder and because of that `TerrariaServerAPI` folder was nowhere to be found) + There is no `TShockAPI.sln`.