### PR TITLE
Fixed startup error

### DIFF
--- a/TShockLauncher/Program.cs
+++ b/TShockLauncher/Program.cs
@@ -36,10 +36,7 @@ if (args.Length > 0 && args[0].ToLower() == "plugins")
 	await NugetCLI.Main(items);
 	return;
 }
-else
-{
-	Start();
-}
+
 
 Dictionary<string, Assembly> _cache = new Dictionary<string, Assembly>();
 


### PR DESCRIPTION
I don't know how this error came about, but I did encounter it when using the experimental version.
![VA{QF}HCMG%)5(Y9(U~4ZNB](https://user-images.githubusercontent.com/62204605/207224512-344d3cbd-1234-4d6a-abc3-afa7f105d0fa.png)
