### PR TITLE
Add WorldTileProvider to tshock config

### DIFF
--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -55,6 +55,10 @@ namespace TShockAPI.Configuration
 		[Description("Allows stacks in chests to go beyond the stack limit during world loading.")]
 		public bool IgnoreChestStacksOnLoad = false;
 
+		/// <summary>Allows changing of the default world tile provider.</summary>
+		[Description("Allows changing of the default world tile provider.")]
+		public string WorldTileProvider = "default";
+
 		#endregion
 
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -384,7 +384,7 @@ namespace TShockAPI
 					Geo = new GeoIPCountry(geoippath);
 
 				// check if a custom tile provider is to be used
-				switch(Config.Settings.WorldTileProvider)
+				switch(Config.Settings.WorldTileProvider?.ToLower())
 				{
 					case "heaptile":
 						Log.ConsoleInfo(GetString($"Using {nameof(HeapTile)} for tile implementation"), TraceLevel.Info);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -383,6 +383,19 @@ namespace TShockAPI
 				if (Config.Settings.EnableGeoIP && File.Exists(geoippath))
 					Geo = new GeoIPCountry(geoippath);
 
+				// check if a custom tile provider is to be used
+				switch(Config.Settings.WorldTileProvider)
+				{
+					case "heaptile":
+						Log.ConsoleInfo(GetString($"Using {nameof(HeapTile)} for tile implementation"), TraceLevel.Info);
+						Main.tile = new TileProvider();
+						break;
+					case "constileation":
+						Log.ConsoleInfo(GetString($"Using {nameof(ConstileationProvider)} for tile implementation"), TraceLevel.Info);
+						Main.tile = new ConstileationProvider();
+						break;
+				}
+
 				Log.ConsoleInfo(GetString("TShock {0} ({1}) now running.", Version, VersionCodename));
 
 				ServerApi.Hooks.GamePostInitialize.Register(this, OnPostInit);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -79,6 +79,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 
 ## Upcoming changes
 * Your changes could be here!
+* Added `WorldTileProvider` to the tshock config with values `default`, `constileation` or `heaptile`. This allows tile providers to be changed in environments where CLI args cannot be altered. See the documentation website for more info about these providers. (@SignatureBeef)
 
 ## TShock 5.1.2
 * Added support for Terraria 1.4.4.8.1 via OTAPI 3.1.19. (@SignatureBeef)


### PR DESCRIPTION
This allows the tshock tile providers to be switched via the config instead of cli args via tsapi, for environments where the command line args cannot be changed.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
