### PR TITLE
Fix console title not updating and world not saving when the last player disconnects

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1469,8 +1469,8 @@ namespace TShockAPI
 				Hooks.PlayerHooks.OnPlayerLogout(tsplr);
 			}
 
-			// The last player will leave after this hook is executed.
-			if (Utils.GetActivePlayerCount() == 1)
+			// If this is the last player online, update the console title and save the world if needed
+			if (Utils.GetActivePlayerCount() == 0)
 			{
 				if (Config.Settings.SaveWorldOnLastPlayerExit)
 					SaveManager.Instance.SaveWorld();


### PR DESCRIPTION
This fixes the issue where console title does not update and world not saving when last player disconnects
Issue #3096