### PR TITLE
Allow some new tile interactions to succeed in Bouncer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Updated to OTAPI 3.1.10-alpha, which allows FreeBSD .NET 6 to use Re-Logic's Linux platform. (@SignatureBeef)
 * Update Github CI to not tarball files for Windows only (@PotatoCider)
 * Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players (@drunderscore)
+* Always allow breaking of tiles that are in `BreakableWhenPlacing` set. This will allow you to place tiles over other tiles (like piles) properly, without being rejected. (@drunderscore)
+* Allow the Axe of Regrowth and the Rubblemaker to pass Bouncer checks. (@drunderscore)
+  * The Axe of Regrowth places a `Saplings` where a tree used to be, which previously failed.
+  * The Rubblemaker places rubble (which are echo piles), of varying styles, which previously failed.
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1932,13 +1932,6 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Player.SelectedItem.placeStyle != style)
-			{
-				TShock.Log.ConsoleError(string.Format("Bouncer / OnPlaceObject rejected object placement with invalid style from {0}", args.Player.Name));
-				args.Handled = true;
-				return;
-			}
-
 			//style 52 and 53 are used by ItemID.Fake_newchest1 and ItemID.Fake_newchest2
 			//These two items cause localised lag and rendering issues
 			if (type == TileID.FakeContainers && (style == 52 || style == 53))
@@ -1975,15 +1968,48 @@ namespace TShockAPI
 				return;
 			}
 
-			// This is necessary to check in order to prevent special tiles such as
-			// queen bee larva, paintings etc that use this packet from being placed
-			// without selecting the right item.
-			if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile)
+			if (args.Player.SelectedItem.type is ItemID.RubblemakerSmall or ItemID.RubblemakerMedium or ItemID.RubblemakerLarge)
 			{
-				TShock.Log.ConsoleDebug("Bouncer / OnPlaceObject rejected awkward tile creation/selection from {0}", args.Player.Name);
-				args.Player.SendTileSquareCentered(x, y, 4);
-				args.Handled = true;
-				return;
+				if (type != TileID.LargePilesEcho && type != TileID.LargePiles2Echo && type != TileID.SmallPiles2x1Echo &&
+				    type != TileID.SmallPiles1x1Echo && type != TileID.PlantDetritus3x2Echo && type != TileID.PlantDetritus2x2Echo)
+				{
+					TShock.Log.ConsoleDebug("Bouncer / OnPlaceObject rejected rubblemaker I can't believe it's not rubble! from {0}",
+						args.Player.Name);
+					args.Player.SendTileSquareCentered(x, y, 4);
+					args.Handled = true;
+					return;
+				}
+			}
+			else if(args.Player.SelectedItem.type == ItemID.AcornAxe)
+			{
+				if (type != TileID.Saplings)
+				{
+					TShock.Log.ConsoleDebug("Bouncer / OnPlaceObject rejected Axe of Regrowth only places saplings {0}", args.Player.Name);
+					args.Player.SendTileSquareCentered(x, y, 4);
+					args.Handled = true;
+					return;
+				}
+			}
+			else
+			{
+				// This is necessary to check in order to prevent special tiles such as
+				// queen bee larva, paintings etc that use this packet from being placed
+				// without selecting the right item.
+				if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile)
+				{
+					TShock.Log.ConsoleDebug("Bouncer / OnPlaceObject rejected awkward tile creation/selection from {0}", args.Player.Name);
+					args.Player.SendTileSquareCentered(x, y, 4);
+					args.Handled = true;
+					return;
+				}
+
+				if (args.Player.SelectedItem.placeStyle != style)
+				{
+					TShock.Log.ConsoleError(string.Format("Bouncer / OnPlaceObject rejected object placement with invalid style from {0}", args.Player.Name));
+					args.Player.SendTileSquareCentered(x, y, 4);
+					args.Handled = true;
+					return;
+				}
 			}
 
 			TileObjectData tileData = TileObjectData.GetTileData(type, style, 0);

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -510,10 +510,16 @@ namespace TShockAPI
 					// If the tile is a pickaxe tile and they aren't selecting a pickaxe, they're hacking.
 					// Item frames can be modified without pickaxe tile.
 					// also add an exception for snake coils, they can be removed when the player places a new one or after x amount of time
+					// If the tile is part of the breakable when placing set, it might be getting broken by a placement.
 					else if (tile.type != TileID.ItemFrame && tile.type != TileID.MysticSnakeRope
-						&& !Main.tileAxe[tile.type] && !Main.tileHammer[tile.type] && tile.wall == 0 && args.Player.TPlayer.mount.Type != 8 && selectedItem.pick == 0 && selectedItem.type != ItemID.GravediggerShovel && !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0)
+					                                       && !Main.tileAxe[tile.type] && !Main.tileHammer[tile.type] && tile.wall == 0 &&
+					                                       args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.pick == 0 &&
+					                                       selectedItem.type != ItemID.GravediggerShovel &&
+					                                       !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0
+					                                       && !TileID.Sets.BreakableWhenPlacing[tile.type])
 					{
-						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (pick) {0} {1} {2}", args.Player.Name, action, editData);
+						TShock.Log.ConsoleDebug("Bouncer / OnTileEdit rejected from (pick) {0} {1} {2}", args.Player.Name, action,
+							editData);
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
 						args.Handled = true;
 						return;


### PR DESCRIPTION
I suppose the `BreakableWhenPlacing` set aren't new interactions, and just have always been broken... but now it's fixed :^)
Formally fixes #2713