### PR TITLE
Fix `/wind`

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4622,21 +4622,22 @@ namespace TShockAPI
 		{
 			if (args.Parameters.Count != 1)
 			{
-				args.Player.SendErrorMessage(GetString("Invalid syntax. Proper syntax: {0}wind <speed>.", Specifier));
+				args.Player.SendErrorMessage(GetString("Invalid syntax. Proper syntax: {0}wind <speed in mph>.", Specifier));
 				return;
 			}
 
-			int speed;
-			if (!int.TryParse(args.Parameters[0], out speed) || speed * 100 < 0)
+			float mph;
+			if (!float.TryParse(args.Parameters[0], out mph) || mph is < -40f or > 40f)
 			{
-				args.Player.SendErrorMessage(GetString("Invalid wind speed."));
+				args.Player.SendErrorMessage(GetString("Invalid wind speed (must be between -40mph and 40mph)."));
 				return;
 			}
 
+			float speed = mph / 50f; // -40 to 40 mph -> -0.8 to 0.8
 			Main.windSpeedCurrent = speed;
 			Main.windSpeedTarget = speed;
 			TSPlayer.All.SendData(PacketTypes.WorldInfo);
-			TSPlayer.All.SendInfoMessage(GetString("{0} changed the wind speed to {1}.", args.Player.Name, speed));
+			TSPlayer.All.SendInfoMessage(GetString("{0} changed the wind speed to {1}mph.", args.Player.Name, mph));
 		}
 
 		#endregion Time/PvpFun Commands

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -4629,7 +4629,7 @@ namespace TShockAPI
 			float mph;
 			if (!float.TryParse(args.Parameters[0], out mph) || mph is < -40f or > 40f)
 			{
-				args.Player.SendErrorMessage(GetString("Invalid wind speed (must be between -40mph and 40mph)."));
+				args.Player.SendErrorMessage(GetString("Invalid wind speed (must be between -40 and 40)."));
 				return;
 			}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,6 +90,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
+* Fixed the `/wind` command not being very helpful. (@punchready)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)


### PR DESCRIPTION
The command was randomly changed in https://github.com/Pryaxis/TShock/commit/05a4e025f7831c6163daa8fbdb1c9436e61aa45e to parse as int instead but not do any conversions. This fixes it, allows entering the value in mph, and limits the range to the safe one also accessible through the journey menu.
See https://github.com/Pryaxis/TShock/discussions/3017.