### PR TITLE
Remove extraneous space in README.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added filter in `GetDataHandlers.HandleCatchNpc` that stops unregistered and logged out players on SSC servers to catch critters. (@tru321)
 * Fixed rejection check inside of `HandlePaintTile` to account for the Paint Sprayer (or Architect Gizmo Pack) being inside your inventory, rather than on an accessory slot. (@drunderscore)
 * Added the lanterns night event to the `/worldevent` command. (@0x3fcf1bbd)
+* Removed extraneous space causing build commands in README to fail. (@EtherTyper)
 
 ## TShock 4.5.12
 * Fixed the ability to spawn Zenith projectile with non-original items. (@AgaSpace)
@@ -23,7 +24,6 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed the ability to create custom messages with your death (or the death of another player) (@AgaSpace)
 * Added the `OnSignRead` handler in `GetDataHandler`, and added the `SignRead` event. Added check to ensure the sign being read is within world bounds `(x >= 0 && y >= 0 && x < Main.maxTilesX && y < Main.maxTilesY)`. (@drunderscore)
 * Added check to `HandleNpcTalk` to ensure the passed NPC index is within bounds (>= -1 && < `Main.maxNPCs`). (@drunderscore)
-* Removed extraneous space causing build commands in README to fail. (@EtherTyper)
 
 ## TShock 4.5.11
 * Add the new allowed buff TentacleSpike to NPC buff cheat detection bouncer. (@sgkoishi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed the ability to create custom messages with your death (or the death of another player) (@AgaSpace)
 * Added the `OnSignRead` handler in `GetDataHandler`, and added the `SignRead` event. Added check to ensure the sign being read is within world bounds `(x >= 0 && y >= 0 && x < Main.maxTilesX && y < Main.maxTilesY)`. (@drunderscore)
 * Added check to `HandleNpcTalk` to ensure the passed NPC index is within bounds (>= -1 && < `Main.maxNPCs`). (@drunderscore)
+* Removed extraneous space causing build commands in README to fail. (@EtherTyper)
 
 ## TShock 4.5.11
 * Add the new allowed buff TentacleSpike to NPC buff cheat detection bouncer. (@sgkoishi)

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You need to re-run the patcher any time `OTAPI` updates. You need to rebuild `Te
 
           $ cd ./TerrariaServerAPI/TShock.Modifications.Bootstrapper/bin/$BUILD_MODE/
           $ mono TShock.Modifications.Bootstrapper.exe -in=OTAPI.dll \
-                -mod=../../../TShock.Modifications.**/bin/$BUILD_MODE/TShock.Modifications.*.dll \ 
+                -mod=../../../TShock.Modifications.**/bin/$BUILD_MODE/TShock.Modifications.*.dll \
                 -o=Output/OTAPI.dll
 
 1. Verify that non-zero modifications ran successfully. Then, build the Terraria Server API executable.


### PR DESCRIPTION
Remove space following backslash in multi-line command, which caused the command to be interpreted as two and fail in `GNU bash, version 5.1.16(1)-release (x86_64-apple-darwin21.1.0)`.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
