### PR TITLE
Fixed Server not tracks deaths, Now players can be viewed with the `/death`, `/pvpdeath`, `/alldeath` and `/allpvpdeath` commands.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -604,6 +604,27 @@ namespace TShockAPI
 			});
 			#endregion
 
+			#region Death Commands
+			add(new Command(Death, "death")
+			{
+				AllowServer = false,
+				HelpText = GetString("Shows your deaths from PVE.")
+			});
+			add(new Command(PVPDeath, "pvpdeath")
+			{
+				AllowServer = false,
+				HelpText = GetString("Shows your deaths from PVP.")
+			});
+			add(new Command(AllDeath, "alldeath")
+			{
+				HelpText = GetString("Shows the currently connected players' deaths from PVE.")
+			});
+			add(new Command(AllPVPDeath, "allpvpdeath")
+			{
+				HelpText = GetString("Shows the currently connected players' deaths from PVP.")
+			});
+			#endregion
+
 			add(new Command(Aliases, "aliases")
 			{
 				HelpText = GetString("Shows a command's aliases.")
@@ -6744,6 +6765,58 @@ namespace TShockAPI
 				playerToGod.SendSuccessMessage(playerToGod.GodMode
 					? GetString("You are now in god mode.", playerToGod.Name)
 					: GetString("You are no longer in god mode.", playerToGod.Name));
+			}
+		}
+
+		private static void Death(CommandArgs args)
+		{
+			string tag = args.TPlayer.numberOfDeathsPVE == 1 ? "LegacyMultiplayer.25" : "LegacyMultiplayer.23";
+			NetworkText text = NetworkText.FromKey(tag, args.Player.Name, args.Player.TPlayer.numberOfDeathsPVE);
+			args.Player.SendMessage(text.ToString(), Color.Red);
+		}
+
+		private static void PVPDeath(CommandArgs args)
+		{
+			string tag = args.TPlayer.numberOfDeathsPVP == 1 ? "LegacyMultiplayer.26" : "LegacyMultiplayer.24";
+			NetworkText text = NetworkText.FromKey(tag, args.Player.Name, args.Player.TPlayer.numberOfDeathsPVP);
+			args.Player.SendMessage(text.ToString(), Color.Red);
+		}
+
+		private static void AllDeath(CommandArgs args)
+		{
+			string tag = "";
+			foreach (TSPlayer ply in TShock.Players)
+			{
+				if (ply != null && ply.Active)
+				{
+					tag = ply.TPlayer.numberOfDeathsPVE == 1 ? "LegacyMultiplayer.25" : "LegacyMultiplayer.23";
+					NetworkText text = NetworkText.FromKey(tag, ply.Name, ply.TPlayer.numberOfDeathsPVE);
+					args.Player.SendMessage(text.ToString(), Color.Red);
+				}
+			}
+
+			if (string.IsNullOrEmpty(tag))
+			{
+				args.Player.SendInfoMessage(GetString("There are currently no players online."));
+			}
+		}
+
+		private static void AllPVPDeath(CommandArgs args)
+		{
+			string tag = "";
+			foreach (TSPlayer ply in TShock.Players)
+			{
+				if (ply != null && ply.Active)
+				{
+					tag = ply.TPlayer.numberOfDeathsPVP == 1 ? "LegacyMultiplayer.26" : "LegacyMultiplayer.24";
+					NetworkText text = NetworkText.FromKey(tag, ply.Name, ply.TPlayer.numberOfDeathsPVP);
+					args.Player.SendMessage(text.ToString(), Color.Red);
+				}
+			}
+
+			if (string.IsNullOrEmpty(tag))
+			{
+				args.Player.SendInfoMessage(GetString("There are currently no players online."));
 			}
 		}
 

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -68,7 +68,9 @@ namespace TShockAPI.DB
 									 new SqlColumn("usedGummyWorm", MySqlDbType.Int32),
 									 new SqlColumn("usedAmbrosia", MySqlDbType.Int32),
 									 new SqlColumn("unlockedSuperCart", MySqlDbType.Int32),
-									 new SqlColumn("enabledSuperCart", MySqlDbType.Int32)
+									 new SqlColumn("enabledSuperCart", MySqlDbType.Int32),
+									 new SqlColumn("numberOfDeathsPVE", MySqlDbType.Int32),
+									 new SqlColumn("numberOfDeathsPVP", MySqlDbType.Int32)
 				);
 			var creator = new SqlTableCreator(db,
 			                                  db.GetSqlType() == SqlType.Sqlite
@@ -134,6 +136,8 @@ namespace TShockAPI.DB
 						playerData.usedAmbrosia = reader.Get<int>("usedAmbrosia");
 						playerData.unlockedSuperCart = reader.Get<int>("unlockedSuperCart");
 						playerData.enabledSuperCart = reader.Get<int>("enabledSuperCart");
+						playerData.numberOfDeathsPVE = reader.Get<int>("numberOfDeathsPVE");
+						playerData.numberOfDeathsPVP = reader.Get<int>("numberOfDeathsPVP");
 						return playerData;
 					}
 				}
@@ -200,8 +204,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex,ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33);",
-						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0);
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex,ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart, numberOfDeathsPVE, numberOfDeathsPVP) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33, @34, @35);",
+						player.Account.ID, playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), playerData.extraSlot, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.skinVariant, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor),TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor),TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0, player.TPlayer.numberOfDeathsPVE, player.TPlayer.numberOfDeathsPVP);
 					return true;
 				}
 				catch (Exception ex)
@@ -214,8 +218,8 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33 WHERE Account = @5;",
-						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0);
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33, numberOfDeathsPVE = @34, numberOfDeathsPVP = @35 WHERE Account = @5;",
+						playerData.health, playerData.maxHealth, playerData.mana, playerData.maxMana, String.Join("~", playerData.inventory), player.Account.ID, player.TPlayer.SpawnX, player.TPlayer.SpawnY, player.TPlayer.hair, player.TPlayer.hairDye, TShock.Utils.EncodeColor(player.TPlayer.hairColor), TShock.Utils.EncodeColor(player.TPlayer.pantsColor), TShock.Utils.EncodeColor(player.TPlayer.shirtColor), TShock.Utils.EncodeColor(player.TPlayer.underShirtColor), TShock.Utils.EncodeColor(player.TPlayer.shoeColor), TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory), TShock.Utils.EncodeColor(player.TPlayer.skinColor), TShock.Utils.EncodeColor(player.TPlayer.eyeColor), player.TPlayer.anglerQuestsFinished, player.TPlayer.skinVariant, player.TPlayer.extraAccessory ? 1 : 0, player.TPlayer.UsingBiomeTorches ? 1 : 0, player.TPlayer.happyFunTorchTime ? 1 : 0, player.TPlayer.unlockedBiomeTorches ? 1 : 0, player.TPlayer.CurrentLoadoutIndex, player.TPlayer.ateArtisanBread ? 1 : 0, player.TPlayer.usedAegisCrystal ? 1 : 0, player.TPlayer.usedAegisFruit ? 1 : 0, player.TPlayer.usedArcaneCrystal ? 1 : 0, player.TPlayer.usedGalaxyPearl ? 1 : 0, player.TPlayer.usedGummyWorm ? 1 : 0, player.TPlayer.usedAmbrosia ? 1 : 0, player.TPlayer.unlockedSuperCart ? 1 : 0, player.TPlayer.enabledSuperCart ? 1 : 0, player.TPlayer.numberOfDeathsPVE, player.TPlayer.numberOfDeathsPVP);
 					return true;
 				}
 				catch (Exception ex)
@@ -270,7 +274,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex, ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33);",
+						"INSERT INTO tsCharacter (Account, Health, MaxHealth, Mana, MaxMana, Inventory, extraSlot, spawnX, spawnY, skinVariant, hair, hairDye, hairColor, pantsColor, shirtColor, underShirtColor, shoeColor, hideVisuals, skinColor, eyeColor, questsCompleted, usingBiomeTorches, happyFunTorchTime, unlockedBiomeTorches, currentLoadoutIndex, ateArtisanBread, usedAegisCrystal, usedAegisFruit, usedArcaneCrystal, usedGalaxyPearl, usedGummyWorm, usedAmbrosia, unlockedSuperCart, enabledSuperCart, numberOfDeathsPVE, numberOfDeathsPVP) VALUES (@0, @1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19, @20, @21, @22, @23, @24, @25, @26, @27, @28, @29, @30, @31, @32, @33, @34, @35);",
 						player.Account.ID,
 						playerData.health,
 						playerData.maxHealth,
@@ -304,7 +308,9 @@ namespace TShockAPI.DB
 						playerData.usedGummyWorm,
 						playerData.usedAmbrosia,
 						playerData.unlockedSuperCart,
-						playerData.enabledSuperCart);
+						playerData.enabledSuperCart,
+						playerData.numberOfDeathsPVE,
+						playerData.numberOfDeathsPVP);
 					return true;
 				}
 				catch (Exception ex)
@@ -317,7 +323,7 @@ namespace TShockAPI.DB
 				try
 				{
 					database.Query(
-						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33 WHERE Account = @5;",
+						"UPDATE tsCharacter SET Health = @0, MaxHealth = @1, Mana = @2, MaxMana = @3, Inventory = @4, spawnX = @6, spawnY = @7, hair = @8, hairDye = @9, hairColor = @10, pantsColor = @11, shirtColor = @12, underShirtColor = @13, shoeColor = @14, hideVisuals = @15, skinColor = @16, eyeColor = @17, questsCompleted = @18, skinVariant = @19, extraSlot = @20, usingBiomeTorches = @21, happyFunTorchTime = @22, unlockedBiomeTorches = @23, currentLoadoutIndex = @24, ateArtisanBread = @25, usedAegisCrystal = @26, usedAegisFruit = @27, usedArcaneCrystal = @28, usedGalaxyPearl = @29, usedGummyWorm = @30, usedAmbrosia = @31, unlockedSuperCart = @32, enabledSuperCart = @33, numberOfDeathsPVE = @34, numberOfDeathsPVP = @35 WHERE Account = @5;",
 						playerData.health,
 						playerData.maxHealth,
 						playerData.mana,
@@ -351,7 +357,9 @@ namespace TShockAPI.DB
 						playerData.usedGummyWorm,
 						playerData.usedAmbrosia,
 						playerData.unlockedSuperCart,
-						playerData.enabledSuperCart);
+						playerData.enabledSuperCart,
+						playerData.numberOfDeathsPVE,
+						playerData.numberOfDeathsPVP);
 					return true;
 				}
 				catch (Exception ex)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2700,16 +2700,6 @@ namespace TShockAPI
 			short numberOfDeathsPVE = args.Data.ReadInt16();
 			short numberOfDeathsPVP = args.Data.ReadInt16();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
-			// When the player spawn into world, the numberOfDeathsPVE and numberOfDeathsPVP is not correct on the SSC Server.
-			// Send the data agrain fixed them.
-			if (context == PlayerSpawnContext.SpawningIntoWorld && args.Player.IsLoggedIn )
-			{
-				if(numberOfDeathsPVE != args.TPlayer.numberOfDeathsPVE || numberOfDeathsPVP != args.TPlayer.numberOfDeathsPVP)
-				{
-					args.Player.Spawn(PlayerSpawnContext.SpawningIntoWorld);
-					return true;
-				}
-			}
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnx, spawny, respawnTimer, numberOfDeathsPVE, numberOfDeathsPVP, context))
 				return true;
 
@@ -2746,6 +2736,17 @@ namespace TShockAPI
 				args.Player.Dead = true;
 			else
 				args.Player.Dead = false;
+
+			// When the player spawn into world, the numberOfDeathsPVE and numberOfDeathsPVP is not correct on the SSC Server.
+			// Send the data agrain fixed them.
+			if (context == PlayerSpawnContext.SpawningIntoWorld && args.Player.IsLoggedIn )
+			{
+				if(numberOfDeathsPVE != args.TPlayer.numberOfDeathsPVE || numberOfDeathsPVP != args.TPlayer.numberOfDeathsPVP)
+				{
+					args.Player.Spawn(PlayerSpawnContext.SpawningIntoWorld);
+					return true;
+				}
+			}
 			return false;
 		}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -856,6 +856,14 @@ namespace TShockAPI
 			/// </summary>
 			public int RespawnTimer { get; set; }
 			/// <summary>
+			/// Player's deaths from PVE.
+			/// </summary>
+			public int NumberOfDeathsPVE { get; set; }
+			/// <summary>
+			/// Player's deaths from PVP.
+			/// </summary>
+			public int NumberOfDeathsPVP { get; set; }
+			/// <summary>
 			/// Context of where the player is spawning from.
 			/// </summary>
 			public PlayerSpawnContext SpawnContext { get; set; }
@@ -864,7 +872,7 @@ namespace TShockAPI
 		/// PlayerSpawn - When a player spawns
 		/// </summary>
 		public static HandlerList<SpawnEventArgs> PlayerSpawn = new HandlerList<SpawnEventArgs>();
-		private static bool OnPlayerSpawn(TSPlayer player, MemoryStream data, byte pid, int spawnX, int spawnY, int respawnTimer, PlayerSpawnContext spawnContext)
+		private static bool OnPlayerSpawn(TSPlayer player, MemoryStream data, byte pid, int spawnX, int spawnY, int respawnTimer, int numberOfDeathsPVE, int numberOfDeathsPVP, PlayerSpawnContext spawnContext)
 		{
 			if (PlayerSpawn == null)
 				return false;
@@ -877,6 +885,8 @@ namespace TShockAPI
 				SpawnX = spawnX,
 				SpawnY = spawnY,
 				RespawnTimer = respawnTimer,
+				NumberOfDeathsPVE = numberOfDeathsPVE,
+				NumberOfDeathsPVP = numberOfDeathsPVP,
 				SpawnContext = spawnContext
 			};
 			PlayerSpawn.Invoke(null, args);
@@ -2687,9 +2697,20 @@ namespace TShockAPI
 			short spawnx = args.Data.ReadInt16();
 			short spawny = args.Data.ReadInt16();
 			int respawnTimer = args.Data.ReadInt32();
+			short numberOfDeathsPVE = args.Data.ReadInt16();
+			short numberOfDeathsPVP = args.Data.ReadInt16();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
-
-			if (OnPlayerSpawn(args.Player, args.Data, player, spawnx, spawny, respawnTimer, context))
+			// When the player spawn into world, the numberOfDeathsPVE and numberOfDeathsPVP is not correct on the SSC Server.
+			// Send the data agrain fixed them.
+			if (context == PlayerSpawnContext.SpawningIntoWorld && args.Player.IsLoggedIn )
+			{
+				if(numberOfDeathsPVE != args.TPlayer.numberOfDeathsPVE || numberOfDeathsPVP != args.TPlayer.numberOfDeathsPVP)
+				{
+					args.Player.Spawn(PlayerSpawnContext.SpawningIntoWorld);
+					return true;
+				}
+			}
+			if (OnPlayerSpawn(args.Player, args.Data, player, spawnx, spawny, respawnTimer, numberOfDeathsPVE, numberOfDeathsPVP, context))
 				return true;
 
 			if ((Main.ServerSideCharacter) && (spawnx == -1 && spawny == -1)) //this means they want to spawn to vanilla spawn

--- a/TShockAPI/Net/SpawnMsg.cs
+++ b/TShockAPI/Net/SpawnMsg.cs
@@ -33,6 +33,8 @@ namespace TShockAPI.Net
 		public short TileX { get; set; }
 		public short TileY { get; set; }
 		public int RespawnTimer { get; set; }
+		public short NumberOfDeathsPVE { get; set; }
+		public short NumberOfDeathsPVP { get; set; }
 		public PlayerSpawnContext PlayerSpawnContext { get; set; }
 
 		public override void Pack(Stream stream)
@@ -41,6 +43,8 @@ namespace TShockAPI.Net
 			stream.WriteInt16(TileX);
 			stream.WriteInt16(TileY);
 			stream.WriteInt32(RespawnTimer);
+			stream.WriteInt16(NumberOfDeathsPVE);
+			stream.WriteInt16(NumberOfDeathsPVP);
 			stream.WriteByte((byte) PlayerSpawnContext);
 		}
 	}

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -287,11 +287,8 @@ namespace TShockAPI
 			player.TPlayer.usedAmbrosia = this.usedAmbrosia == 1;
 			player.TPlayer.unlockedSuperCart = this.unlockedSuperCart == 1;
 			player.TPlayer.enabledSuperCart = this.enabledSuperCart == 1;
-
-			if (this.numberOfDeathsPVE > 0)
-				player.TPlayer.numberOfDeathsPVE = this.numberOfDeathsPVE;
-			if (this.numberOfDeathsPVP > 0)
-				player.TPlayer.numberOfDeathsPVP = this.numberOfDeathsPVP;
+			player.TPlayer.numberOfDeathsPVE = this.numberOfDeathsPVE;
+			player.TPlayer.numberOfDeathsPVP = this.numberOfDeathsPVP;
 
 			if (extraSlot != null)
 				player.TPlayer.extraAccessory = extraSlot.Value == 1 ? true : false;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -62,6 +62,8 @@ namespace TShockAPI
 		public int usedAmbrosia;
 		public int unlockedSuperCart;
 		public int enabledSuperCart;
+		public int numberOfDeathsPVE;
+		public int numberOfDeathsPVP;
 
 		public PlayerData(TSPlayer player)
 		{
@@ -140,6 +142,8 @@ namespace TShockAPI
 			this.usedAmbrosia = player.TPlayer.usedAmbrosia ? 1 : 0;
 			this.unlockedSuperCart = player.TPlayer.unlockedSuperCart ? 1 : 0;
 			this.enabledSuperCart = player.TPlayer.enabledSuperCart ? 1 : 0;
+			this.numberOfDeathsPVE = player.TPlayer.numberOfDeathsPVE;
+			this.numberOfDeathsPVP = player.TPlayer.numberOfDeathsPVP;
 
 			Item[] inventory = player.TPlayer.inventory;
 			Item[] armor = player.TPlayer.armor;
@@ -283,6 +287,11 @@ namespace TShockAPI
 			player.TPlayer.usedAmbrosia = this.usedAmbrosia == 1;
 			player.TPlayer.unlockedSuperCart = this.unlockedSuperCart == 1;
 			player.TPlayer.enabledSuperCart = this.enabledSuperCart == 1;
+
+			if (this.numberOfDeathsPVE > 0)
+				player.TPlayer.numberOfDeathsPVE = this.numberOfDeathsPVE;
+			if (this.numberOfDeathsPVP > 0)
+				player.TPlayer.numberOfDeathsPVP = this.numberOfDeathsPVP;
 
 			if (extraSlot != null)
 				player.TPlayer.extraAccessory = extraSlot.Value == 1 ? true : false;

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1404,6 +1404,8 @@ namespace TShockAPI
 					TileX = (short)tilex,
 					TileY = (short)tiley,
 					RespawnTimer = respawnTimer ?? TShock.Players[Index].RespawnTimer * 60,
+					NumberOfDeathsPVE = (short)TPlayer.numberOfDeathsPVE,
+					NumberOfDeathsPVP = (short)TPlayer.numberOfDeathsPVP,
 					PlayerSpawnContext = context,
 				};
 				msg.PackFull(ms);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 
 * Add ability for items given to players to be inserted directly into their inventory instead of spawned as an item drop (@pontaoski)
 * Added support of `-lang` and `-language` flags for our i18n system. (@KawaiiYuyu)
+* Fixed Server not tracks deaths, Now players can be viewed with the `/death`, `/pvpdeath`, `/alldeath` and `/allpvpdeath` commands. (@hufang360)
 
 ## TShock 4.5.18
 * Fixed `TSPlayer.GiveItem` not working if the player is in lava. (@PotatoCider)


### PR DESCRIPTION
Fixed Server not tracks deaths, Now players can be viewed with the `/death`, `/pvpdeath`, `/alldeath` and `/allpvpdeath` commands.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
