### PR TITLE
Set the `GetDataHandledEventArgs.Player` property for the `SyncTilePicking` data handler

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2248,6 +2248,7 @@ namespace TShockAPI
 
 			var args = new SyncTilePickingEventArgs
 			{
+                                Player = player,
 				PlayerIndex = playerIndex,
 				TileX = tileX,
 				TileY = tileY,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -105,6 +105,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Initialized achievements and the `AchievementManager` on the server. This ensures that players cannot cause exceptions to be thrown, chat messages are always logged, and allows achievement names to be localized in the console. Also added a test case for this. (@drunderscore)
 * Allowed multiple test cases to be in TShock's test suite. (@drunderscore)
 * Fixed unable to use Purification/Evil Powder in jungle. (@sgkoishi)
+* Set the `GetDataHandledEventArgs.Player` property for the `SyncTilePicking` data handler. (@drunderscore)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
Small little bug that made it impossible to know the true source of the packet :^)