### PR TITLE
Fix Pryaxis/TShock#3073

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1199,18 +1199,18 @@ namespace TShockAPI
 			int index = args.Index;
 			float[] ai = args.Ai;
 
+			// Clients do send NaN values so we can't just kick them
+			// See https://github.com/Pryaxis/TShock/issues/3076
 			if (!float.IsFinite(pos.X) || !float.IsFinite(pos.Y))
 			{
-				TShock.Log.ConsoleInfo(GetString("Bouncer / OnNewProjectile force kicked (attempted to set position to infinity or NaN) from {0}", args.Player.Name));
-				args.Player.Kick(GetString("Detected DOOM set to ON position."), true, true);
+				TShock.Log.ConsoleInfo(GetString("Bouncer / OnNewProjectile rejected set position to infinity or NaN from {0}", args.Player.Name));
 				args.Handled = true;
 				return;
 			}
 
 			if (!float.IsFinite(vel.X) || !float.IsFinite(vel.Y))
 			{
-				TShock.Log.ConsoleInfo(GetString("Bouncer / OnNewProjectile force kicked (attempted to set velocity to infinity or NaN) from {0}", args.Player.Name));
-				args.Player.Kick(GetString("Detected DOOM set to ON position."), true, true);
+				TShock.Log.ConsoleInfo(GetString("Bouncer / OnNewProjectile rejected set velocity to infinity or NaN from {0}", args.Player.Name));
 				args.Handled = true;
 				return;
 			}


### PR DESCRIPTION
This is a vanilla bug.

Some projectiles move in a way that depends on the position of the player, and they try to compute their 'direction' relative to the player, for example, `player.Center - projectile.Center`.

The [Counterweight](https://terraria.wiki.gg/wiki/Counterweights) appears to use `player.Center` as its default position, and it also calculates the direction (rotating), which is `{ X: 0, Y: 0 }`. Zero vector can't be normalized and attempt to normalize it will result in `{ X: NaN, Y: NaN }` - so the velocity and position are messed up because NaN values were added to them.

See also:
* Terraria.Player.Counterweight()
* Terraria.Projectile.HandleMovement() && aiStyle == 99