### PR TITLE
Fix `NetHooks_NameCollision` to kick duplicate players.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
+* Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)
 * You could be here!
 
 ## TShock 4.5.16

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -521,7 +521,7 @@ namespace TShockAPI
 			{
 				if (player.IP == ip)
 				{
-					player.Kick("You logged in from the same IP.", true, true, "Server", true);
+					player.Kick("You logged in from the same IP.", true, true, null, true);
 					args.Handled = true;
 					return;
 				}
@@ -530,7 +530,7 @@ namespace TShockAPI
 					var ips = JsonConvert.DeserializeObject<List<string>>(player.Account.KnownIps);
 					if (ips.Contains(ip))
 					{
-						player.Kick("You logged in from another location.", true, true, "Server", true);
+						player.Kick("You logged in from another location.", true, true, null, true);
 						args.Handled = true;
 					}
 				}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -521,7 +521,7 @@ namespace TShockAPI
 			{
 				if (player.IP == ip)
 				{
-					Netplay.Clients[player.Index].PendingTermination = true;
+					player.Kick("You logged in from the same IP.", true, true, "Server", true);
 					args.Handled = true;
 					return;
 				}
@@ -530,7 +530,7 @@ namespace TShockAPI
 					var ips = JsonConvert.DeserializeObject<List<string>>(player.Account.KnownIps);
 					if (ips.Contains(ip))
 					{
-						Netplay.Clients[player.Index].PendingTermination = true;
+						player.Kick("You logged in from another location.", true, true, "Server", true);
 						args.Handled = true;
 					}
 				}
@@ -1279,7 +1279,7 @@ namespace TShockAPI
 
 			//Reset toggle creative powers to default, preventing potential power transfer & desync on another user occupying this slot later.
 
-			foreach(var kv in CreativePowerManager.Instance._powersById)
+			foreach (var kv in CreativePowerManager.Instance._powersById)
 			{
 				var power = kv.Value;
 


### PR DESCRIPTION
This PR fixes connections being stuck in a limbo where `PendingTermination` is `true` but `PendingTerminationApproved` is `false`. This problem occurs after a name collision.

The server doesn't fully try to reset the existing player's socket, creating the situation where the existing player is still present in the server but cannot interact with it due to `Player.PendingTermination` being `true`. SSC characters are not properly handled in this situation due to SSC not being saved unless the existing player disconnects first. I handled this by just kicking the player ensuring that `saveSSI` is set to `true`.

Fixes issue #2530. 