### PR TITLE
Handle vanilla `-lang` and `-language` CLI flags for I18n

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Check loadout slots for hacked item stacks. (@drunderscore)
 * Fix players being kicked after using the Flamethrower to apply the `OnFire3` debuff for `1200` ticks. (@BashGuy10)
 * Fix being kicked for using the new sponge types on liquid. (@BashGuy10)
+* Added support of `-lang` and `-language` flags for our i18n system. (@KawaiiYuyu)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)


### PR DESCRIPTION
In most cases, user would use the same language for both Terraria and TShock if the language is officially supported by this game. So we can just use those 2 flags to configure the culture.

Even if a user really want to use different langs they can also use envvars to override it.