### PR TITLE
Fix hard/mediumcore ban on death when settings are enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * SetDefaultsEventArgs now includes a nullable ItemVariant instance. (@SignatureBeef)
 * Use a string interpolation and escape single quotes when escaping tables (@drunderscore)
 * Removed obsolete resource files `TShockAPI/Resources.resx` and `TShockAPI/Resources.Designer.cs`. (@Arthri)
+* Fixed hardcore and mediumcore not banning on death when settings are enabled. This also alters the TSPlayer.Ban method to remove the force option which is no longer needed. (@SignatureBeef)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4157,7 +4157,7 @@ namespace TShockAPI
 
 				if (shouldBan)
 				{
-					if (!args.Player.Ban(banReason, false, "TShock"))
+					if (!args.Player.Ban(banReason, "TShock"))
 					{
 						TShock.Log.ConsoleDebug("GetDataHandlers / HandlePlayerKillMeV2 kicked with difficulty {0} {1}", args.Player.Name, args.TPlayer.difficulty);
 						args.Player.Kick("You died! Normally, you'd be banned.", true, true);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1701,30 +1701,26 @@ namespace TShockAPI
 		/// Bans and disconnects the player from the server.
 		/// </summary>
 		/// <param name="reason">The reason to be displayed to the server.</param>
-		/// <param name="force">If the ban should bypass immunity to ban checks.</param>
 		/// <param name="adminUserName">The player who initiated the ban.</param>
-		public bool Ban(string reason, bool force = false, string adminUserName = null)
+		public bool Ban(string reason, string adminUserName = null)
 		{
 			if (!ConnectionAlive)
 				return true;
-			if (force)
-			{
-				TShock.Bans.InsertBan($"{Identifier.IP}{IP}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
-				TShock.Bans.InsertBan($"{Identifier.UUID}{UUID}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
-				if (Account != null)
-				{
-					TShock.Bans.InsertBan($"{Identifier.Account}{Account.Name}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
-				}
 
-				Disconnect(string.Format("Banned: {0}", reason));
-				string verb = force ? "force " : "";
-				if (string.IsNullOrWhiteSpace(adminUserName))
-					TSPlayer.All.SendInfoMessage("{0} was {1}banned for '{2}'.", Name, verb, reason);
-				else
-					TSPlayer.All.SendInfoMessage("{0} {1}banned {2} for '{3}'.", adminUserName, verb, Name, reason);
-				return true;
+			TShock.Bans.InsertBan($"{Identifier.IP}{IP}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
+			TShock.Bans.InsertBan($"{Identifier.UUID}{UUID}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
+			if (Account != null)
+			{
+				TShock.Bans.InsertBan($"{Identifier.Account}{Account.Name}", reason, adminUserName, DateTime.UtcNow, DateTime.MaxValue);
 			}
-			return false;
+
+			Disconnect(string.Format("Banned: {0}", reason));
+
+			if (string.IsNullOrWhiteSpace(adminUserName))
+				TSPlayer.All.SendInfoMessage("{0} was banned for '{1}'.", Name, reason);
+			else
+				TSPlayer.All.SendInfoMessage("{0} banned {1} for '{2}'.", adminUserName, Name, reason);
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->

This removes the `force` parameter in the `TSPlayer.Ban` method that is no longer required, as it was never proceeding with the ban.
Aims to fix #2651 

![Screen Shot 2022-10-07 at 6 46 57 pm](https://user-images.githubusercontent.com/776327/194512830-8ca48c52-6111-4899-9972-dcd6056bf1a9.png)
