### PR TITLE
 Added DataHandler for NpcTalk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## TShock 4.5.12
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)
+* Added hook `GetDataHandlers.OnNpcTalk` for NpcTalk and a handler for it that stopping unregistered and logged out players to interact with NPC, preventing them to smuggling or duplicating items via NPC item slots. (@tru321)
 
 ## TShock 4.5.11
 * Add the new allowed buff TentacleSpike to NPC buff cheat detection bouncer. (@sgkoishi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## TShock 4.5.12
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)
-* Added hook `GetDataHandlers.OnNpcTalk` for NpcTalk and a handler for it that stopping unregistered and logged out players to interact with NPC, preventing them to smuggling or duplicating items via NPC item slots. (@tru321)
+* Added hook `GetDataHandlers.OnNpcTalk` for NpcTalk and a handler for it that stops unregistered and logged out players from interacting with NPCs, preventing them from smuggling or duplicating items via NPC item slots. (@tru321)
 
 ## TShock 4.5.11
 * Add the new allowed buff TentacleSpike to NPC buff cheat detection bouncer. (@sgkoishi)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -1073,11 +1073,12 @@ namespace TShockAPI
 		public class NpcTalkEventArgs : GetDataHandledEventArgs
 		{
 			/// <summary>
-			/// Player Id
+			/// The Terraria ID of the player talking to the NPC
 			/// </summary>
 			public byte PlayerId { get; set; }
+			
 			/// <summary>
-			/// NPC Id player's talk to
+			/// The NPC ID of the NPC the player is talking to
 			/// </summary>
 			public short NPCTalkTarget { get; set; }
 		}
@@ -3145,6 +3146,7 @@ namespace TShockAPI
 
 			if (OnNpcTalk(args.Player, args.Data, plr, npc))
 				return true;
+			
 			//Rejecting player who trying to talk to a npc if player were disabled, mainly for unregistered and logged out players. Preventing smuggling or duplicating their items if player put it in a npc's item slot
 			if (args.Player.IsBeingDisabled())
 			{


### PR DESCRIPTION
This should stopping unregistered and logged out players to interact with NPC. Which prevent them smuggling or duplicating items via NPC items slot.