### PR TITLE
Add tshock installer executable

### DIFF
--- a/.github/workflows/ci-otapi3.yml
+++ b/.github/workflows/ci-otapi3.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Install msgfmt
         run: sudo apt-get install -y gettext
 
+      - name: Produce installer
+        run: |
+            cd TShockInstaller
+            dotnet publish -r ${{ matrix.arch }} -f net6.0 -c Release -p:PublishSingleFile=true --self-contained true
+
       - name: Produce build
         run: |
             cd TShockLauncher
@@ -45,6 +50,10 @@ jobs:
         if: ${{ matrix.arch != 'win-x64' }}
         run: |
             chmod +x TShockLauncher/bin/Release/net6.0/${{ matrix.arch }}/publish/TShock.Server
+
+      - name: Copy installer
+        run: |
+            cp TShockInstaller/bin/Release/net6.0/${{ matrix.arch }}/publish/* TShockLauncher/bin/Release/net6.0/${{ matrix.arch }}/publish/
 
       # preserve file perms: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: Tarball artifact (non-Windows)

--- a/TShock.sln
+++ b/TShock.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TShockLauncher", "TShockLau
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TShockLauncher.Tests", "TShockLauncher.Tests\TShockLauncher.Tests.csproj", "{90AB47F3-8220-48FC-BDAB-D6E97BFDA51B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TShockInstaller", "TShockInstaller\TShockInstaller.csproj", "{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +104,22 @@ Global
 		{90AB47F3-8220-48FC-BDAB-D6E97BFDA51B}.Release|x64.Build.0 = Release|Any CPU
 		{90AB47F3-8220-48FC-BDAB-D6E97BFDA51B}.Release|x86.ActiveCfg = Release|Any CPU
 		{90AB47F3-8220-48FC-BDAB-D6E97BFDA51B}.Release|x86.Build.0 = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Debug|x86.Build.0 = Debug|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|x64.Build.0 = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|x86.ActiveCfg = Release|Any CPU
+		{17AC4DD0-8334-4B5C-ABED-77EAF52D75FA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TShockInstaller/Program.cs
+++ b/TShockInstaller/Program.cs
@@ -1,0 +1,93 @@
+﻿using System.Diagnostics;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using ICSharpCode.SharpZipLib.GZip;
+using ICSharpCode.SharpZipLib.Tar;
+
+Console.WriteLine($"TShock Installer {typeof(Program).GetType().Assembly.GetName().Version}.");
+
+// reference: https://github.com/dotnet/install-scripts/blob/main/src/dotnet-install.sh
+// ./dotnet-install.sh -verbose -version 6.0.11 --runtime dotnet
+
+Console.WriteLine("Determining dotnet runtime url...");
+
+string? url = null;
+if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-osx-x64.tar.gz";
+else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-win-x64.zip";
+else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-linux-x64.tar.gz";
+
+if(url is null)
+{
+	Console.WriteLine("Unable to determine .net runtime to install. " +
+		"Refer to https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script " +
+		"and install using --install-dir dotnet, so that the dotnet folder is beside TShock.Server.dll");
+	return;
+}
+
+Console.WriteLine("Using url: " + url);
+
+var filename = url.Split('/').Last();
+var is_targz = filename.EndsWith(".tar.gz");
+
+var download_info = new FileInfo(filename);
+if (!download_info.Exists) // todo hash check
+{
+	Console.WriteLine($"Downloading: {filename}...");
+
+	using var client = new HttpClient();
+	using var resp = await client.GetStreamAsync(url);
+	using var fs = new FileStream(filename, FileMode.Create);
+	await resp.CopyToAsync(fs);
+}
+else
+{
+	Console.WriteLine("Using existing download on disk: " + filename);
+}
+
+var dotnet_path = Path.Combine("dotnet", "dotnet" + (is_targz ? "" : ".exe"));
+var tshock_path = "TShock.Server" + (is_targz ? "" : ".exe");
+
+if (!File.Exists(dotnet_path))
+{
+	Console.WriteLine("Extracting to ./dotnet/");
+	if (is_targz)
+	{
+		using var srm_dotnet_file = File.OpenRead(filename);
+		using var srm_gzip = new GZipInputStream(srm_dotnet_file);
+
+		using var tar_archive = TarArchive.CreateInputTarArchive(srm_gzip, System.Text.Encoding.UTF8);
+		tar_archive.ExtractContents("dotnet");
+
+		[DllImport("libc", SetLastError = true)]
+		static extern int chmod(string pathname, int mode);
+
+		chmod(dotnet_path, 755);
+	}
+	else
+	{
+		ZipFile.ExtractToDirectory(filename, "dotnet");
+	}
+}
+else
+{
+	Console.WriteLine($"Extract skipped, existing found at: {dotnet_path}");
+}
+
+var dotnet_root = System.IO.Path.GetFullPath("dotnet");
+Console.WriteLine($"To be able to run {tshock_path} yourself set the environment variable DOTNET_ROOT={dotnet_root}");
+
+Environment.SetEnvironmentVariable("DOTNET_ROOT", dotnet_root);
+
+Console.WriteLine($"Extracted, launching: {tshock_path}");
+var proc = new Process();
+proc.StartInfo = new()
+{
+	 FileName = tshock_path,
+};
+foreach (var arg in args)
+	proc.StartInfo.ArgumentList.Add(arg);
+proc.Start();
+await proc.WaitForExitAsync();

--- a/TShockInstaller/Program.cs
+++ b/TShockInstaller/Program.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 
-Console.WriteLine($"TShock Installer {typeof(Program).GetType().Assembly.GetName().Version}.");
+Console.WriteLine($"TShock Installer {typeof(Program).Assembly.GetName().Version}.");
 
 // reference: https://github.com/dotnet/install-scripts/blob/main/src/dotnet-install.sh
 // ./dotnet-install.sh -verbose -version 6.0.11 --runtime dotnet

--- a/TShockInstaller/Program.cs
+++ b/TShockInstaller/Program.cs
@@ -95,7 +95,14 @@ Console.WriteLine($"To be able to run {tshock_path} yourself set the environment
 Environment.SetEnvironmentVariable("DOTNET_ROOT", dotnet_root);
 
 Console.WriteLine($"Extracted, launching: {tshock_path}");
+
 var proc = new Process();
+
+Console.CancelKeyPress += (sender, e) =>
+{
+	e.Cancel = !proc.HasExited;
+};
+
 proc.StartInfo = new()
 {
 	 FileName = tshock_path,

--- a/TShockInstaller/Program.cs
+++ b/TShockInstaller/Program.cs
@@ -36,7 +36,7 @@ if(url is null)
 {
 	Console.WriteLine("Unable to determine .net runtime to install. " +
 		"Refer to https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script " +
-		"and install using --install-dir dotnet, so that the dotnet folder is beside TShock.Server.dll");
+		"and install using --install-dir dotnet, so that the dotnet folder is beside TShock.Server[.exe]");
 	return;
 }
 

--- a/TShockInstaller/Program.cs
+++ b/TShockInstaller/Program.cs
@@ -11,13 +11,26 @@ Console.WriteLine($"TShock Installer {typeof(Program).GetType().Assembly.GetName
 
 Console.WriteLine("Determining dotnet runtime url...");
 
+var arch = RuntimeInformation.ProcessArchitecture switch
+{
+	Architecture.X64 => "x64",
+	Architecture.Arm64 => "arm64",
+	_ => null
+};
+
+if (arch is null)
+{
+	Console.WriteLine($"{RuntimeInformation.ProcessArchitecture} is not yet supported via this installer.");
+	return;
+}
+
 string? url = null;
 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-osx-x64.tar.gz";
+	url = $"https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-osx-{arch}.tar.gz";
 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-win-x64.zip";
+	url = $"https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-win-{arch}.zip";
 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-	url = "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-linux-x64.tar.gz";
+	url = $"https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.11/dotnet-runtime-6.0.11-linux-{arch}.tar.gz";
 
 if(url is null)
 {

--- a/TShockInstaller/TShockInstaller.csproj
+++ b/TShockInstaller/TShockInstaller.csproj
@@ -8,6 +8,7 @@
     <Version>5.0.0</Version>
     <PublishTrimmed>true</PublishTrimmed>
     <AssemblyName>TShock.Installer</AssemblyName>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TShockInstaller/TShockInstaller.csproj
+++ b/TShockInstaller/TShockInstaller.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Version>5.0.0</Version>
+    <PublishTrimmed>true</PublishTrimmed>
+    <AssemblyName>TShock.Installer</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.4.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This aims to fix a lot of the "the console just closes" issues we've been seeing recently by adding a second executable, `./TShock.Installer[.exe]`, to the archive for those who do not have dotnet installed globally on their system.

The installer will download the dotnet 6.0.11 runtime to a local ./dotnet folder, it will then set the DOTNET_ROOT environment variable that ./TShock.Server will proceed to use to run the non-self contained version.

**Why not just make TShock.Server be self contained?** 
1. Because many people have expressed they do not want dotnet in every installation, especially when considering GSP's whom already have it installed globally.
2. MonoMod has had issues with jit hooks, at least on arm64 when in self-contained + single file modes. however, this can be explored further due to recent changes, or via the new reorg branch which may allow clrjit to be found easier (at least for custom setups) which was difficult in the current version. alternatively, single file mode should just be avoided at the expense of more ./bin redirections, but point 1 takes precedence so this is not really effective either way.

**Will TShock.Server be affected?** 
No, it remains the same, the Installer will just setup dotnet, and call the existing setup which remains a singlefile but not self-contained (TShock.Server[.exe]).

**Can TShock.Server not be a single file so TShock.Server.dll and others are extracted?** 
Yes, but out of scope for this PR (and mainly just a flag in CI if someone wanted to change that later)

**Why do you hardcode the urls?** 
Because we don't support .net7 yet, nor did i want to overcomplicate the downloading using APIs. Happy for someone to do this, and ive left the reference to dotnet-install.[ps1/sh] which can be used to do this for when security/patches are released, but for now, 6.0.11 is known to work.

**Can TShock.Installer[.exe] be called x instead?** 
Yes, i have no emotional attachment, i only cared about the actual functionality, so happy to rename, or someone can rename after merging if there is some preference later before a release/doco.

_note, i would suggest updating doco if this gets merged to make people aware of this, but if they read the docs they would know to install dotnet to begin with, so hopefully by naming it TShock.Installer, they will try it by nature, and thus will download dotnet for them..._

**Below are what the installer looks like on various OS's:** 

_note, ignore `TShock Installer 6.0.0.0` being printed, fixed in a recent commit to show 5.0.0_

Linux ARM64 / RPI
![image](https://user-images.githubusercontent.com/776327/202931747-aa38a184-4ae9-4dc8-940a-b673f6ad2d74.png)

OSX x64 Intel:
![image](https://user-images.githubusercontent.com/776327/202932499-862bc799-dc37-478a-bfe8-75bb8321dfb5.png)

Ubuntu x64 (ubuntu-22.10-live-server-amd64):
![VirtualBox_Ubuntu_21_11_2022_09_34_39](https://user-images.githubusercontent.com/776327/202932640-f25bcee8-cb08-4089-8c6d-21a7b95cc78e.png)

Windows 11 x64:
![Screenshot 2022-11-21 094503](https://user-images.githubusercontent.com/776327/202933174-3a2061d5-cf02-4e0a-8899-26f3ef024d07.png)


<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
