### PR TITLE
Update Github CI to not tarball artifacts for Windows only

### DIFF
--- a/.github/workflows/ci-otapi3.yml
+++ b/.github/workflows/ci-otapi3.yml
@@ -44,12 +44,22 @@ jobs:
             chmod +x TShockLauncher/bin/Release/net6.0/${{ matrix.arch }}/publish/TShock.Server
 
       # preserve file perms: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
-      - name: Archive artifact
+      - name: Tarball artifact (non-Windows)
+        if: ${{ matrix.arch != 'win-x64' }}
         run: |
             cd TShockLauncher/bin/Release/net6.0/${{ matrix.arch }}/publish/
             tar -cvf ../../../../../../TShock-Beta-${{ matrix.arch }}-Release.tar *
 
-      - uses: actions/upload-artifact@v3
+      - name: Upload artifact (non-Windows)
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.arch != 'win-x64' }}
         with:
           name: TShock-Beta-${{ matrix.arch }}-Release
           path: TShock-Beta-${{ matrix.arch }}-Release.tar
+
+      - name: Upload artifact (Windows)
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.arch == 'win-x64' }}
+        with:
+          name: TShock-Beta-${{ matrix.arch }}-Release
+          path: TShockLauncher/bin/Release/net6.0/${{ matrix.arch }}/publish/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Fixed `/tempgroup` breaking on durations greater than roughly 24 days. (@punchready)
 * Fixed player not being checked for permissions to use the Shellphone (Ocean), Shellphone (Underworld) and Shellphone (Spawn). (@hufang360)
 * Updated to OTAPI 3.1.10-alpha, which allows FreeBSD .NET 6 to use Re-Logic's Linux platform. (@SignatureBeef)
+* Update Github CI to not tarball files for Windows only (@PotatoCider)
 
 ## TShock 4.5.18
-* Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@gohjoseph)
+* Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)
 * Only allow using Teleportation Potions, Magic Conch, and Demon Conch whilst holding them. (@drunderscore)
 * Updated server startup language to be more clear when encountering a fatal startup error. Now, the server gives more context as to what happened so that there's a better chance of people being able to help themselves. (@hakusaro)
 * Added `-worldevil <type>` command line argument (@NotGeri)
@@ -47,8 +48,8 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Bumped Newtonsoft Json to 13.0.1. (@dependabot)
 
 ## TShock 4.5.17
-* Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@gohjoseph)
-* Fixed mobs not dropping picked up coins. (@gohjoseph)
+* Fixed duplicate characters (twins) after repeatedly logging in as the same character due to connection not being immediately closed during `NetHooks_NameCollision`. (@PotatoCider)
+* Fixed mobs not dropping picked up coins. (@PotatoCider)
 
 ## TShock 4.5.16
 * Added preliminary support for Terraria 1.4.3.6. (@SignatureBeef, @hakusaro)


### PR DESCRIPTION
Windows users now don't need to untar artifacts. *nix OSes artifacts are still tarballed to preserve file execute permissions

Closes #2704.