### PR TITLE
Update server autostart instructions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -89,6 +89,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a method `TSPlayer.GiveItem`, which has `TShockAPI.NetItem` structure in its arguments. (@AgaSpace)
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
+* Updated the documentation for auto-starting the server. (@HerrSubset)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)

--- a/docs/command-line-parameters.md
+++ b/docs/command-line-parameters.md
@@ -31,6 +31,6 @@ These command line flags are in-addition to the ones that the Terraria server of
 
 ## Autostarting TShock
 
-If you want to start TShock automatically though a script, and bypass the interactive startup prompt, you need to specify a `-world` path, a `-port`, and `-maxplayers`.
+If you want to start TShock automatically though a script, and bypass the interactive startup prompt, you need to specify a `-world` path and `-autocreate`.
 
-For example: `TShock.Server.exe -world C:\Terraria\worlds\MyWorld.wld -port 7777 -maxplayers 8`
+For example: `TShock.Server.exe -world C:\Terraria\worlds\MyWorld.wld -autocreate 1`


### PR DESCRIPTION
Specifying a combination of -world, -port and -maxplayers did not auto-start the TShock server for me. I found that -world and -autocreate were required. The other settings could be read from config.json.

As such, I updated the documentation.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
