### PR TITLE
Initialize achievements and the `AchievementManager` on the server

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -45,6 +45,10 @@ using TShockAPI.Localization;
 using TShockAPI.Configuration;
 using Terraria.GameContent.Creative;
 using System.Runtime.InteropServices;
+using MonoMod.Cil;
+using Terraria.Achievements;
+using Terraria.Initializers;
+using Terraria.UI.Chat;
 using TShockAPI.Modules;
 
 namespace TShockAPI
@@ -429,6 +433,33 @@ namespace TShockAPI
 
 				EnglishLanguage.Initialize();
 
+				// The AchievementTagHandler expects Main.Achievements to be non-null, which is not normally the case on dedicated servers.
+				// When trying to parse an achievement chat tag, it will instead throw.
+				// The tag is parsed when calling ChatManager.ParseMessage, which is used in TShock when writing chat messages to the
+				// console. Our OnChat handler uses Utils.Broadcast, which will send the message to all connected clients, write the message
+				// to the console and the log. Due to the order of execution, the message ends up being sent to all connected clients, but
+				// throws whilst trying to write to the console, and never gets written to the log.
+				// To solve the issue, we make achievements available on the server, allowing the tag handler to work as expected, and
+				// even allowing the localization of achievement names to appear in the console.
+
+				if (Game != null)
+				{
+					// Initialize the AchievementManager, which is normally only done on clients.
+					Game._achievements = new AchievementManager();
+
+					IL.Terraria.Initializers.AchievementInitializer.Load += OnAchievementInitializerLoad;
+
+					// Actually call AchievementInitializer.Load, which is also normally only done on clients.
+					AchievementInitializer.Load();
+				}
+				else
+				{
+					// If we don't have a Game instance, then we'll just remove the achievement tag handler entirely. This will cause the
+					// raw tag to just be used instead (and not be localized), but still avoid all the issues outlined above.
+					ChatManager._handlers.Remove("a", out _);
+					ChatManager._handlers.Remove("achievement", out _);
+				}
+
 				ModuleManager.Initialise(new object[] { this });
 
 				if (Config.Settings.RestApiEnabled)
@@ -465,6 +496,13 @@ namespace TShockAPI
 			}
 		}
 
+		private static void OnAchievementInitializerLoad(ILContext il)
+		{
+			// Modify AchievementInitializer.Load to remove the Main.netMode == 2 check (occupies the first 4 IL instructions)
+			for (var i = 0; i < 4; i++)
+				il.Body.Instructions.RemoveAt(0);
+		}
+
 		protected void CrashReporter_HeapshotRequesting(object sender, EventArgs e)
 		{
 			foreach (TSPlayer player in TShock.Players)
@@ -485,6 +523,8 @@ namespace TShockAPI
 					Geo.Dispose();
 				}
 				SaveManager.Instance.Dispose();
+
+				IL.Terraria.Initializers.AchievementInitializer.Load -= OnAchievementInitializerLoad;
 
 				ModuleManager.Dispose();
 

--- a/TShockLauncher.Tests/ChatTests.cs
+++ b/TShockLauncher.Tests/ChatTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Xna.Framework;
+using NUnit.Framework;
+using Terraria.UI.Chat;
+
+namespace TShockLauncher.Tests;
+
+public class ChatTests
+{
+	/// <summary>
+	/// Ensures that the <see cref="Terraria.GameContent.UI.Chat.AchievementTagHandler"/> does not cause exceptions when used on the server.
+	/// </summary>
+	///
+	/// <remarks>The behaviour of TShock regarding the achievement tag handler changes depending on if TShock has
+	/// a <see cref="Terraria.Main"/> instance or not. Therefore, we do not check the correctness of the parsed message, but only if it
+	/// throws an exception.
+	/// </remarks>
+	[TestCase]
+	public void TestChatAchievementTagHandler()
+	{
+		Assert.That(() =>
+		{
+			ChatManager.ParseMessage("No achievement tags", Color.White);
+			ChatManager.ParseMessage("One achievement tag: [a:KILL_THE_SUN]", Color.White);
+			ChatManager.ParseMessage("One achievement tag, using the longer variant: [achievement:KILL_THE_SUN]", Color.White);
+			ChatManager.ParseMessage("Multiple achievement tags: [a:KILL_THE_SUN] and [a:TOPPED_OFF]", Color.White);
+			ChatManager.ParseMessage("One achievement tag, referring to a non-existent achievement: [a:_THIS_WILL_NEVER_EXIST_]", Color.White);
+			ChatManager.ParseMessage("Both valid and invalid achievement tags: [a:KILL_THE_SUN] and [a:_THIS_WILL_NEVER_EXIST_]", Color.White);
+		}, Throws.Nothing);
+	}
+}

--- a/TShockLauncher.Tests/GroupTests.cs
+++ b/TShockLauncher.Tests/GroupTests.cs
@@ -1,6 +1,4 @@
 using NUnit.Framework;
-using Terraria;
-using Terraria.Localization;
 using TShockAPI;
 using TShockAPI.DB;
 
@@ -8,21 +6,6 @@ namespace TShockLauncher.Tests;
 
 public class GroupTests
 {
-	/// <summary>
-	/// This will be called automatically by nunit before other tests in this class.
-	/// It serves to initialise the bare minimum variables needed for TShock to be testable without booting up an actual server.
-	/// </summary>
-	[SetUp]
-	public static void SetupTShock()
-	{
-		Program.SavePath = ""; // 1.4.4.2 staticness introduced this where by default it is null, and any touch to Terraria.Main will use it and cause a crash.
-		LanguageManager.Instance.SetLanguage(GameCulture.DefaultCulture); // TShockAPI.Localization will fail without ActiveCulture set
-		Lang.InitializeLegacyLocalization(); // TShockAPI.Localization will fail without preparing NPC names etc
-
-		var ts = new TShock(null); // prepares configs etc
-		ts.Initialize(); // used to prepare tshocks own static variables, such as the TShock.DB instance
-	}
-
 	/// <summary>
 	/// This tests to ensure the group commands work.
 	/// </summary>

--- a/TShockLauncher.Tests/TestSetup.cs
+++ b/TShockLauncher.Tests/TestSetup.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using Terraria;
+using Terraria.Localization;
+using TShockAPI;
+
+namespace TShockLauncher.Tests;
+
+[SetUpFixture]
+public class TestSetup
+{
+	/// <summary>
+	/// This will be called automatically by NUnit before the first test.
+	/// It serves to initialise the bare minimum variables needed for TShock to be testable without booting up an actual server.
+	/// </summary>
+	[OneTimeSetUp]
+	public static void SetupTShock()
+	{
+		Program.SavePath = ""; // 1.4.4.2 staticness introduced this where by default it is null, and any touch to Terraria.Main will use it and cause a crash.
+		LanguageManager.Instance.SetLanguage(GameCulture.DefaultCulture); // TShockAPI.Localization will fail without ActiveCulture set
+		Lang.InitializeLegacyLocalization(); // TShockAPI.Localization will fail without preparing NPC names etc
+
+		var ts = new TShock(null); // prepares configs etc
+		ts.Initialize(); // used to prepare tshocks own static variables, such as the TShock.DB instance
+	}
+}

--- a/TShockLauncher.Tests/TestSetup.cs
+++ b/TShockLauncher.Tests/TestSetup.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Terraria;
+using Terraria.Initializers;
 using Terraria.Localization;
 using TShockAPI;
 
@@ -15,6 +16,8 @@ public class TestSetup
 	[OneTimeSetUp]
 	public static void SetupTShock()
 	{
+		ChatInitializer.Load();
+
 		Program.SavePath = ""; // 1.4.4.2 staticness introduced this where by default it is null, and any touch to Terraria.Main will use it and cause a crash.
 		LanguageManager.Instance.SetLanguage(GameCulture.DefaultCulture); // TShockAPI.Localization will fail without ActiveCulture set
 		Lang.InitializeLegacyLocalization(); // TShockAPI.Localization will fail without preparing NPC names etc

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,6 +84,8 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Improved rejection message and code duplication in `OnPlayerBuff` (@drunderscore)
   * This will make it so Bouncer rejections regarding `PlayerAddBuff` will now always include the sender index, buff type, receiver index, and time in ticks, allowing much faster triage of buff whitelist issues.
 * Allowed Digging Molecart and bomb fish to break tiles and place tracks (@sgkoishi)
+* Initialized achievements and the `AchievementManager` on the server. This ensures that players cannot cause exceptions to be thrown, chat messages are always logged, and allows achievement names to be localized in the console. Also added a test case for this. (@drunderscore)
+* Allowed multiple test cases to be in TShock's test suite. (@drunderscore)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
This formally fixes #2661

See the first commit's message for fine details about the fix itself.

Note that these changes should **never** cause achievements to be awarded or saved on the server. Some methods in `AchievementsHelper` check the `netMode` to ensure it is not on the server. For the methods that do not, it is either checked at the call site that it is not the server, or simply unreachable by control flow on the server. If you do know of an instance where the server could award an achievement, do let me know, because **it is undesirable**.

Edit: To visualize what this PR is actually achieving (get it??), here's a demonstration

Chat message:
```
woah i just got the [a:KILL_THE_SUN] achievement!
thats way better than the [a:TOPPED_OFF] achievement
neither of those compare to the [a:THIS_IS_NOT_VALID_LMAO] achievement
```

Console (no longer throws, and properly logs message):
![image](https://user-images.githubusercontent.com/15949431/205384928-e8c717dd-cfb0-4afc-a1b4-a31dfd3a78f6.png)
