### PR TITLE
Rewrite the .dockerignore file into a denylist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,20 @@
-# ignore every file
-*
+# Ignore all Git metadata and build output (in all directories).
+**/.git*
+**/bin/
+**/obj/
 
-# except for the ones required for building
-!i18n/
-!prebuilts/
-!TerrariaServerAPI/
-!TShockAPI/
-!TShockLauncher/
-!TShockLauncher.Tests/
-!TShock.sln
-
-# but exclude build artifacts
-*/bin/
-*/obj/
+# Ignore other specific files that aren't needed for the build itself.
+/.all-contributorsrc
+/.dockerignore
+/.editorconfig
+/.vscode
+/appveyor.yml
+/COPYING
+/crowdin.yml
+/Dockerfile
+/docs
+/README.md
+/README_cn.md
+/renovate.json
+/scripts
+/SECURITY.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -89,6 +89,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a method `TSPlayer.GiveItem`, which has `TShockAPI.NetItem` structure in its arguments. (@AgaSpace)
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
+* Rewrote the `.dockerignore` file into a denylist. (@timschumi)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)


### PR DESCRIPTION
This should help with not forgetting to add any new directories (such as TShockInstaller and TShockPluginManager, which have been missing until now).