### PR TITLE
Fixed SSC not save `ateArtisanBread`, `usedAegisCrystal`, `usedAegisFruit`, `usedArcaneCrystal`, `usedGalaxyPearl`, `usedGummyWorm`, `usedAmbrosia`, `unlockedSuperCart`, `enabledSuperCart` flags, and Server will correct read them.

### DIFF
--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -59,7 +59,16 @@ namespace TShockAPI.DB
 									 new SqlColumn("usingBiomeTorches", MySqlDbType.Int32),
 									 new SqlColumn("happyFunTorchTime", MySqlDbType.Int32),
 									 new SqlColumn("unlockedBiomeTorches", MySqlDbType.Int32),
-									 new SqlColumn("currentLoadoutIndex", MySqlDbType.Int32)
+									 new SqlColumn("currentLoadoutIndex", MySqlDbType.Int32),
+									 new SqlColumn("ateArtisanBread", MySqlDbType.Int32),
+									 new SqlColumn("usedAegisCrystal", MySqlDbType.Int32),
+									 new SqlColumn("usedAegisFruit", MySqlDbType.Int32),
+									 new SqlColumn("usedArcaneCrystal", MySqlDbType.Int32),
+									 new SqlColumn("usedGalaxyPearl", MySqlDbType.Int32),
+									 new SqlColumn("usedGummyWorm", MySqlDbType.Int32),
+									 new SqlColumn("usedAmbrosia", MySqlDbType.Int32),
+									 new SqlColumn("unlockedSuperCart", MySqlDbType.Int32),
+									 new SqlColumn("enabledSuperCart", MySqlDbType.Int32)
 				);
 			var creator = new SqlTableCreator(db,
 			                                  db.GetSqlType() == SqlType.Sqlite
@@ -116,6 +125,15 @@ namespace TShockAPI.DB
 						playerData.happyFunTorchTime = reader.Get<int>("happyFunTorchTime");
 						playerData.unlockedBiomeTorches = reader.Get<int>("unlockedBiomeTorches");
 						playerData.currentLoadoutIndex = reader.Get<int>("currentLoadoutIndex");
+						playerData.ateArtisanBread = reader.Get<int>("ateArtisanBread");
+						playerData.usedAegisCrystal = reader.Get<int>("usedAegisCrystal");
+						playerData.usedAegisFruit = reader.Get<int>("usedAegisFruit");
+						playerData.usedArcaneCrystal = reader.Get<int>("usedArcaneCrystal");
+						playerData.usedGalaxyPearl = reader.Get<int>("usedGalaxyPearl");
+						playerData.usedGummyWorm = reader.Get<int>("usedGummyWorm");
+						playerData.usedAmbrosia = reader.Get<int>("usedAmbrosia");
+						playerData.unlockedSuperCart = reader.Get<int>("unlockedSuperCart");
+						playerData.enabledSuperCart = reader.Get<int>("enabledSuperCart");
 						return playerData;
 					}
 				}
@@ -182,8 +200,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24);",
-						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex);
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex,ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33);",
+						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0);
 					return true;
 				}
 				catch (Exception ex)
@@ -196,8 +214,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24 WHERE Account = @5;",
-						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex);
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33 WHERE Account = @5;",
+						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0);
 					return true;
 				}
 				catch (Exception ex)
@@ -252,7 +270,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24);",
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex, ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33);",
 						player.Account.ID,
 						playerData.health,
 						playerData.maxHealth,
@@ -277,7 +295,16 @@ namespace TShockAPI.DB
 						playerData.usingBiomeTorches,
 						playerData.happyFunTorchTime,
 						playerData.unlockedBiomeTorches,
-						playerData.currentLoadoutIndex);
+						playerData.currentLoadoutIndex,
+						playerData.ateArtisanBread,
+						playerData.usedAegisCrystal,
+						playerData.usedAegisFruit,
+						playerData.usedArcaneCrystal,
+						playerData.usedGalaxyPearl,
+						playerData.usedGummyWorm,
+						playerData.usedAmbrosia,
+						playerData.unlockedSuperCart,
+						playerData.enabledSuperCart);
 					return true;
 				}
 				catch (Exception ex)
@@ -290,7 +317,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24 WHERE Account = @5;",
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33 WHERE Account = @5;",
 						playerData.health,
 						playerData.maxHealth,
 						playerData.mana,
@@ -315,7 +342,16 @@ namespace TShockAPI.DB
 						playerData.usingBiomeTorches,
 						playerData.happyFunTorchTime,
 						playerData.unlockedBiomeTorches,
-						playerData.currentLoadoutIndex);
+						playerData.currentLoadoutIndex,
+						playerData.ateArtisanBread,
+						playerData.usedAegisCrystal,
+						playerData.usedAegisFruit,
+						playerData.usedArcaneCrystal,
+						playerData.usedGalaxyPearl,
+						playerData.usedGummyWorm,
+						playerData.usedAmbrosia,
+						playerData.unlockedSuperCart,
+						playerData.enabledSuperCart);
 					return true;
 				}
 				catch (Exception ex)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2434,6 +2434,16 @@ namespace TShockAPI
 			bool usingBiomeTorches = torchFlags[0];
 			bool happyFunTorchTime = torchFlags[1];
 			bool unlockedBiomeTorches = torchFlags[2];
+			bool unlockedSuperCart = torchFlags[3];
+			bool enabledSuperCart = torchFlags[4];
+			BitsByte bitsByte10 = args.Data.ReadInt8();
+			bool usedAegisCrystal = bitsByte10[0];
+			bool usedAegisFruit = bitsByte10[1];
+			bool usedArcaneCrystal = bitsByte10[2];
+			bool usedGalaxyPearl = bitsByte10[3];
+			bool usedGummyWorm = bitsByte10[4];
+			bool usedAmbrosia = bitsByte10[5];
+			bool ateArtisanBread = bitsByte10[6];
 
 			if (OnPlayerInfo(args.Player, args.Data, playerid, hair, skinVariant, difficulty, name))
 			{
@@ -2482,6 +2492,15 @@ namespace TShockAPI
 				args.Player.TPlayer.UsingBiomeTorches = usingBiomeTorches;
 				args.Player.TPlayer.happyFunTorchTime = happyFunTorchTime;
 				args.Player.TPlayer.unlockedBiomeTorches = unlockedBiomeTorches;
+				args.Player.TPlayer.ateArtisanBread = ateArtisanBread;
+				args.Player.TPlayer.usedAegisCrystal = usedAegisCrystal;
+				args.Player.TPlayer.usedAegisFruit = usedAegisFruit;
+				args.Player.TPlayer.usedArcaneCrystal = usedArcaneCrystal;
+				args.Player.TPlayer.usedGalaxyPearl = usedGalaxyPearl;
+				args.Player.TPlayer.usedGummyWorm = usedGummyWorm;
+				args.Player.TPlayer.usedAmbrosia = usedAmbrosia;
+				args.Player.TPlayer.unlockedSuperCart = unlockedSuperCart;
+				args.Player.TPlayer.enabledSuperCart = enabledSuperCart;
 
 				NetMessage.SendData((int)PacketTypes.PlayerInfo, -1, args.Player.Index, NetworkText.FromLiteral(args.Player.Name), args.Player.Index);
 				return true;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -53,6 +53,15 @@ namespace TShockAPI
 		public int happyFunTorchTime;
 		public int unlockedBiomeTorches;
 		public int currentLoadoutIndex;
+		public int ateArtisanBread;
+		public int usedAegisCrystal;
+		public int usedAegisFruit;
+		public int usedArcaneCrystal;
+		public int usedGalaxyPearl;
+		public int usedGummyWorm;
+		public int usedAmbrosia;
+		public int unlockedSuperCart;
+		public int enabledSuperCart;
 
 		public PlayerData(TSPlayer player)
 		{
@@ -122,6 +131,15 @@ namespace TShockAPI
 			this.happyFunTorchTime = player.TPlayer.happyFunTorchTime ? 1 : 0;
 			this.unlockedBiomeTorches = player.TPlayer.unlockedBiomeTorches ? 1 : 0;
 			this.currentLoadoutIndex = player.TPlayer.CurrentLoadoutIndex;
+			this.ateArtisanBread = player.TPlayer.ateArtisanBread ? 1 : 0;
+			this.usedAegisCrystal = player.TPlayer.usedAegisCrystal ? 1 : 0;
+			this.usedAegisFruit = player.TPlayer.usedAegisFruit ? 1 : 0;
+			this.usedArcaneCrystal = player.TPlayer.usedArcaneCrystal ? 1 : 0;
+			this.usedGalaxyPearl = player.TPlayer.usedGalaxyPearl ? 1 : 0;
+			this.usedGummyWorm = player.TPlayer.usedGummyWorm ? 1 : 0;
+			this.usedAmbrosia = player.TPlayer.usedAmbrosia ? 1 : 0;
+			this.unlockedSuperCart = player.TPlayer.unlockedSuperCart ? 1 : 0;
+			this.enabledSuperCart = player.TPlayer.enabledSuperCart ? 1 : 0;
 
 			Item[] inventory = player.TPlayer.inventory;
 			Item[] armor = player.TPlayer.armor;
@@ -256,6 +274,15 @@ namespace TShockAPI
 			player.TPlayer.happyFunTorchTime = this.happyFunTorchTime == 1;
 			player.TPlayer.unlockedBiomeTorches = this.unlockedBiomeTorches == 1;
 			player.TPlayer.CurrentLoadoutIndex = this.currentLoadoutIndex;
+			player.TPlayer.ateArtisanBread = this.ateArtisanBread == 1;
+			player.TPlayer.usedAegisCrystal = this.usedAegisCrystal == 1;
+			player.TPlayer.usedAegisFruit = this.usedAegisFruit == 1;
+			player.TPlayer.usedArcaneCrystal = this.usedArcaneCrystal == 1;
+			player.TPlayer.usedGalaxyPearl = this.usedGalaxyPearl == 1;
+			player.TPlayer.usedGummyWorm = this.usedGummyWorm == 1;
+			player.TPlayer.usedAmbrosia = this.usedAmbrosia == 1;
+			player.TPlayer.unlockedSuperCart = this.unlockedSuperCart == 1;
+			player.TPlayer.enabledSuperCart = this.enabledSuperCart == 1;
 
 			if (extraSlot != null)
 				player.TPlayer.extraAccessory = extraSlot.Value == 1 ? true : false;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Check loadout slots for hacked item stacks. (@drunderscore)
 * Fix players being kicked after using the Flamethrower to apply the `OnFire3` debuff for `1200` ticks. (@BashGuy10)
 * Fix being kicked for using the new sponge types on liquid. (@BashGuy10)
+* Fixed SSC not save `ateArtisanBread`, `usedAegisCrystal`, `usedAegisFruit`, `usedArcaneCrystal`, `usedGalaxyPearl`, `usedGummyWorm`, `usedAmbrosia`, `unlockedSuperCart`, `enabledSuperCart` flags, and Server will correct read them. (@hufang360)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)


### PR DESCRIPTION
Fixed SSC not save `ateArtisanBread`, `usedAegisCrystal`, `usedAegisFruit`, `usedArcaneCrystal`, `usedGalaxyPearl`, `usedGummyWorm`, `usedAmbrosia`, `unlockedSuperCart`, `enabledSuperCart` flags, and Server will correct read them.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
