### PR TITLE
More correctly implement GPLv3 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 ## Upcoming changes
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 * Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
+* Updated GNU GPL disclaimer when the server starts to say that it comes with `ABSOLUTELY NO WARRANTY` and added a link to the GPL as per what the license requires. (@hakusaro)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -380,8 +380,8 @@ namespace TShockAPI
 				Initialized?.Invoke();
 
 				Log.ConsoleInfo("Welcome to TShock for Terraria!");
-				Log.ConsoleInfo("TShock comes with no warranty & is free software.");
-				Log.ConsoleInfo("You can modify & distribute it under the terms of the GNU GPLv3.");
+				Log.ConsoleInfo("TShock is free, and comes with ABSOLUTELY NO WARRANTY.");
+				Log.ConsoleInfo("You can modify & distribute it under GPLv3 or later, see: https://www.gnu.org/licenses/.");
 
 			}
 			catch (Exception ex)


### PR DESCRIPTION
The previous startup disclaimer probably didn't do a good-enough job of
explaining license terms to people. This updates it emphasizing that
there is no warranty with the software, and that the actual license is
GPL v3 or later, not GPL v3. Further, since we don't ship the license
with the software (yet), this gives people a link to the license. The
license itself says we should provide a link if we don't, so yeah.

Inspired by the fact that we had another user pop into discord asking
why all of their stuff was deleted.

I tried to keep the startup disclaimer roughly-the-same-size as the
original disclaimer (no more than 3 lines, some-ish length), because
this is so annoying but I feel like we actually need to try to be
compliant here.

I'm 60% sure we should implement a command that explains this but I
really don't want to do that.