### PR TITLE
 Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed painting wall/tile being rejected from hand of creation. (@Rozen4334)
 * Added a second `Utils.TryParseTime` method for parsing large, positive time spans. (@punchready)
 * Fixed `/tempgroup` breaking on durations greater than roughly 24 days. (@punchready)
+* Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players (@drunderscore)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1739,7 +1739,8 @@ namespace TShockAPI
 				if (npc.townNPC && npc.netID != NPCID.Guide && npc.netID != NPCID.Clothier)
 				{
 					if (type != BuffID.Lovestruck && type != BuffID.Stinky && type != BuffID.DryadsWard &&
-						type != BuffID.Wet && type != BuffID.Slimed && type != BuffID.GelBalloonBuff && type != BuffID.Frostburn2)
+						type != BuffID.Wet && type != BuffID.Slimed && type != BuffID.GelBalloonBuff && type != BuffID.Frostburn2 &&
+						type != BuffID.Shimmer)
 					{
 						detectedNPCBuffTimeCheat = true;
 					}
@@ -2529,7 +2530,9 @@ namespace TShockAPI
 			{ BuffID.OnFire3, 360 },                // BuffID: 323
 			{ BuffID.Frostburn2, 900 },             // BuffID: 324
 			{ BuffID.BoneWhipNPCDebuff, 240 },      // BuffID: 326
-			{ BuffID.TentacleSpike, 540 }           // BuffID: 337
+			{ BuffID.TentacleSpike, 540 },          // BuffID: 337
+			{ BuffID.BloodButcherer, 540 },         // BuffID: 344
+			{ BuffID.Shimmer, 100 },		// BuffID: 353
 		};
 
 		/// <summary>


### PR DESCRIPTION
See: https://terraria.wiki.gg/wiki/Blood_Butcherer

Edit: Shimmer is applied by players to NPCs for 100 ticks, each tick the NPC is in the liquid. It is also done by multiple players at once.