### PR TITLE
Provide a way for plugins to override TShock SSC

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -883,7 +883,7 @@ namespace TShockAPI
 					args.Player.IsLoggedIn = true;
 					args.Player.IsDisabledForSSC = false;
 
-					if (Main.ServerSideCharacter)
+					if (TShock.UsingTShockSSC)
 					{
 						if (args.Player.HasPermission(Permissions.bypassssc))
 						{
@@ -954,7 +954,7 @@ namespace TShockAPI
 
 			args.Player.Logout();
 			args.Player.SendSuccessMessage(GetString("You have been successfully logged out of your account."));
-			if (Main.ServerSideCharacter)
+			if (TShock.UsingTShockSSC)
 			{
 				args.Player.SendWarningMessage(GetString("Server side characters are enabled. You need to be logged-in to play."));
 			}
@@ -1753,7 +1753,7 @@ namespace TShockAPI
 
 		private static void SaveSSC(CommandArgs args)
 		{
-			if (Main.ServerSideCharacter)
+			if (TShock.UsingTShockSSC)
 			{
 				args.Player.SendSuccessMessage(GetString("Your server-side character data has been saved."));
 				foreach (TSPlayer player in TShock.Players)
@@ -1768,9 +1768,9 @@ namespace TShockAPI
 
 		private static void OverrideSSC(CommandArgs args)
 		{
-			if (!Main.ServerSideCharacter)
+			if (!TShock.UsingTShockSSC)
 			{
-				args.Player.SendErrorMessage(GetString("Server-side characters is disabled."));
+				args.Player.SendErrorMessage(GetString("Server-side characters are disabled."));
 				return;
 			}
 			if (args.Parameters.Count < 1)
@@ -2026,7 +2026,7 @@ namespace TShockAPI
 		private static void Off(CommandArgs args)
 		{
 
-			if (Main.ServerSideCharacter)
+			if (TShock.UsingTShockSSC)
 			{
 				foreach (TSPlayer player in TShock.Players)
 				{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2600,7 +2600,7 @@ namespace TShockAPI
 			{
 				args.Player.PlayerData.StoreSlot(slot, type, prefix, stack);
 			}
-			else if (Main.ServerSideCharacter && TShock.Config.Settings.DisableLoginBeforeJoin && !bypassTrashCanCheck &&
+			else if (TShock.UsingTShockSSC && TShock.Config.Settings.DisableLoginBeforeJoin && !bypassTrashCanCheck &&
 					 args.Player.HasSentInventory && !args.Player.HasPermission(Permissions.bypassssc))
 			{
 				// The player might have moved an item to their trash can before they performed a single login attempt yet.
@@ -2645,7 +2645,7 @@ namespace TShockAPI
 					args.Player.IsLoggedIn = true;
 					args.Player.IsDisabledForSSC = false;
 
-					if (Main.ServerSideCharacter)
+					if (TShock.UsingTShockSSC)
 					{
 						if (args.Player.HasPermission(Permissions.bypassssc))
 						{
@@ -3230,7 +3230,7 @@ namespace TShockAPI
 					args.Player.IsLoggedIn = true;
 					args.Player.IsDisabledForSSC = false;
 
-					if (Main.ServerSideCharacter)
+					if (TShock.UsingTShockSSC)
 					{
 						if (args.Player.HasPermission(Permissions.bypassssc))
 						{
@@ -4263,7 +4263,7 @@ namespace TShockAPI
 				}
 			}
 
-			if (args.TPlayer.difficulty == 2 && Main.ServerSideCharacter && args.Player.IsLoggedIn)
+			if (args.TPlayer.difficulty == 2 && TShock.UsingTShockSSC && args.Player.IsLoggedIn)
 			{
 				if (TShock.CharacterDB.RemovePlayer(args.Player.Account.ID))
 				{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -137,6 +137,17 @@ namespace TShockAPI
 		/// </summary>
 		public static Dictionary<string, SecureRest.TokenData> RESTStartupTokens = new Dictionary<string, SecureRest.TokenData>();
 
+		/// <summary>
+		/// Whether to set a player's inventory with SSC and force them to log in to play. Set this to false to enable
+		/// server-side inventory setting while overriding TShock's implementation of it.
+		/// </summary>
+		public static bool UseSSCInventory { get; set; } = true;
+
+		/// <summary>
+		/// Whether TShock's server-side character system is enabled.
+		/// </summary>
+		public static bool UsingTShockSSC => Main.ServerSideCharacter && UseSSCInventory;
+
 		/// <summary>The TShock anti-cheat/anti-exploit system.</summary>
 		internal Bouncer Bouncer;
 
@@ -1100,7 +1111,7 @@ namespace TShockAPI
 				LastCheck = DateTime.UtcNow;
 			}
 
-			if (Main.ServerSideCharacter && (DateTime.UtcNow - LastSave).TotalMinutes >= ServerSideCharacterConfig.Settings.ServerSideCharacterSave)
+			if (UsingTShockSSC && (DateTime.UtcNow - LastSave).TotalMinutes >= ServerSideCharacterConfig.Settings.ServerSideCharacterSave)
 			{
 				foreach (TSPlayer player in Players)
 				{
@@ -1433,7 +1444,7 @@ namespace TShockAPI
 					Utils.Broadcast(GetString("{0} has left.", tsplr.Name), Color.Yellow);
 				Log.Info(GetString("{0} disconnected.", tsplr.Name));
 
-				if (tsplr.IsLoggedIn && !tsplr.IsDisabledPendingTrashRemoval && Main.ServerSideCharacter && (!tsplr.Dead || tsplr.TPlayer.difficulty != 2))
+				if (tsplr.IsLoggedIn && !tsplr.IsDisabledPendingTrashRemoval && UsingTShockSSC && (!tsplr.Dead || tsplr.TPlayer.difficulty != 2))
 				{
 					tsplr.PlayerData.CopyCharacter(tsplr);
 					CharacterDB.InsertPlayerData(tsplr);
@@ -1721,10 +1732,10 @@ namespace TShockAPI
 
 			if (!player.IsLoggedIn)
 			{
-				if (Main.ServerSideCharacter)
+				if (UsingTShockSSC)
 				{
 					player.IsDisabledForSSC = true;
-					player.SendErrorMessage(GetString("Server side characters is enabled! Please {0}register or {0}login to play!", Commands.Specifier));
+					player.SendErrorMessage(GetString("Server side characters are enabled! Please {0}register or {0}login to play!", Commands.Specifier));
 					player.LoginHarassed = true;
 				}
 				else if (Config.Settings.RequireLogin)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -90,6 +90,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
+* Added the property `TShock.UseSSCInventory` for plugin developers to override TShock's default SSC system. (@ZakFahey)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)


### PR DESCRIPTION
Add `TShock.UseSSCInventory`, which can be set to false by another plugin on initialization to override TShock's SSC implementation while keeping SSC on. This fixes the use case where you want to be able to override players' inventories from the server, but you don't want to use TShock's SSC system or force players to stay logged in.

Context: this functionality is in the internal Penguin Games server fork of TShock that we have, but I'm trying to merge everything from there upstream because I don't want to have to deal with maintaining a fork. Especially with 1.4.5 coming out any day now, I don't want to create more work for myself. We use SSC but allow logged-out users to play, and I'm sure that that's the case for other public servers as well.

Not all instances of `Main.ServerSideCharacter` were replaced because this is the code our server uses, and it works. I could understand wanting to change most if not all instances of it, though.