### PR TITLE
Fix Inferno Fork's OnFire debuff causing Bouncer reject abnormal buff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players. (@drunderscore)
 * In OTAPI 3.1.11-alpha, chest stacking was fixed. (@SignatureBeef)
 * In OTAPI 3.1.12-alpha, "server world deletions" were fixed. (@SignatureBeef)
+* Fix Inferno Fork causing kick from rejected abnormal buff. (@Stealownz)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players. (@drunderscore)
 * In OTAPI 3.1.11-alpha, chest stacking was fixed. (@SignatureBeef)
 * In OTAPI 3.1.12-alpha, "server world deletions" were fixed. (@SignatureBeef)
-* Fix Inferno Fork causing kick from rejected abnormal buff. (@Stealownz)
+* Fixed Inferno Fork causing kick from rejected abnormal buff. (@Stealownz)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2527,7 +2527,7 @@ namespace TShockAPI
 			{ BuffID.RainbowWhipNPCDebuff, 240  },  // BuffID: 316
 			{ BuffID.MaceWhipNPCDebuff, 240  },     // BuffID: 319
 			{ BuffID.GelBalloonBuff, 1800  },       // BuffID: 320
-			{ BuffID.OnFire3, 360 },                // BuffID: 323
+			{ BuffID.OnFire3, 960 },                // BuffID: 323
 			{ BuffID.Frostburn2, 900 },             // BuffID: 324
 			{ BuffID.BoneWhipNPCDebuff, 240 },      // BuffID: 326
 			{ BuffID.TentacleSpike, 540 },          // BuffID: 337


### PR DESCRIPTION
Inferno Fork's OnFire debuff was buffed up to `60 * Main.rand.Next(8, 16)`

```
2022-10-11 13:35:25 - TextLog: VERBOSE: Bouncer / OnNPCAddBuff rejected abnormal buff (323) added to Paladin (290) from Stealownz.
```

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
