### PR TITLE
More robust parsing of large timespans (Fixes #2625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 * Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
 * Updated server startup language to be more clear when encountering a fatal startup error. Now, the server gives more context as to what happened so that there's a better chance of people being able to help themselves. (@hakusaro)
+* Added a second `Utils.TryParseTime` method for parsing large, positive time spans. (@punchready)
+* Fixed `/tempgroup` breaking on durations greater than roughly 24 days. (@punchready)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1512,7 +1512,7 @@ namespace TShockAPI
 					}
 				}
 
-				if (TShock.Utils.TryParseTime(duration, out int seconds))
+				if (TShock.Utils.TryParseTime(duration, out ulong seconds))
 				{
 					expiration = DateTime.UtcNow.AddSeconds(seconds);
 				}
@@ -1880,7 +1880,7 @@ namespace TShockAPI
 
 			if (args.Parameters.Count > 2)
 			{
-				int time;
+				ulong time;
 				if (!TShock.Utils.TryParseTime(args.Parameters[2], out time))
 				{
 					args.Player.SendErrorMessage("Invalid time string! Proper format: _d_h_m_s, with at least one time specifier.");
@@ -1888,7 +1888,7 @@ namespace TShockAPI
 					return;
 				}
 
-				ply[0].tempGroupTimer = new System.Timers.Timer(time * 1000);
+				ply[0].tempGroupTimer = new System.Timers.Timer(time * 1000d);
 				ply[0].tempGroupTimer.Elapsed += ply[0].TempGroupTimerElapsed;
 				ply[0].tempGroupTimer.Start();
 			}

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -608,6 +608,82 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Attempts to parse a string as a positive timespan (_d_m_h_s).
+		/// </summary>
+		/// <param name="str">The time string.</param>
+		/// <param name="seconds">The seconds.</param>
+		/// <returns>Whether the string was parsed successfully.</returns>
+		public bool TryParseTime(string str, out ulong seconds)
+		{
+			seconds = 0;
+
+			if (string.IsNullOrWhiteSpace(str))
+			{
+				return false;
+			}
+
+			var sb = new StringBuilder(3);
+			for (int i = 0; i < str.Length; i++)
+			{
+				if (char.IsDigit(str[i]) || (str[i] == '-' || str[i] == '+' || str[i] == ' '))
+					sb.Append(str[i]);
+				else
+				{
+					int num;
+					if (!int.TryParse(sb.ToString().Trim(' '), out num))
+						return false;
+
+					sb.Clear();
+
+					if (num == 0)
+					{
+						continue;
+					}
+
+					int numSeconds;
+					switch (str[i])
+					{
+						case 's':
+							numSeconds = num;
+							break;
+						case 'm':
+							numSeconds = num * 60;
+							break;
+						case 'h':
+							numSeconds = num * 60 * 60;
+							break;
+						case 'd':
+							numSeconds = num * 60 * 60 * 24;
+							break;
+						default:
+							return false;
+					}
+
+					if (numSeconds > 0)
+					{
+						if (ulong.MaxValue - seconds < (uint)numSeconds)
+						{
+							return false;
+						}
+
+						seconds += (uint)numSeconds;
+					}
+					else if (seconds >= (uint)Math.Abs(numSeconds))
+					{
+						seconds -= (uint)Math.Abs(numSeconds);
+					}
+					else
+					{
+						return false;
+					}
+				}
+			}
+			if (sb.Length != 0)
+				return false;
+			return true;
+		}
+
+		/// <summary>
 		/// Searches for a projectile by identity and owner
 		/// </summary>
 		/// <param name="identity">identity</param>

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -574,7 +574,7 @@ namespace TShockAPI
 			var sb = new StringBuilder(3);
 			for (int i = 0; i < str.Length; i++)
 			{
-				if (Char.IsDigit(str[i]) || (str[i] == '-' || str[i] == '+' || str[i] == ' '))
+				if (char.IsDigit(str[i]) || str[i] == '-' || str[i] == '+' || str[i] == ' ')
 					sb.Append(str[i]);
 				else
 				{
@@ -625,7 +625,7 @@ namespace TShockAPI
 			var sb = new StringBuilder(3);
 			for (int i = 0; i < str.Length; i++)
 			{
-				if (char.IsDigit(str[i]) || (str[i] == '-' || str[i] == '+' || str[i] == ' '))
+				if (char.IsDigit(str[i]) || str[i] == '-' || str[i] == '+' || str[i] == ' ')
 					sb.Append(str[i]);
 				else
 				{


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->

Added a robust parsing method for positive timespans using an `ulong`.
Commands that parse timespans now support up to `9999999` days.
The old method must stay unmodified for compatibility, other plugins can upgrade manually if needed.

Fixes #2625