### PR TITLE
Fixed Bouncer possibly rejecting Explosive Bunny critter releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 * Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
 * Updated server startup language to be more clear when encountering a fatal startup error. Now, the server gives more context as to what happened so that there's a better chance of people being able to help themselves. (@hakusaro)
+* Fixed Bouncer rejecting Explosive Bunny critter release when using the Bunny Cannon, if the player had since stopped selecting the Explosive Bunny. (@drunderscore)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)


### PR DESCRIPTION
Fixes #2616

When using a Bunny Cannon, an Explosive Bunny item (which is also a
critter release item) is used to create an Explosive Bunny projectile,
which will later (in the future) release an Explosive Bunny NPC, by the
release critter packet. The existing checks required that the player be
actively selecting the item to create the critter, however this didn't
make sense for Explosive Bunnies, as they would be released in the
future, possibly when the player was no longer selecting that item.

This commit relaxes the restrictions on Explosive Bunny critter
releases, now requiring either holding the release item, or having
recently created an Explosive Bunny projectile, and that the release
coordinates are within the area of one of their Explosive Bunny
projectiles.