### PR TITLE
Only allow using Teleportation Potion and friends whilst holding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
   * If there is no section called "Upcoming changes" below this line, please add one with `## Upcoming changes` as the first line, and then a bulleted item directly after with the first change.
 
 ## Upcoming changes
+* Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3814,6 +3814,13 @@ namespace TShockAPI
 			switch (type)
 			{
 				case 0: // Teleportation Potion
+					if (args.Player.ItemInHand.type != ItemID.TeleportationPotion &&
+					    args.Player.SelectedItem.type != ItemID.TeleportationPotion)
+					{
+						TShock.Log.ConsoleDebug("GetDataHandlers / HandleTeleportationPotion rejected not holding the correct item {0} {1}", args.Player.Name, type);
+						return true;
+					}
+
 					if (!args.Player.HasPermission(Permissions.tppotion))
 					{
 						Fail("Teleportation Potions");
@@ -3821,6 +3828,13 @@ namespace TShockAPI
 					}
 					break;
 				case 1: // Magic Conch
+					if (args.Player.ItemInHand.type != ItemID.MagicConch &&
+					    args.Player.SelectedItem.type != ItemID.MagicConch)
+					{
+						TShock.Log.ConsoleDebug("GetDataHandlers / HandleTeleportationPotion rejected not holding the correct item {0} {1}", args.Player.Name, type);
+						return true;
+					}
+
 					if (!args.Player.HasPermission(Permissions.magicconch))
 					{
 						Fail("the Magic Conch");
@@ -3828,6 +3842,13 @@ namespace TShockAPI
 					}
 					break;
 				case 2: // Demon Conch
+					if (args.Player.ItemInHand.type != ItemID.DemonConch &&
+					    args.Player.SelectedItem.type != ItemID.DemonConch)
+					{
+						TShock.Log.ConsoleDebug("GetDataHandlers / HandleTeleportationPotion rejected not holding the correct item {0} {1}", args.Player.Name, type);
+						return true;
+					}
+
 					if (!args.Player.HasPermission(Permissions.demonconch))
 					{
 						Fail("the Demon Conch");


### PR DESCRIPTION
Some simple protections against using these when you shouldn't be able to!