### PR TITLE
Add CI for Docker images

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,25 @@
+name: CI (Docker image)
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,windows/amd64
+          push: false
+          pull: true
+          cache-from: type=gha, scope=${{ github.workflow }}
+          cache-to: type=gha, scope=${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-ARG TARGETPLATFORM=linux/amd64
-ARG BUILDPLATFORM=${TARGETPLATFORM}
+# TARGETPLATFORM and BUILDPLATFORM are automatically filled in by Docker buildx.
+# They should not be set in the global scope manually.
 
 FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/dotnet/sdk:6.0 AS builder
-
-ARG TARGETPLATFORM
 
 # Copy build context
 WORKDIR /TShock
@@ -12,6 +10,10 @@ COPY . ./
 # Build and package release based on target architecture
 RUN dotnet build -v m
 WORKDIR /TShock/TShockLauncher
+
+# Make TARGETPLATFORM available to the container.
+ARG TARGETPLATFORM
+
 RUN \ 
   case "${TARGETPLATFORM}" in \
     "linux/amd64") export ARCH="linux-x64" \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,6 +90,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
+* Added CI for Docker images. (@timschumi)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,15 +14,15 @@ Open ports can also be passed through using `-p <host_port>:<container_port>`.
 
 For Example:
 ```bash
-# Building the image
-docker build -t tshock:linux-amd64 --build-arg TARGETPLATFORM=linux/amd64 .
+# Building the image using buildx and loading it into docker
+docker buildx build -t tshock:latest --load .
 
 # Running the image
 docker run -p 7777:7777 -p 7878:7878 \
            -v /home/cider/tshock/:/tshock \
            -v /home/cider/.local/share/Terraria/Worlds:/worlds \
            -v /home/cider/tshock/plugins:/plugins \
-           --rm -it tshock:linux-amd64 \
+           --rm -it tshock:latest \
            -world /worlds/backflip.wld -motd "OMFG DOCKER"
 ```
 
@@ -33,7 +33,7 @@ Using `docker buildx`, you could build [multi-platform images](https://docs.dock
 For Example:
 ```bash
 # Building the image using buildx and loading it into docker
-sudo docker buildx build -t tshock:linux-arm64 --platform linux/arm64 --load .
+docker buildx build -t tshock:linux-arm64 --platform linux/arm64 --load .
 
 # Running the image
 docker run -p 7777:7777 -p 7878:7878 \


### PR DESCRIPTION
This doesn't push the image anywhere, it just makes sure that the Docker build _works_.

Note that this removes the recommendation to use `docker build` even for native builds, since users would now have to set both `TARGETPLATFORM` and `BUILDPLATFORM` manually. `docker buildx` is available since Docker engine 19.03, which has been released in late 2019, so it isn't as bleeding-edge as it once was and more widely available now.