### PR TITLE
Increase Cursed Inferno Maximum Debuff Time

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2854,7 +2854,7 @@ namespace TShockAPI
 			{ BuffID.Poisoned, 3600 },              // BuffID: 20
 			{ BuffID.OnFire, 1200 },                // BuffID: 24
 			{ BuffID.Confused, short.MaxValue },    // BuffID: 31 Brain of Confusion Internal Item ID: 3223
-			{ BuffID.CursedInferno, 420 },          // BuffID: 39
+			{ BuffID.CursedInferno, 600 },          // BuffID: 39
 			{ BuffID.Frostburn, 900 },              // BuffID: 44
 			{ BuffID.Ichor, 1200 },                 // BuffID: 69
 			{ BuffID.Venom, 1800 },                 // BuffID: 70

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -92,6 +92,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Fixed typo in `/gbuff`. (@sgkoishi, #2955)
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
 * Added CI for Docker images. (@timschumi)
+* Fixed Cursed Flares kicking players for invalid buff. (@Arthri)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Warning: If you do not update the changelog, your pull request will be ignored and eventually closed, without comment, without any support, and without any opinion or interaction from the TShock team. This is your only warning. -->
Increased Cursed Inferno's maximum debuff time from 420 frames(8 seconds) to 600 frames(10 seconds), as Cursed Flare applies it with 10 seconds. https://terraria.wiki.gg/wiki/Cursed_Inferno