### PR TITLE
Fix NetTile IndexOutOfRangeException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players. (@drunderscore)
 * In OTAPI 3.1.11-alpha, chest stacking was fixed. (@SignatureBeef)
 * In OTAPI 3.1.12-alpha, "server world deletions" were fixed. (@SignatureBeef)
-* Fixed NetTile errors by implementing new packet read/write data
+* Fixed NetTile errors by implementing new packet read/write data. (@SignatureBeef)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This is the rolling changelog for TShock for Terraria. Use past tense when addin
 * Allow Blood Butcherer and Shimmer buffs to be applied to NPCs by players. (@drunderscore)
 * In OTAPI 3.1.11-alpha, chest stacking was fixed. (@SignatureBeef)
 * In OTAPI 3.1.12-alpha, "server world deletions" were fixed. (@SignatureBeef)
+* Fixed NetTile errors by implementing new packet read/write data
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -463,11 +463,15 @@ namespace TShockAPI.Handlers
 			if ((updateType & TileDataType.TilePaint) != 0)
 			{
 				tile.color(newTile.TileColor);
+				tile.fullbrightBlock(newTile.FullbrightBlock);
+				tile.invisibleBlock(newTile.InvisibleBlock);
 			}
 
 			if ((updateType & TileDataType.WallPaint) != 0)
 			{
 				tile.wallColor(newTile.WallColor);
+				tile.fullbrightWall(newTile.FullbrightWall);
+				tile.invisibleWall(newTile.InvisibleWall);
 			}
 
 			if ((updateType & TileDataType.Liquid) != 0)

--- a/TShockAPI/Net/NetTile.cs
+++ b/TShockAPI/Net/NetTile.cs
@@ -45,6 +45,10 @@ namespace TShockAPI.Net
 		public bool Slope1 { get; set; }
 		public bool Slope2 { get; set; }
 		public bool Slope3 { get; set; }
+		public bool FullbrightBlock { get; set; }
+		public bool FullbrightWall { get; set; }
+		public bool InvisibleBlock { get; set; }
+		public bool InvisibleWall { get; set; }
 
 		public byte Slope
 		{
@@ -172,6 +176,22 @@ namespace TShockAPI.Net
 
 			stream.WriteByte(bits);
 
+			bits = new BitsByte();
+
+			if (FullbrightBlock)
+				bits[0] = true;
+
+			if (FullbrightWall)
+				bits[1] = true;
+
+			if (InvisibleBlock)
+				bits[2] = true;
+
+			if (InvisibleWall)
+				bits[3] = true;
+
+			stream.WriteByte(bits);
+
 			if (HasColor)
 			{
 				stream.WriteByte(TileColor);
@@ -206,6 +226,7 @@ namespace TShockAPI.Net
 		{
 			var flags = (BitsByte) stream.ReadInt8();
 			var flags2 = (BitsByte)stream.ReadInt8();
+			var flags3 = (BitsByte)stream.ReadInt8();
 
 			Wire2 = flags2[0];
 			Wire3 = flags2[1];
@@ -213,6 +234,11 @@ namespace TShockAPI.Net
 			Slope2 = flags2[5];
 			Slope3 = flags2[6];
 			Wire4 = flags2[7];
+
+			FullbrightBlock = flags3[0];
+			FullbrightWall = flags3[1];
+			InvisibleBlock = flags3[2];
+			InvisibleWall = flags3[3];
 
 			if (flags2[2])
 			{


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->

This aims to fix #2712 by implementing the new fields sent over the protocol. Hopefully have covered tile updating correctly, but please let me know if i missed anything...

Before fix when trying to place an item frame, while logged out:
![image](https://user-images.githubusercontent.com/776327/195271309-2425758d-4efb-4127-8db2-4915e97879db.png)


After fix when repeating the same actions (able to finish unpacking, and can proceed to place a bunch of item frames):
![image](https://user-images.githubusercontent.com/776327/195271386-967d2c5d-7cc8-4374-8680-9c5c3e396466.png)
