### PR TITLE
Include geoip.dat file again

### DIFF
--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -20,6 +20,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<None Include="..\prebuilts\GeoIP.dat">
+		  <Link>GeoIP.dat</Link>
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
 		<PackageReference Include="MySql.Data" Version="8.0.31" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.10" />
@@ -84,7 +91,7 @@
 	</Target>
 	<Target Name="MoveBin" AfterTargets="Publish">
 		<ItemGroup>
-			<MoveBinaries Include="$(PublishDir)*" Exclude="$(PublishDir)\TShock.Server*" />
+			<MoveBinaries Include="$(PublishDir)*" Exclude="$(PublishDir)\TShock.Server*;$(PublishDir)\GeoIP.dat" />
 		</ItemGroup>
 		<Move SourceFiles="@(MoveBinaries)" DestinationFolder="$(PublishDir)bin" ContinueOnError="true" />
 	</Target>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -63,6 +63,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added localization support for console spam reduction. (@KawaiiYuyu)
 * Added an internationalization system. The base for the i18n system was built by Janet Blackquill ([@pontaoski](https://github.com/pontaoski)). A small donation in her honor was made to the [KDE project](https://kde.org/) as a thankyou for this work. This also includes the `TSHOCK_LANGUAGE` environment variable. Setting `TSHOCK_LANGUAGE=tok` will enable a small number of [Toki Pona](https://tokipona.org/) translations as a proof-of-concept. (@pontaoski)
 * Added support for Terraria 1.4.4.6, through OTAPI 3.1.5. (@SignatureBeef)
+* Added GeoIP.dat back to the included list of files. (@SignatureBeef)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)


### PR DESCRIPTION
This should allow the GeoIP.dat file to be found, and used the same way it used to on TShock 4. It appears I had missed including this in the upgrade, and simply allowing it to copy to the output will allow the system to start working again. Confirmed by enabling in config and joining via mobile (external network) and my country has appeared, N/A otherwise (local network)
Note: only ipv4 was tested, and both debug and publish variant on osx.

Image below of my test (external ip intentionally excluded)

![Screen Shot 2022-10-22 at 9 39 47 pm](https://user-images.githubusercontent.com/776327/197337194-5bcaade8-cb1c-4085-947a-639fb0e63326.png)


<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
