### PR TITLE
Relax custom death message restrictions to allow Inferno potions in PvP

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2659,9 +2659,12 @@ namespace TShockAPI
 			 * If the player was not specified, that is, the player index is -1, then it is definitely a custom cause, as you can only deal damage with a projectile or another player.
 			 * This is how everything else works. If an NPC is specified, its value is not -1, which is a custom cause.
 			 *
+			 * An exception to this is damage dealt by the Inferno potion to other players -- it is only identified by the other index value of 16,
+			 * even lacking a source player index.
+			 *
 			 * Checking whether this damage came from the player is necessary, because the damage from the player can come even when it is hit by a NPC
 			*/
-			if (TShock.Config.Settings.DisableCustomDeathMessages && id != args.Player.Index &&
+			if (TShock.Config.Settings.DisableCustomDeathMessages && id != args.Player.Index && reason._sourceOtherIndex != 16 &&
 				(reason._sourcePlayerIndex == -1 || reason._sourceNPCIndex != -1 || reason._sourceOtherIndex != -1 || reason._sourceCustomReason != null))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerDamage rejected custom death message from {0}", args.Player.Name));

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -106,6 +106,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Allowed multiple test cases to be in TShock's test suite. (@drunderscore)
 * Fixed unable to use Purification/Evil Powder in jungle. (@sgkoishi)
 * Set the `GetDataHandledEventArgs.Player` property for the `SyncTilePicking` data handler. (@drunderscore)
+* Relaxed custom death message restrictions to allow Inferno potions in PvP. (@drunderscore)
 
 ## TShock 5.1.3
 * Added support for Terraria 1.4.4.9 via OTAPI 3.1.20. (@SignatureBeef)


### PR DESCRIPTION
This allows Inferno potions to properly deal damage in PvP (previously it was rejected).

Unfortunately, there is an additional bug relating to Inferno potions [described here](https://github.com/Pryaxis/Terraria/issues/13) that is impossible for us to patch.