### PR TITLE
Added check to `HandleNpcTalk` to ensure the passed NPC index is within bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)
 * Added hook `GetDataHandlers.OnNpcTalk` for NpcTalk and a handler for it that stops unregistered and logged out players from interacting with NPCs, preventing them from smuggling or duplicating items via NPC item slots. (@tru321)
 * Fixed the ability to create custom messages with your death (or the death of another player) (@AgaSpace)
+* Added check to `HandleNpcTalk` to ensure the passed NPC index is within bounds (>= -1 && < `Main.maxNPCs`). (@drunderscore)
 
 ## TShock 4.5.11
 * Add the new allowed buff TentacleSpike to NPC buff cheat detection bouncer. (@sgkoishi)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3160,9 +3160,16 @@ namespace TShockAPI
 				TShock.Log.ConsoleDebug("Bouncer / HandleNpcTalk rejected from bouncer throttle from {0}", args.Player.Name);
 				return true;
 			}
+
+			// -1 is a magic value, represents not talking to an NPC
+			if (npc < -1 || npc >= Main.maxNPCs)
+			{
+				TShock.Log.ConsoleDebug("Bouncer / HandleNpcTalk rejected from bouncer out of bounds from {0}", args.Player.Name);
+				return true;
+			}
 			return false;
-		}		
-		
+		}
+
 		private static bool HandlePlayerAnimation(GetDataHandlerArgs args)
 		{
 			if (OnPlayerAnimation(args.Player, args.Data))


### PR DESCRIPTION
NPC index must be `>= -1 && < Main.maxNPCs`.
