### PR TITLE
Remove unnecessary range check for quick stack

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -676,13 +676,9 @@ namespace TShockAPI
 
 			if (args.Chest != null)
 			{
+				// After checking for protected regions, no further range checking is necessarily because the client packet only specifies the
+				// inventory slot to quick stack. The vanilla Terraria server itself determines what chests are close enough to the player.
 				if (Config.Settings.RegionProtectChests && !Regions.CanBuild((int)args.WorldPosition.X, (int)args.WorldPosition.Y, tsplr))
-				{
-					args.Handled = true;
-					return;
-				}
-
-				if (!tsplr.IsInRange(args.Chest.x, args.Chest.y))
 				{
 					args.Handled = true;
 					return;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -106,6 +106,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Allowed multiple test cases to be in TShock's test suite. (@drunderscore)
 * Fixed unable to use Purification/Evil Powder in jungle. (@sgkoishi)
 * Set the `GetDataHandledEventArgs.Player` property for the `SyncTilePicking` data handler. (@drunderscore)
+* Removed unnecessary range check that artifically shortened quick stack reach. (@boddyn, #2885, @bcat)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
Fixes #2885.

[As described here](https://github.com/Pryaxis/TShock/issues/2885#issuecomment-1367732843), vanilla Terraria already has a range check for quick stacking ([packet 85](https://tshock.readme.io/docs/multiplayer-packet-structure#force-item-into-nearest-chest-85) from the client only lists the inventory slot to quick stack, and the server decides what chests are close enough). As such, removing TShock's check is safe, and it enables quick stacking to the same range as vanilla (~36 tiles) rather than the 32 tiles TShock is limited to with the extra range check.

Example of distance that you couldn't quick stack from before, but can now after this fix:

![image](https://user-images.githubusercontent.com/115921/210279970-8719acbd-0f04-4d33-8c12-95c4feadf8b7.png)