### PR TITLE
Lazy initialize TextLog._logWriter

### DIFF
--- a/TShockAPI/TextLog.cs
+++ b/TShockAPI/TextLog.cs
@@ -29,7 +29,8 @@ namespace TShockAPI
 	/// </summary>
 	public class TextLog : ILog, IDisposable
 	{
-		private readonly StreamWriter _logWriter;
+		private readonly bool ClearFile;
+		private StreamWriter _logWriter;
 
 		/// <summary>
 		/// File name of the Text log
@@ -44,7 +45,7 @@ namespace TShockAPI
 		public TextLog(string filename, bool clear)
 		{
 			FileName = filename;
-			_logWriter = new StreamWriter(filename, !clear);
+			ClearFile = clear;
 		}
 
 		public bool MayWriteType(TraceLevel type)
@@ -247,6 +248,10 @@ namespace TShockAPI
 		{
 			if (!MayWriteType(level))
 				return;
+			if (_logWriter is null)
+			{
+				_logWriter = new StreamWriter(FileName, !ClearFile);
+			}
 
 			var caller = "TShock";
 
@@ -278,7 +283,10 @@ namespace TShockAPI
 
 		public void Dispose()
 		{
-			_logWriter.Dispose();
+			if (_logWriter != null)
+			{
+				_logWriter.Dispose();
+			}
 		}
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -88,6 +88,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Added a method `TSPlayer.UpdateSection` with arguments `rectangle` and `isLoaded`, which will load some area from the server to the player. (@AgaSpace)
 * Added a method `TSPlayer.GiveItem`, which has `TShockAPI.NetItem` structure in its arguments. (@AgaSpace)
 * Added a property `TSPlayer.Hostile`, which gets pvp player mode. (@AgaSpace)
+* Fixed bug where when the `UseSqlLogs` config property is true, an empty log file would still get created. (@ZakFahey)
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
 


### PR DESCRIPTION
There is an instance of this in SqlLog that's used as a backup, but since the StreamWriter is created in the constructor, the file is created too. This means that you'll get an empty text log created every time a server starts up, even if you have text logs disabled. This is especially problematic when you have a multi-server setup with file write conflicts.