### PR TITLE
Prevent server broadcast to accept empty message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Updated server startup language to be more clear when encountering a fatal startup error. Now, the server gives more context as to what happened so that there's a better chance of people being able to help themselves. (@hakusaro)
 * Added `-worldevil <type>` command line argument (@NotGeri)
 * Added PlayerHasBuildPermission hook to PlayerHooks. (@AnzhelikaO, @Killia0)
+* Prevent Server Broadcast to display prefix without a message. (@PackmanDude)
 
 ## TShock 4.5.17
 * Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1955,12 +1955,15 @@ namespace TShockAPI
 
 		private static void Broadcast(CommandArgs args)
 		{
-			string message = string.Join(" ", args.Parameters);
+			if (args.Count > 0)
+			{
+				string message = string.Join(" ", args.Parameters);
 
-			TShock.Utils.Broadcast(
-				"(Server Broadcast) " + message,
-				Convert.ToByte(TShock.Config.Settings.BroadcastRGB[0]), Convert.ToByte(TShock.Config.Settings.BroadcastRGB[1]),
-				Convert.ToByte(TShock.Config.Settings.BroadcastRGB[2]));
+				TShock.Utils.Broadcast(
+					"(Server Broadcast) " + message,
+					Convert.ToByte(TShock.Config.Settings.BroadcastRGB[0]), Convert.ToByte(TShock.Config.Settings.BroadcastRGB[1]),
+					Convert.ToByte(TShock.Config.Settings.BroadcastRGB[2]));
+			}
 		}
 
 		private static void Off(CommandArgs args)


### PR DESCRIPTION
If used without a parameter, the /broadcast, /bc or /say command will display `(Server Broadcast) ` only. This PR fixes that and prevents Super Admins from spamming into chat with an empty sentences.