### PR TITLE
Fix some confusion introduced by 98eed42 and b184133

### DIFF
--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -79,7 +79,7 @@ namespace TShockAPI.DB
 
 		public PlayerData GetPlayerData(TSPlayer player, int acctid)
 		{
-			PlayerData playerData = new PlayerData(false);
+			PlayerData playerData = new PlayerData(true);
 
 			try
 			{

--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -74,6 +74,7 @@ namespace TShockAPI.DB
 						Permissions.canchangepassword,
 						Permissions.canlogout,
 						Permissions.summonboss,
+						Permissions.worldupgrades,
 						Permissions.whisper,
 						Permissions.wormhole,
 						Permissions.canpaint,

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3619,8 +3619,9 @@ namespace TShockAPI
 			return false;
 		}
 
-		private static readonly int[] invasions = { -1, -2, -3, -4, -5, -6, -7, -8, -10, -11 };
+		private static readonly int[] invasions = { -1, -2, -3, -4, -5, -6, -7, -8, -10 };
 		private static readonly int[] pets = { -12, -13, -14, -15 };
+		private static readonly int[] upgrades = { -11, -17, -18 };
 		private static bool HandleSpawnBoss(GetDataHandlerArgs args)
 		{
 			if (args.Player.IsBouncerThrottled())
@@ -3632,8 +3633,8 @@ namespace TShockAPI
 			var plr = args.Data.ReadInt16();
 			var thingType = args.Data.ReadInt16();
 
-			var isKnownBoss = thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType];
-			if ((isKnownBoss || thingType == -16) && !args.Player.HasPermission(Permissions.summonboss))
+			var isKnownBoss = (thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType]) || thingType == -16;
+			if (isKnownBoss && !args.Player.HasPermission(Permissions.summonboss))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawnBoss rejected boss {0} {1}", args.Player.Name, thingType));
 				args.Player.SendErrorMessage(GetString("You do not have permission to summon bosses."));
@@ -3651,6 +3652,13 @@ namespace TShockAPI
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawnBoss rejected pet {0} {1}", args.Player.Name, thingType));
 				args.Player.SendErrorMessage(GetString("You do not have permission to spawn pets."));
+				return true;
+			}
+
+			if (upgrades.Contains(thingType) && !args.Player.HasPermission(Permissions.worldupgrades))
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawnBoss rejected upgrade {0} {1}", args.Player.Name, thingType));
+				args.Player.SendErrorMessage(GetString("You do not have permission to use permanent boosters."));
 				return true;
 			}
 
@@ -3720,7 +3728,7 @@ namespace TShockAPI
 					break;
 			}
 
-			if (NPCID.Sets.MPAllowedEnemies[thingType])
+			if (thingType < 0 || isKnownBoss)
 			{
 				if (TShock.Config.Settings.AnonymousBossInvasions)
 					TShock.Utils.SendLogs(thing, Color.PaleVioletRed, args.Player);

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -346,8 +346,12 @@ namespace TShockAPI
 		[Description("User can change the homes of NPCs.")]
 		public static readonly string movenpc = "tshock.world.movenpc";
 
+		[Obsolete("Feature no longer available.")]
 		[Description("User can convert hallow into corruption and vice-versa.")]
 		public static readonly string converthardmode = "tshock.world.converthardmode";
+
+		[Description("User can use world-based permanent boosters like Advanced Combat Techniques")]
+		public static readonly string worldupgrades = "tshock.world.worldupgrades";
 
 		[Description("User can force the server to Halloween mode.")]
 		public static readonly string halloween = "tshock.world.sethalloween";


### PR DESCRIPTION
* Deleted `tsCharacter` table will no longer result in empty inventory, but starter ones.
* [World-based permanent boosters](https://terraria.wiki.gg/wiki/Consumables#Permanent_boosters) like [`Advanced Combat Techniques`](https://terraria.wiki.gg/wiki/Advanced_Combat_Techniques) and [`Peddler's Satchel`](https://terraria.wiki.gg/wiki/Peddler%27s_Satchel) requires their corresponding permission instead of `summonboss`.

<hr>

* `converthardmode` was removed more than 10 years ago in 7f5ee04