### PR TITLE
Corrected customDeathReason in OnPlayerDamage

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2249,6 +2249,8 @@ namespace TShockAPI
 			 * 
 			 * If the player was not specified, that is, the player index is -1, then it is definitely a custom cause, as you can only deal damage with a projectile or another player.
 			 * This is how everything else works. If an NPC is specified, its value is not -1, which is a custom cause.
+			 * 
+			 * Checking whether this damage came from the player is necessary, because the damage from the player can come even when it is hit by a NPC
 			*/
 			if (TShock.Config.Settings.DisableCustomDeathMessages && id != args.Player.Index && 
 				(reason._sourcePlayerIndex == -1 || reason._sourceNPCIndex != -1 || reason._sourceOtherIndex != -1 || reason._sourceCustomReason != null))

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2250,7 +2250,7 @@ namespace TShockAPI
 			 * If the player was not specified, that is, the player index is -1, then it is definitely a custom cause, as you can only deal damage with a projectile or another player.
 			 * This is how everything else works. If an NPC is specified, its value is not -1, which is a custom cause.
 			*/
-			if (TShock.Config.Settings.DisableCustomDeathMessages &&
+			if (TShock.Config.Settings.DisableCustomDeathMessages && id != args.Player.Index && 
 				(reason._sourcePlayerIndex == -1 || reason._sourceNPCIndex != -1 || reason._sourceOtherIndex != -1 || reason._sourceCustomReason != null))
 			{
 				TShock.Log.ConsoleDebug("Bouncer / OnPlayerDamage rejected custom death message from {0}", args.Player.Name);


### PR DESCRIPTION
Previously it was called for absolutely any damage from the player.

