### PR TITLE
Use a string interpolation and escape single quotes when escaping tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Added preliminary support for Terraria 1.4.4.4. (@SignatureBeef)
 * GrassSpreadEventArgs Color property has been changed from a Byte to a TileColorCache type. (@SignatureBeef)
 * SetDefaultsEventArgs now includes a nullable ItemVariant instance. (@SignatureBeef)
+* Use a string interpolation and escape single quotes when escaping tables (@drunderscore)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)

--- a/TShockAPI/DB/IQueryBuilder.cs
+++ b/TShockAPI/DB/IQueryBuilder.cs
@@ -172,7 +172,7 @@ namespace TShockAPI.DB
 		/// <returns></returns>
 		protected override string EscapeTableName(string table)
 		{
-			return table.SFormat("'{0}'", table);
+			return $"\'{table}\'";
 		}
 	}
 


### PR DESCRIPTION
This should have previously caused issues, but it didn't, and now it does.
Modernize it by using a string interpolation, and properly escaping the single quotes (which you apparently have to do?)

This was noticed when implementing #2675, as the TShock database was regenerated with the new SSC columns, but occasionally failed because of the lack of escapes.