### PR TITLE
Geoip exclude

### DIFF
--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -23,6 +23,7 @@
 		<None Include="..\prebuilts\GeoIP.dat">
 		  <Link>GeoIP.dat</Link>
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
 		</None>
 	</ItemGroup>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 
 ## Upcoming changes
 * Fixed item giving potentially dropping too many items (@PotatoCider, @punchready)
+* Excluded GeoIP.dat from release bundle (@SignatureBeef)
 
 ## TShock 5.0.0
 * Reduced load/save console spam. (@SignatureBeef, @YehnBeep)


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->

This will exclude GeoIP.dat from the single file bundle (while still being included in the project) - not sure how we missed this, but this will allow the releases to load GeoIP.dat as intended.

![image](https://user-images.githubusercontent.com/776327/199407419-1ac8b693-e153-4e60-914a-2322f9495dcc.png)
