### PR TITLE
Minor i18n fix with interpolation

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -5341,7 +5341,10 @@ namespace TShockAPI
 				if (ply != null && ply.Active)
 				{
 					if (displayIdsRequested)
-						players.Add(GetString($"{ply.Name} (Index: {ply.Index}{(ply.Account != null ? ", Account ID: " + ply.Account.ID : "")})"));
+						if (ply.Account != null)
+							players.Add(GetString($"{ply.Name} (Index: {ply.Index}, Account ID: {ply.Account.ID})"));
+						else
+							players.Add(GetString($"{ply.Name} (Index: {ply.Index})"));
 					else
 						players.Add(ply.Name);
 				}
@@ -5352,7 +5355,7 @@ namespace TShockAPI
 				new PaginationTools.Settings
 				{
 					IncludeHeader = false,
-					FooterFormat = GetString($"Type {Specifier}who {(displayIdsRequested ? "-i" : string.Empty)}{Specifier} for more.")
+					FooterFormat = GetString($"Type {Specifier}who {(displayIdsRequested ? "-i" : string.Empty)} for more.")
 				}
 			);
 		}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3189,13 +3189,13 @@ namespace TShockAPI
 						args.Player.IsDisabledForBannedWearable = false;
 
 
-					args.Player.SendMessage(GetString("Authenticated as " + args.Player.Name + " successfully."), Color.LimeGreen);
-					TShock.Log.ConsoleInfo(args.Player.Name + " authenticated successfully as user " + args.Player.Name + ".");
+					args.Player.SendMessage(GetString($"Authenticated as {args.Player.Name} successfully."), Color.LimeGreen);
+					TShock.Log.ConsoleInfo($"{args.Player.Name} authenticated successfully as user {args.Player.Name}.");
 					TShock.UserAccounts.SetUserAccountUUID(account, args.Player.UUID);
 					Hooks.PlayerHooks.OnPlayerPostLogin(args.Player);
 					return true;
 				}
-				args.Player.Kick("Your password did not match this character's password.", true, true);
+				args.Player.Kick(GetString("Your password did not match this character's password."), true, true);
 				return true;
 			}
 


### PR DESCRIPTION
The extractor handle the concatenate incorrectly:
`"Authenticated as " + args.Player.Name + " successfully."` => `Authenticated as  successfully.`

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
