### PR TITLE
Add lanterns night event to `/worldevent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Added hook `GetDataHandlers.OnReleaseNpc` to handling ReleaseNPC packet and a bouncer to stops unregistered and logged out players on SSC servers from releasing critters NPC. The bouncer has additional filter to stops players who tried to release different critter using crafted packet, e.g. using bunny item to release golden bunny. (@tru321)
 * Added filter in `GetDataHandlers.HandleCatchNpc` that stops unregistered and logged out players on SSC servers to catch critters. (@tru321)
-* Added the lanterns night event to the `/worldmode` command. (@0x3fcf1bbd)
-
-## Upcoming changes
 * Fixed rejection check inside of `HandlePaintTile` to account for the Paint Sprayer (or Architect Gizmo Pack) being inside your inventory, rather than on an accessory slot. (@drunderscore)
+* Added the lanterns night event to the `/worldevent` command. (@0x3fcf1bbd)
 
 ## TShock 4.5.12
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Added hook `GetDataHandlers.OnReleaseNpc` to handling ReleaseNPC packet and a bouncer to stops unregistered and logged out players on SSC servers from releasing critters NPC. The bouncer has additional filter to stops players who tried to release different critter using crafted packet, e.g. using bunny item to release golden bunny. (@tru321)
 * Added filter in `GetDataHandlers.HandleCatchNpc` that stops unregistered and logged out players on SSC servers to catch critters. (@tru321)
+* Added the lanterns night event to the `/worldmode` command. (@0x3fcf1bbd)
 
 ## Upcoming changes
 * Fixed rejection check inside of `HandlePaintTile` to account for the Paint Sprayer (or Architect Gizmo Pack) being inside your inventory, rather than on an accessory slot. (@drunderscore)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2165,6 +2165,7 @@ namespace TShockAPI
 					if (!args.Player.HasPermission(Permissions.managelanternsnightevent))
 					{
 						FailedPermissionCheck();
+						return;
 					}
 					LanternsNight(args);
 					return;

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2388,7 +2388,15 @@ namespace TShockAPI
 		private static void LanternsNight(CommandArgs args)
 		{
 			LanternNight.ToggleManualLanterns();
-			args.Player.SendInfoMessage("{0}ed a lantern night.", LanternNight.LanternsUp ? "Start" : "Stop");
+			string msg = $" st{(LanternNight.LanternsUp ? "art" : "opp")}ed a lantern night.";
+			if (args.Silent)
+			{
+				args.Player.SendInfoMessage("You" + msg);
+			}
+			else
+			{
+				TSPlayer.All.SendInfoMessage(args.Player.Name + msg);
+			}
 		}
 
 		private static void ClearAnglerQuests(CommandArgs args)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2060,7 +2060,8 @@ namespace TShockAPI
 			"eclipse",
 			"invasion",
 			"sandstorm",
-			"rain"
+			"rain",
+			"lanternsnight"
 		};
 		static readonly List<string> _validInvasions = new List<string>()
 		{
@@ -2157,6 +2158,15 @@ namespace TShockAPI
 						return;
 					}
 					Rain(args);
+					return;
+
+				case "lanternsnight":
+				case "lanterns":
+					if (!args.Player.HasPermission(Permissions.managelanternsnightevent))
+					{
+						FailedPermissionCheck();
+					}
+					LanternsNight(args);
 					return;
 
 				default:
@@ -2372,6 +2382,12 @@ namespace TShockAPI
 				TSPlayer.All.SendInfoMessage("{0} caused it to rain.", args.Player.Name);
 				return;
 			}
+		}
+
+		private static void LanternsNight(CommandArgs args)
+		{
+			LanternNight.ToggleManualLanterns();
+			args.Player.SendInfoMessage("{0}ed a lantern night.", LanternNight.LanternsUp ? "Start" : "Stop");
 		}
 
 		private static void ClearAnglerQuests(CommandArgs args)

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -307,6 +307,9 @@ namespace TShockAPI
 		[Description("User can use the 'rain' subcommand of the 'worldevent' command")]
 		public static readonly string managerainevent = "tshock.world.events.rain";
 
+		[Description("User can use the 'lanternsnight' subcommand of the 'worldevent' command")]
+		public static readonly string managelanternsnightevent = "tshock.world.events.lanternsnight";
+
 		[Description("User can change expert state.")]
 		public static readonly string toggleexpert = "tshock.world.toggleexpert";
 


### PR DESCRIPTION
This event has been there for a long time in vanilla by now, but was surprisingly forgotten, even though it is a nice event.
This should add basic enough functionality for users to be able to toggle the event.
Didn't know under which "Upcoming changes" header the changelog should have been put, defaulted to top one.
Please do tell if something was forgotten for this PR, as it is my first one here.