### PR TITLE
Update Bouncer / OnNPCAddBuff

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1737,7 +1737,7 @@ namespace TShockAPI
 				{
 					bucket = 6;
 				}
-				else if (selectedItemType == ItemID.BottomlessHoneyBucket 
+				else if (selectedItemType == ItemID.BottomlessHoneyBucket
 					|| selectedItemType == ItemID.HoneyAbsorbantSponge)
 				{
 					bucket = 7;
@@ -1981,35 +1981,51 @@ namespace TShockAPI
 				return;
 			}
 
-			bool detectedNPCBuffTimeCheat = false;
-
-			if (NPCAddBuffTimeMax.ContainsKey(type))
+			if (!args.Player.HasPermission(Permissions.ignorenpcbuffdetection))
 			{
-				if (time > NPCAddBuffTimeMax[type])
+				bool detectedNPCBuffTimeCheat = false;
+
+				if (NPCAddBuffTimeMax.ContainsKey(type))
+				{
+					if (time > NPCAddBuffTimeMax[type])
+					{
+						detectedNPCBuffTimeCheat = true;
+					}
+
+					if (npc.townNPC)
+					{
+						if (type != BuffID.Poisoned
+						    && type != BuffID.OnFire
+						    && type != BuffID.Confused
+						    && type != BuffID.CursedInferno
+						    && type != BuffID.Ichor
+						    && type != BuffID.Venom
+						    && type != BuffID.Midas
+						    && type != BuffID.Wet
+						    && type != BuffID.Lovestruck
+						    && type != BuffID.Stinky
+						    && type != BuffID.Slimed
+						    && type != BuffID.DryadsWard
+						    && type != BuffID.GelBalloonBuff
+						    && type != BuffID.OnFire3
+						    && type != BuffID.Frostburn2
+						    && type != BuffID.Shimmer)
+						{
+							detectedNPCBuffTimeCheat = true;
+						}
+					}
+				}
+				else
 				{
 					detectedNPCBuffTimeCheat = true;
 				}
 
-				if (npc.townNPC && npc.netID != NPCID.Guide && npc.netID != NPCID.Clothier)
+				if (detectedNPCBuffTimeCheat)
 				{
-					if (type != BuffID.Lovestruck && type != BuffID.Stinky && type != BuffID.DryadsWard &&
-						type != BuffID.Wet && type != BuffID.Slimed && type != BuffID.GelBalloonBuff && type != BuffID.Frostburn2 &&
-						type != BuffID.Shimmer)
-					{
-						detectedNPCBuffTimeCheat = true;
-					}
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNPCAddBuff rejected abnormal buff ({0}) added to {1} ({2}) from {3}.", type, npc.TypeName, npc.netID, args.Player.Name));
+					args.Player.Kick(GetString($"Added buff to {npc.TypeName} NPC abnormally."), true);
+					args.Handled = true;
 				}
-			}
-			else
-			{
-				detectedNPCBuffTimeCheat = true;
-			}
-
-			if (detectedNPCBuffTimeCheat)
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNPCAddBuff rejected abnormal buff ({0}) added to {1} ({2}) from {3}.", type, npc.TypeName, npc.netID, args.Player.Name));
-				args.Player.Kick(GetString($"Added buff to {npc.TypeName} NPC abnormally."), true);
-				args.Handled = true;
 			}
 		}
 
@@ -2842,12 +2858,12 @@ namespace TShockAPI
 			{ BuffID.MaceWhipNPCDebuff, 240  },     // BuffID: 319
 			{ BuffID.GelBalloonBuff, 1800  },       // BuffID: 320
 			{ BuffID.OnFire3, 1200 },               // BuffID: 323
-			{ BuffID.Frostburn2, 900 },             // BuffID: 324
+			{ BuffID.Frostburn2, 1200 },            // BuffID: 324
 			{ BuffID.BoneWhipNPCDebuff, 240 },      // BuffID: 326
 			{ BuffID.TentacleSpike, 540 },          // BuffID: 337
 			{ BuffID.CoolWhipNPCDebuff, 240 },      // BuffID: 340
 			{ BuffID.BloodButcherer, 540 },         // BuffID: 344
-			{ BuffID.Shimmer, 100 },		// BuffID: 353
+			{ BuffID.Shimmer, 100 },		        // BuffID: 353
 		};
 
 		/// <summary>

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -155,6 +155,9 @@ namespace TShockAPI
 		[Description("Prevents your actions from being ignored if damage is too high.")]
 		public static readonly string ignoredamagecap = "tshock.ignore.damage";
 
+		[Description("Prevents your from being kicked by npc buff hack detection.")]
+		public static readonly string ignorenpcbuffdetection = "tshock.ignore.npcbuff";
+
 		[Description("Bypass server side character checks.")]
 		public static readonly string bypassssc = "tshock.ignore.ssc";
 
@@ -439,7 +442,7 @@ namespace TShockAPI
 
 		[Description("User can kill others.")]
 		public static readonly string kill = "tshock.kill";
-		
+
 		[Description("Player can respawn themselves.")]
 		public static readonly string respawn = "tshock.respawn";
 

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -945,6 +945,9 @@ namespace TShockAPI
 		{
 			PrepareLangForDump();
 			// Lang.setLang(true);
+
+			Directory.CreateDirectory("docs");
+
 			Configuration.TShockConfig.DumpDescriptions();
 			Permissions.DumpDescriptions();
 			Configuration.ServerSideConfig.DumpDescriptions();

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Check loadout slots for hacked item stacks. (@drunderscore)
 * Fix players being kicked after using the Flamethrower to apply the `OnFire3` debuff for `1200` ticks. (@BashGuy10)
 * Fix being kicked for using the new sponge types on liquid. (@BashGuy10)
+* Allow flask buffs to be applied on town npc due to the Flymeal. Add a permission could skip the buff detection. (@KawaiiYuyu)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)

--- a/docs/permission-descriptions.md
+++ b/docs/permission-descriptions.md
@@ -210,6 +210,10 @@ Prevents you from being disabled by liquid set abuse detection.
 Prevents you from being disabled by abnormal MP.
 * **Commands**: `None`
 
+## tshock.ignore.npcbuff
+Prevents your from being kicked by npc buff hack detection.
+* **Commands**: `None`
+
 ## tshock.ignore.paint
 Prevents you from being disabled by paint abuse detection.
 * **Commands**: `None`


### PR DESCRIPTION
- Increase the max allow time for Frostburn2 buff to 1200 bacause of the Elf Melter.

- The melee weapon Flymeal(ItemID: 5129) is able to hurt town NPCs. And there are some items could make a generic melee weapon inflicts debuff on NPC such as flasks. So we should allow those debuffs to be applied on town NPCs.

- Add a permission to skip this check, which can be used for admins doing some hack or as a workaround when there's an update. 