### PR TITLE
Fix #2674 - Change the use of current directory to match the server a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * SetDefaultsEventArgs now includes a nullable ItemVariant instance. (@SignatureBeef)
 * Use a string interpolation and escape single quotes when escaping tables (@drunderscore)
 * Removed obsolete resource files `TShockAPI/Resources.resx` and `TShockAPI/Resources.Designer.cs`. (@Arthri)
+* Plugins and ./bin dependencies are now loaded relative to the launcher, this improves the use of startup files (@SignatureBeef)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)

--- a/TShockLauncher/Program.cs
+++ b/TShockLauncher/Program.cs
@@ -42,7 +42,7 @@ Assembly? Default_Resolving(System.Runtime.Loader.AssemblyLoadContext arg1, Asse
 	if (arg2?.Name is null) return null;
 	if (_cache.TryGetValue(arg2.Name, out Assembly? asm) && asm is not null) return asm;
 
-	var loc = Path.Combine(Environment.CurrentDirectory, "bin", arg2.Name + ".dll");
+	var loc = Path.Combine(AppContext.BaseDirectory, "bin", arg2.Name + ".dll");
 	if (File.Exists(loc))
 		asm = arg1.LoadFromAssemblyPath(loc);
 


### PR DESCRIPTION
…ssembly location

This will allow dependencies to be resolved beside the assembly as intended when startup scripts are used outside the working directory. I am not sure why or how many people would do this, as TSAPI wont load plugins (existing issue), but this is a step in the direction of opening up to allow considerations for that.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
