### PR TITLE
docker: Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -29,6 +29,14 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=pr
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Build image
         id: build
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up buildx
         uses: docker/setup-buildx-action@v3
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,windows/amd64

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -45,13 +45,14 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,windows/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           pull: true
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
       - name: Generate build provenance attestation
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -37,6 +37,8 @@ jobs:
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          flavor: |
+            latest=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Build image
         id: build
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
+      id-token: write
       packages: write
     steps:
       - name: Checkout
@@ -28,6 +30,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
       - name: Build image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -38,3 +41,9 @@ jobs:
           pull: true
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -14,12 +16,25 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate version information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,windows/amd64
-          push: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           pull: true
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -93,6 +93,7 @@ Use past tense when adding new entries; sign your name off when you add or chang
 * Rewrote the `.dockerignore` file into a denylist. (@timschumi)
 * Added CI for Docker images. (@timschumi)
 * Fixed Cursed Flares kicking players for invalid buff. (@Arthri)
+* Added automatic publishing of Docker images to GHCR. (@timschumi)
 
 ## TShock 5.2
 * An additional option `pvpwithnoteam` is added at `PvPMode` to enable PVP with no team. (@CelestialAnarchy, #2617, @ATFGK)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,32 +14,27 @@ Open ports can also be passed through using `-p <host_port>:<container_port>`.
 
 For Example:
 ```bash
-# Building the image using buildx and loading it into docker
-docker buildx build -t tshock:latest --load .
-
-# Running the image
 docker run -p 7777:7777 -p 7878:7878 \
            -v /home/cider/tshock/:/tshock \
            -v /home/cider/.local/share/Terraria/Worlds:/worlds \
            -v /home/cider/tshock/plugins:/plugins \
-           --rm -it tshock:latest \
+           --rm -it ghcr.io/pryaxis/tshock:latest \
            -world /worlds/backflip.wld -motd "OMFG DOCKER"
 ```
 
-## Building for Other Platforms
+## Building custom images
 
-Using `docker buildx`, you could build [multi-platform images](https://docs.docker.com/build/building/multi-platform/) for TShock.
+Occasionally, it may be necessary to adjust TShock with customizations that are not included in the upstream project.
+Therefore, these changes are also not available in the officially provided Docker images.
 
-For Example:
+To build and load a Docker image from your local checkout, use the following `buildx` command:
+
 ```bash
-# Building the image using buildx and loading it into docker
-docker buildx build -t tshock:linux-arm64 --platform linux/arm64 --load .
+docker buildx build -t tshock:latest --load .
+```
 
-# Running the image
-docker run -p 7777:7777 -p 7878:7878 \
-           -v /home/cider/tshock/:/tshock \
-           -v /home/cider/.local/share/Terraria/Worlds:/worlds \
-           -v /home/cider/tshock/plugins:/plugins \
-           --rm -it tshock:linux-arm64 \
-           -world /worlds/backflip.wld -motd "ARM64 ftw"
+It is also possible to build [multi-platform images](https://docs.docker.com/build/building/multi-platform/) for TShock (e.g. an image targeting `arm64`, on a host that is not `arm64`):
+
+```bash
+docker buildx build -t tshock:linux-arm64 --platform linux/arm64 --load .
 ```


### PR DESCRIPTION
This Pull Request implements automatic tagging and pushing of built Docker images to the GitHub Container Registry (ghcr.io).

**Note:** This PR failing the Docker CI is a result of changing token permissions. It should work fine once again once the PR is merged. Completed runs of these changes can be viewed [here](https://github.com/timschumi/TShock/actions), and an example PR is visible [here](https://github.com/timschumi/TShock/pull/2).

On the following events, the Action will generate and push tags:

| Event | Tags | Notes |
|----------|--------|----------|
| Push to branch `general-devel` | `ghcr.io/pryaxis/tshock:general-devel` | Applies to any branch |
| Push of tag `v2.2.2` | `ghcr.io/pryaxis/tshock:2.2.3` <br> `ghcr.io/pryaxis/tshock:2.2` <br> `ghcr.io/pryaxis/tshock:2` <br> `ghcr.io/pryaxis/tshock:latest` | Applies to any tag starting with `v` |
| Push of tag `some-testing-version` | `ghcr.io/pryaxis/tshock:some-testing-version` | Applies to any tag not starting with `v` |
| ~~Push to Pull Request #3048~~ | ~~`ghcr.io/pryaxis/tshock:pr-3048`~~ | ~~Applies to any Pull Request~~ |

The specific behavior can be adjusted in the Workflow file as necessary.
