### PR TITLE
Added /ssc reset command

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1872,7 +1872,7 @@ namespace TShockAPI
 		{
 			args.Player.SendMessage(GetString("TShock SSC Help"), Color.White);
 			args.Player.SendMessage(GetString("Available SSC commands:"), Color.White);
-			args.Player.SendMessage(GetString($"ssc {"reset".Color(Utils.RedHighlight)} <Target> [Flags]"), Color.White);
+			args.Player.SendMessage(GetString($"ssc {"reset".Color(Utils.RedHighlight)} <User>"), Color.White);
 		}
 
 		private static void OverrideSSC(CommandArgs args)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -106,6 +106,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Allowed multiple test cases to be in TShock's test suite. (@drunderscore)
 * Fixed unable to use Purification/Evil Powder in jungle. (@sgkoishi)
 * Set the `GetDataHandledEventArgs.Player` property for the `SyncTilePicking` data handler. (@drunderscore)
+* Added the ability to reset a player's (or all players) SSC inventories via an-ingame command. (@renderbr)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
This pull request adds one very simple command: /ssc reset. Obviously, this will be the "ssc" manager, so other subcommands are perfectly welcome. For now, it only serves one function:

You may utilize the command in a few ways.

Firstly, /ssc reset *. This will reset all player's inventories, server-wide. Anyone with the ssc bypass permission will be, of course bypassed.

Then, you may either use /ssc reset [player name], which will reset a currently online player, OR instead of a player name you may use an account name, and it will reset the account's inventory despite whether or not the user is online. Obviously, the ssc bypass permission is taken into account here as well.

I think this command will be highly beneficial for... practically anyone utilizing SSC. In years past, we had to rely on plugins created by others, when the actual functionality for everything that is done here was already built into TShock, it just wasn't being utilized in this way. This will make the server administrator user experience much better. Obviously, I am also welcome to any feedback or changes that those of you reviewing would want to make.

I also removed some unused using directives, along with cleaned up some other areas of Commands.cs. If these changes are not welcome, feel free to remove them in the review.