### PR TITLE
fix(SpawnHandler): player "break" after respawning

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2778,6 +2778,9 @@ namespace TShockAPI
 					return false;
 				}
 
+				// spawn the player before teleporting
+				NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)PlayerSpawnContext.ReviveFromDeath);
+
 				// the player has not changed his spawnpoint yet, so we assert the server-saved spawnpoint 
 				// by teleporting the player instead of letting the game use the client's incorrect spawnpoint.
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn force ssc teleport for {0} at ({1},{2})", args.Player.Name, args.TPlayer.SpawnX, args.TPlayer.SpawnY));


### PR DESCRIPTION
Mobile phone players see other players who respawned on SSC Server:
![89cd824576ede255dd47f1ab7da3d8e5](https://github.com/user-attachments/assets/47c9103c-9b76-472f-a0f6-5a2d60b0d996)
(Other players break into pieces) 
(PC players don't have this problem)
This PR add `NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)PlayerSpawnContext.ReviveFromDeath);` to sends respawn packet to other players before player teleports to spawnpoint (which make him "break")