### PR TITLE
Fixed rejection check inside of `HandlePaintTile` when using Paint Sprayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * Do not forget to sign every line you change with your name. (@hakusaro)
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
+## Upcoming changes
+* Fixed rejection check inside of `HandlePaintTile` to account for the Paint Sprayer (or Architect Gizmo Pack) being inside your inventory, rather than on an accessory slot. (@drunderscore)
+
 ## TShock 4.5.12
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)
 * Added hook `GetDataHandlers.OnNpcTalk` for NpcTalk and a handler for it that stops unregistered and logged out players from interacting with NPCs, preventing them from smuggling or duplicating items via NPC item slots. (@tru321)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3549,6 +3549,11 @@ namespace TShockAPI
 				return true;
 			}
 
+			bool hasPaintSprayerAbilities(Item item) =>
+				item != null
+				&& item.stack > 0
+				&& (item.type == ItemID.PaintSprayer || item.type == ItemID.ArchitectGizmoPack);
+
 			// Not selecting paintbrush or paint scraper or the spectre versions? Hacking.
 			if (args.Player.SelectedItem.type != ItemID.PaintRoller &&
 				args.Player.SelectedItem.type != ItemID.PaintScraper &&
@@ -3556,8 +3561,8 @@ namespace TShockAPI
 				args.Player.SelectedItem.type != ItemID.SpectrePaintRoller &&
 				args.Player.SelectedItem.type != ItemID.SpectrePaintScraper &&
 				args.Player.SelectedItem.type != ItemID.SpectrePaintbrush &&
-				!args.Player.Accessories.Any(i => i != null && i.stack > 0 &&
-					(i.type == ItemID.PaintSprayer || i.type == ItemID.ArchitectGizmoPack)))
+				!args.Player.Accessories.Any(hasPaintSprayerAbilities) &&
+				!args.Player.Inventory.Any(hasPaintSprayerAbilities))
 			{
 				TShock.Log.ConsoleDebug("GetDataHandlers / HandlePaintTile rejected select consistency {0}", args.Player.Name);
 				args.Player.SendData(PacketTypes.PaintTile, "", x, y, Main.tile[x, y].color());

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -899,6 +899,18 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Gets the player's inventory (first 5 rows)
+		/// </summary>
+		public IEnumerable<Item> Inventory
+		{
+			get
+			{
+				for (int i = 0; i < 50; i++)
+					yield return TPlayer.inventory[i];
+			}
+		}
+
+		/// <summary>
 		/// Gets the player's accessories.
 		/// </summary>
 		public IEnumerable<Item> Accessories


### PR DESCRIPTION
The check inside of `HandlePaintTile` did not account for the Paint Sprayer or Architect Gizmo Pack being inside your inventory, which works identically to it being on an accessory slot.

I've been told before to name local methods in lowerCamelCase, so that's what I've done here for `hasPaintSprayerAbilities`

Closes #2486