### PR TITLE
feat: Add spawning pets perm to default group

### DIFF
--- a/TShockAPI/DB/GroupManager.cs
+++ b/TShockAPI/DB/GroupManager.cs
@@ -74,6 +74,7 @@ namespace TShockAPI.DB
 						Permissions.canchangepassword,
 						Permissions.canlogout,
 						Permissions.summonboss,
+						Permissions.spawnpets,
 						Permissions.worldupgrades,
 						Permissions.whisper,
 						Permissions.wormhole,


### PR DESCRIPTION
Add permission for users to spawn pets for default usergroup.
Codebase currently warns about possible high net usage over this permission, so discussions are in order in regards to enhancements to make this possible.

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. -->
