### PR TITLE
Fix mobs not dropping picked up coins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)
-* Fixed mobs not dropping picked up coins (@gohjoseph)
+* Fixed mobs not dropping picked up coins. (@gohjoseph)
 * You could be here!
 
 ## TShock 4.5.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)
+* Fixed mobs not dropping picked up coins (@gohjoseph)
 * You could be here!
 
 ## TShock 4.5.16

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3958,7 +3958,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			return true;
+			return false;
 		}
 
 		private static bool HandleKillPortal(GetDataHandlerArgs args)


### PR DESCRIPTION
This PR will not set `SyncExtraValue` packets from clients as handled. This allows mobs to pick up coins as intended in expert mode and master mode. It was previously set as handled before to prevent platinum coins from duplicating. However, it seems the issue with platinum coins has not gone away since that change.

Fixes #2546 