### PR TITLE
Whitelist the Mighty Wind and Hellfire buffs

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -400,7 +400,7 @@ namespace TShockAPI
 			};
 			PlayerAddBuffWhitelist[BuffID.OnFire3] = new BuffLimit
 			{
-				MaxTicks = 60 * 5,
+				MaxTicks = 60 * 6,
 				CanBeAddedWithoutHostile = false,
 				CanOnlyBeAppliedToSender = false
 			};

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -428,6 +428,12 @@ namespace TShockAPI
 				CanBeAddedWithoutHostile = true,
 				CanOnlyBeAppliedToSender = true
 			};
+			PlayerAddBuffWhitelist[BuffID.WindPushed] = new BuffLimit
+			{
+				MaxTicks = 2,
+				CanBeAddedWithoutHostile = true,
+				CanOnlyBeAppliedToSender = true
+			};
 
 			#endregion Whitelist
 		}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,6 +84,8 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Improved rejection message and code duplication in `OnPlayerBuff` (@drunderscore)
   * This will make it so Bouncer rejections regarding `PlayerAddBuff` will now always include the sender index, buff type, receiver index, and time in ticks, allowing much faster triage of buff whitelist issues.
 * Allowed Digging Molecart and bomb fish to break tiles and place tracks (@sgkoishi)
+* Increased whitelisted duration of the Mighty Wind (`WindPushed`) buff (from sandstorms). (@drunderscore)
+* Whitelisted the Hellfire (`OnFire3`) buff. (@drunderscore)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
This was reported in [this comment](https://github.com/Pryaxis/TShock/pull/2827#issuecomment-1328418946), and then reminded to me by another Discord server.