### PR TITLE
Fix `GiveItem` not working if the player is in lava

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
+* Fix `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
-* Fix `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
+* Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1380,7 +1380,9 @@ namespace TShockAPI
 		public virtual void GiveItem(int type, int stack, int prefix = 0)
 		{
 			int itemIndex = Item.NewItem(new EntitySource_DebugCommand(), (int)X, (int)Y, TPlayer.width, TPlayer.height, type, stack, true, prefix, true);
-			SendData(PacketTypes.ItemDrop, "", itemIndex);
+			Main.item[itemIndex].playerIndexTheItemIsReservedFor = this.Index;
+			SendData(PacketTypes.ItemDrop, "", itemIndex, 1);
+			SendData(PacketTypes.ItemOwner, null, itemIndex);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The flammable items incinerate in lava if you do `/i 2` while in lava (dirt blocks are flammable).
This PR fixes the problem by setting item owner so that the game doesn't burn the item immediately.

P.S. I stumbled across this fix. Not sure of the working mechanism behind it.