### PR TITLE
Allow for reloading of player bans

### DIFF
--- a/TShockAPI/DB/BanManager.cs
+++ b/TShockAPI/DB/BanManager.cs
@@ -82,7 +82,7 @@ namespace TShockAPI.DB
 				throw new Exception(GetString("Could not find a database library (probably Sqlite3.dll)"));
 			}
 
-			EnsureBansCollection();
+			UpdateBans();
 			TryConvertBans();
 
 			OnBanValidate += BanValidateCheck;
@@ -90,14 +90,11 @@ namespace TShockAPI.DB
 		}
 
 		/// <summary>
-		/// Ensures the <see cref="_bans"/> collection is ready to use.
+		/// Updates the <see cref="_bans"/> collection from database.
 		/// </summary>
-		private void EnsureBansCollection()
+		public void UpdateBans()
 		{
-			if (_bans == null)
-			{
-				_bans = RetrieveAllBans().ToDictionary(b => b.TicketNumber);
-			}
+			_bans = RetrieveAllBans().ToDictionary(b => b.TicketNumber);
 		}
 
 		/// <summary>

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -607,6 +607,7 @@ namespace TShockAPI
 			TShock.ItemBans.DataModel.UpdateItemBans();
 			TShock.ProjectileBans.UpdateBans();
 			TShock.TileBans.UpdateBans();
+			TShock.Bans.UpdateBans();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Allows all bans to be reloaded from the database (similarly to item bans, projectile bans, groups etc) via the `UpdateBans` method in `BanManager` (`EnsureBansCollection`, but no longer single-use), and now does so when the reload command is executed. The method has been made public. I refrained from restructuring/refactoring `BanManager` any more than absolutely necessary.

I would like to update the `/reload` response string to be more verbose on specifically what has been reloaded, but am unsure of i18n implications so have left it be.