### PR TITLE
Arm64 implementation for Raspberry PI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes (TShock 5.0.0)
 * Reduced load/save console spam. (@SignatureBeef, @YehnBeep)
+* Replaced SQLite library with Microsoft.Data.Sqlite for arm64 support (@SignatureBeef)
 
 ## Upcoming changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 
 ## Upcoming changes (TShock 5.0.0)
 * Reduced load/save console spam. (@SignatureBeef, @YehnBeep)
-* Replaced SQLite library with Microsoft.Data.Sqlite for arm64 support (@SignatureBeef)
+* Replaced SQLite library with Microsoft.Data.Sqlite for arm64 support. (@SignatureBeef)
 
 ## Upcoming changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes (TShock 5.0.0)
 * Reduced load/save console spam. (@SignatureBeef, @YehnBeep)
 * Replaced SQLite library with Microsoft.Data.Sqlite for arm64 support. (@SignatureBeef)
+* Initial support for MonoMod hooks on Raspberry Pi (arm64). (@kevzhao2)
 
 ## Upcoming changes
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -258,9 +258,6 @@ namespace TShockAPI
 				//TShock handles this
 				args.Result = OTAPI.Hooks.NetMessage.PlayerAnnounceResult.None;
 			};
-			// if sqlite.interop cannot be found, try and search the runtimes folder. this usually happens when debugging tsapi
-			// since it does not have the dependency installed directly
-			NativeLibrary.SetDllImportResolver(typeof(Microsoft.Data.Sqlite.SqliteConnection).Assembly, ResolveNativeDep);
 
 			Main.SettingsUnlock_WorldEvil = true;
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -28,7 +28,6 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using MaxMind;
-using System.Data.SQLite;
 using MySql.Data.MySqlClient;
 using Newtonsoft.Json;
 using Rests;
@@ -261,7 +260,7 @@ namespace TShockAPI
 			};
 			// if sqlite.interop cannot be found, try and search the runtimes folder. this usually happens when debugging tsapi
 			// since it does not have the dependency installed directly
-			NativeLibrary.SetDllImportResolver(typeof(SQLiteConnection).Assembly, ResolveNativeDep);
+			NativeLibrary.SetDllImportResolver(typeof(Microsoft.Data.Sqlite.SqliteConnection).Assembly, ResolveNativeDep);
 
 			Main.SettingsUnlock_WorldEvil = true;
 
@@ -322,7 +321,7 @@ namespace TShockAPI
 				{
 					string sql = Path.Combine(SavePath, Config.Settings.SqliteDBPath);
 					Directory.CreateDirectory(Path.GetDirectoryName(sql));
-					DB = new SQLiteConnection(string.Format("Data Source={0},Version=3", sql));
+					DB = new Microsoft.Data.Sqlite.SqliteConnection(string.Format("Data Source={0}", sql));
 				}
 				else if (Config.Settings.StorageType.ToLower() == "mysql")
 				{
@@ -441,8 +440,16 @@ namespace TShockAPI
 			}
 			catch (Exception ex)
 			{
-				Log.ConsoleError("Fatal Startup Exception");
-				Log.ConsoleError(ex.ToString());
+				if (Log is not null)
+				{
+					Log.ConsoleError("Fatal Startup Exception");
+					Log.ConsoleError(ex.ToString());
+				}
+				else
+				{
+					Console.WriteLine("Fatal Startup Exception");
+					Console.WriteLine(ex.ToString());
+				}
 				Environment.Exit(1);
 			}
 		}

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
-    <PackageReference Include="MySql.Data" Version="8.0.27" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="MySql.Data" Version="8.0.28" />
     <PackageReference Include="SQLite" Version="3.13.0" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
   </ItemGroup>

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -30,8 +30,7 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="MySql.Data" Version="8.0.28" />
-    <PackageReference Include="SQLite" Version="3.13.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TShockLauncher.Tests/TShockLauncher.Tests.csproj
+++ b/TShockLauncher.Tests/TShockLauncher.Tests.csproj
@@ -7,10 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -16,15 +16,15 @@
 		<ProjectReference Include="..\TerrariaServerAPI\TerrariaServerAPI\TerrariaServerAPI.csproj" ExcludeFromSingleFile="true" />
 		<ProjectReference Include="..\TShockAPI\TShockAPI.csproj" ExcludeFromSingleFile="true" Condition="'$(PublishSingleFile)' == 'true'" />
 		<ProjectReference Include="..\TShockAPI\TShockAPI.csproj" ReferenceOutputAssembly="false" Condition="'$(PublishSingleFile)' != 'true'" />
-		<Reference Include="HttpServer" ExcludeFromSingleFile="true" >
+		<Reference Include="HttpServer" ExcludeFromSingleFile="true">
 			<HintPath>..\prebuilts\HttpServer.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>
 		<!-- match tshocks dependencies so that publishing outputs all files to ./bin -->
-		<PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
-		<PackageReference Include="MySql.Data" Version="8.0.27" />
+		<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+		<PackageReference Include="MySql.Data" Version="8.0.28" />
 		<PackageReference Include="SQLite" Version="3.13.0" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
 	</ItemGroup>

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -25,8 +25,7 @@
 		<!-- match tshocks dependencies so that publishing outputs all files to ./bin -->
 		<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
 		<PackageReference Include="MySql.Data" Version="8.0.28" />
-		<PackageReference Include="SQLite" Version="3.13.0" />
-		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.3" />
 	</ItemGroup>
 	
 	<Target Name="MoveTShockDebug" AfterTargets="FinalCleanup;PostBuildEvent">


### PR DESCRIPTION
This PR bumps all dependencies to their latest, and in particular MonoMod for its new Arm64 support for raspberry pi thanks to @kevzhao2. 

I have also changed the SQLite library to use Microsoft.Data.Sqlite as it works out of the box for Arm64, so there is a slight change for the QueryResult to dispose of the command instead of disposing of it preemptively.

_Note: apple silicon is not included in this, [yet](https://github.com/MonoMod/MonoMod/issues/90).
Note 2: i didn't bother adding arm64 support to the changelog, since it already has the expectation of working for the current gen-dev, but i'm happy to do so as kev's work does need some praise._

![Screen Shot 2022-03-27 at 9 37 46 pm](https://user-images.githubusercontent.com/776327/160279845-fe702082-0454-4d71-8559-a9f6bbacd7da.png)
