### PR TITLE
Added two new config options, relating to the TShockAPI DB.

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -5254,6 +5254,7 @@ namespace TShockAPI
 					new PaginationTools.Settings
 					{
 						HeaderFormat = GetString("Commands ({{0}}/{{1}}):"),
+						HeaderTextColor = new Color(117, 188, 250),
 						FooterFormat = GetString("Type {0}help {{0}} for more.", Specifier)
 					});
 			}

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -528,6 +528,10 @@ namespace TShockAPI.Configuration
 		[Description("The type of database to use when storing data (either \"sqlite\" or \"mysql\").")]
 		public string StorageType = "sqlite";
 
+		public bool isStorageTypeSeperateFromTShockDBType = false;
+
+		public string TShockDBType = "sqlite";
+
 		/// <summary>The path of sqlite db.</summary>
 		[Description("The path of sqlite db.")]
 		public string SqliteDBPath = "tshock.sqlite";

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -313,7 +313,7 @@ namespace TShockAPI.DB
 				group.Parent = parent;
 			}
 
-			string query = (TShock.Config.Settings.StorageType.ToLower() == "sqlite")
+			string query = (TShock.Config.Settings.StorageType.ToLower() == "sqlite" && (TShock.Config.Settings.TShockDBType != "mysql" && TShock.Config.Settings.isStorageTypeSeperateFromTShockDBType == true))
 				? "INSERT OR IGNORE INTO GroupList (GroupName, Parent, Commands, ChatColor) VALUES (@0, @1, @2, @3);"
 				: "INSERT IGNORE INTO GroupList SET GroupName=@0, Parent=@1, Commands=@2, ChatColor=@3";
 			if (database.Query(query, name, parentname, permissions, chatcolor) == 1)

--- a/TShockAPI/DB/ProjectileManager.cs
+++ b/TShockAPI/DB/ProjectileManager.cs
@@ -25,12 +25,12 @@ using TShockAPI.Hooks;
 
 namespace TShockAPI.DB
 {
-	public class ProjectileManagager
+	public class ProjectileManager
 	{
 		private IDbConnection database;
 		public List<ProjectileBan> ProjectileBans = new List<ProjectileBan>();
 
-		public ProjectileManagager(IDbConnection db)
+		public ProjectileManager(IDbConnection db)
 		{
 			database = db;
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -93,7 +93,7 @@ namespace TShockAPI
 		/// <summary>Users - Static reference to the user manager for accessing the user database system.</summary>
 		public static UserAccountManager UserAccounts;
 		/// <summary>ProjectileBans - Static reference to the projectile ban system.</summary>
-		public static ProjectileManagager ProjectileBans;
+		public static ProjectileManager ProjectileBans;
 		/// <summary>TileBans - Static reference to the tile ban system.</summary>
 		public static TileManager TileBans;
 		/// <summary>RememberedPos - Static reference to the remembered position manager.</summary>
@@ -367,7 +367,7 @@ namespace TShockAPI
 				Regions = new RegionManager(DB);
 				UserAccounts = new UserAccountManager(DB);
 				Groups = new GroupManager(DB);
-				ProjectileBans = new ProjectileManagager(DB);
+				ProjectileBans = new ProjectileManager(DB);
 				TileBans = new TileManager(DB);
 				RememberedPos = new RememberedPosManager(DB);
 				CharacterDB = new CharacterManager(DB);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1379,7 +1379,7 @@ namespace TShockAPI
 			if (tsplr.ReceivedInfo)
 			{
 				if (!tsplr.SilentKickInProgress && tsplr.State >= 3)
-					Utils.Broadcast(tsplr.Name + " has left.", Color.Yellow);
+					Utils.Broadcast(tsplr.Name + " [c/ff6464:h][c/ff6b65:a][c/ff7266:s] [c/ff8069:l][c/ff876a:e][c/ff8e6c:f][c/ff956d:t][c/ff9d6f:!]", Color.IndianRed);
 				Log.Info("{0} disconnected.", tsplr.Name);
 
 				if (tsplr.IsLoggedIn && !tsplr.IsDisabledPendingTrashRemoval && Main.ServerSideCharacter && (!tsplr.Dead || tsplr.TPlayer.difficulty != 2))
@@ -1642,14 +1642,14 @@ namespace TShockAPI
 									   player.Group.Name, player.Country, TShock.Utils.GetActivePlayerCount(),
 									   TShock.Config.Settings.MaxSlots));
 				if (!player.SilentJoinInProgress)
-					Utils.Broadcast(GetString("{0} ({1}) has joined.", player.Name, player.Country), Color.Yellow);
+					Utils.Broadcast(GetString("{0} ({1}) [c/8080ff:h][c/8073ff:a][c/8066ff:s] [c/804cff:j][c/8040ff:o][c/8033ff:i][c/8026ff:n][c/8019ff:e][c/800cff:d][c/8000ff:!]", player.Name, player.Country), Color.LightGreen);
 			}
 			else
 			{
 				Log.Info(GetString("{0} ({1}) from '{2}' group joined. ({3}/{4})", player.Name, player.IP,
 									   player.Group.Name, TShock.Utils.GetActivePlayerCount(), TShock.Config.Settings.MaxSlots));
 				if (!player.SilentJoinInProgress)
-					Utils.Broadcast(GetString("{0} has joined.", player.Name), Color.Yellow);
+					Utils.Broadcast(GetString("{0} [c/8080ff:h][c/8073ff:a][c/8066ff:s] [c/804cff:j][c/8040ff:o][c/8033ff:i][c/8026ff:n][c/8019ff:e][c/800cff:d][c/8000ff:!]", player.Name), Color.LightGreen);
 			}
 
 			if (Config.Settings.DisplayIPToAdmins)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -314,13 +314,13 @@ namespace TShockAPI
 			// Further exceptions are written to TShock's log from now on.
 			try
 			{
-				if (Config.Settings.StorageType.ToLower() == "sqlite")
+				if (Config.Settings.StorageType.ToLower() == "sqlite" && Config.Settings.TShockDBType != "mysql")
 				{
 					string sql = Path.Combine(SavePath, Config.Settings.SqliteDBPath);
 					Directory.CreateDirectory(Path.GetDirectoryName(sql));
 					DB = new Microsoft.Data.Sqlite.SqliteConnection(string.Format("Data Source={0}", sql));
 				}
-				else if (Config.Settings.StorageType.ToLower() == "mysql")
+				else if (Config.Settings.StorageType.ToLower() == "mysql" || (Config.Settings.isStorageTypeSeperateFromTShockDBType == true && Config.Settings.TShockDBType == "mysql"))
 				{
 					try
 					{


### PR DESCRIPTION
In this pull request, I have implemented two new config options:

    "isStorageTypeSeperateFromTShockDBType": true/false
    "TShockDBType": "mysql"/"sqlite"
    
 Essentially, what this does is allow the actual TShock DB (the one that stores things like Users, Bans, etc.) to be stored in a separate the way than the rest of the plugins.

What is the use case of this? If someone wanted User groups to be global across multiple servers but wanted local plugin storage. This was a pretty simple implementation and the server seems to be running fine with no problems!