### PR TITLE
World Evil Startup Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
 * Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
 * Updated server startup language to be more clear when encountering a fatal startup error. Now, the server gives more context as to what happened so that there's a better chance of people being able to help themselves. (@hakusaro)
+* Added `-worldevil <type>` command line argument (@NotGeri)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -768,6 +768,28 @@ namespace TShockAPI
 						}
 					})
 
+				.AddFlag("-worldevil", (value) =>
+				{
+
+					int worldEvil;
+					switch (value.ToLower())
+					{
+						case "random":
+							worldEvil = -1;
+							break;
+						case "corrupt":
+							worldEvil = 0;
+							break;
+						case "crimson":
+							worldEvil = 1;
+							break;
+						default:
+							throw new InvalidOperationException("Invalid value given for command line argument \"-worldevil\".");
+					}
+
+					ServerApi.LogWriter.PluginWriteLine(this, String.Format("New worlds will be generated with the {0} world evil type!", value), TraceLevel.Verbose);
+					WorldGen.WorldGenParam_Evil = worldEvil;
+				})
 
 				//Flags without arguments
 				.AddFlag("-logclear", () => LogClear = true)


### PR DESCRIPTION
# Story

Since [#1396](https://github.com/Pryaxis/TShock/pull/1396), people could pick their world evil type when a new world is created without having the necessary in game progression. 

We automatically generate worlds using `-autogenerate` as we use an interface for the size, seed and other properties of worlds. This meant we'd have either needed to use some hacky standard input way of piping in the desired world evil type or create a feature request here.

The prior is less than ideal for several reasons so I decided to give this a shot. 

With this change, adding a simple startup parameter, `-worldevil <crimson|corruption|random>` should achieve what we wanted and hopefully, other people having this issue can use this as well!

Closes [#2631](https://github.com/Pryaxis/TShock/issues/2631).

---

# Testing
I wasn't too confident using Terraria's built in features like this so I did a few tests to see if my changes worked and it seems like they do.

Once I managed to finally build the project locally, I simply did:

```bash
./TerrariaServer.exe -autocreate 1 -worldname <name> -worldpath ./worlds/ -world ./worlds/ -worldevil <setting>
```

Replacing `<name>` with something like `corruption_test_2` incrementing it each time and replacing `<setting>` with `crimson`, `corrupt` or `random` depending on what I wanted to achieve. 

**Results**: Everything seemed to generate perfectly. In-game venturing out for a few moments always showed the correct biome and copying over the world file to single-player showed the correct icons as well: https://i.geri.dev/vuoSLNPUO42X.gif

---

Please do let me know if I should change anything!