### PR TITLE
fix(Bouncer): fix players bypass region protection and build permissions when using Quick Stack

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -137,7 +137,7 @@ namespace TShockAPI
 			GetDataHandlers.KillMe += OnKillMe;
 			GetDataHandlers.FishOutNPC += OnFishOutNPC;
 			GetDataHandlers.FoodPlatterTryPlacing += OnFoodPlatterTryPlacing;
-			OTAPI.Hooks.Chest.QuickStack += OnChestOnQuickStack;
+			OTAPI.Hooks.Chest.QuickStack += OnQuickStack;
 
 
 			// The following section is based off Player.PlaceThing_Tiles_PlaceIt and Player.PlaceThing_Tiles_PlaceIt_GetLegacyTileStyle.
@@ -2877,7 +2877,7 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
-		internal void OnChestOnQuickStack(object sender, OTAPI.Hooks.Chest.QuickStackEventArgs args)
+		internal void OnQuickStack(object sender, OTAPI.Hooks.Chest.QuickStackEventArgs args)
 		{
 			var id = args.ChestIndex;
 			var plr = TShock.Players[args.PlayerId];
@@ -2898,13 +2898,6 @@ namespace TShockAPI
 			if (!plr.HasBuildPermission(Main.chest[id].x, Main.chest[id].y) && TShock.Config.Settings.RegionProtectChests)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnQuickStack rejected from region protection? from {0}", plr.Name));
-				args.Result = HookResult.Cancel;
-				return;
-			}
-
-			if (!plr.IsInRange(Main.chest[id].x, Main.chest[id].y, 600/16))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnQuickStack rejected from range check from {0}", plr.Name));
 				args.Result = HookResult.Cancel;
 				return;
 			}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -19,7 +19,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Terraria.ID;
-using TShockAPI.Net;
 using Terraria;
 using Microsoft.Xna.Framework;
 using TShockAPI.Localization;
@@ -29,6 +28,7 @@ using Terraria.DataStructures;
 using Terraria.Localization;
 using TShockAPI.Models.PlayerUpdate;
 using System.Threading.Tasks;
+using OTAPI;
 using Terraria.GameContent.Tile_Entities;
 
 namespace TShockAPI
@@ -137,6 +137,7 @@ namespace TShockAPI
 			GetDataHandlers.KillMe += OnKillMe;
 			GetDataHandlers.FishOutNPC += OnFishOutNPC;
 			GetDataHandlers.FoodPlatterTryPlacing += OnFoodPlatterTryPlacing;
+			OTAPI.Hooks.Chest.QuickStack += OnChestOnQuickStack;
 
 
 			// The following section is based off Player.PlaceThing_Tiles_PlaceIt and Player.PlaceThing_Tiles_PlaceIt_GetLegacyTileStyle.
@@ -2505,7 +2506,7 @@ namespace TShockAPI
 				Main.item[num].playerIndexTheItemIsReservedFor = args.Player.Index;
 				NetMessage.SendData((int)PacketTypes.ItemDrop, args.Player.Index, -1, NetworkText.Empty, num, 1f);
 				NetMessage.SendData((int)PacketTypes.ItemOwner, args.Player.Index, -1, NetworkText.Empty, num);
-				
+
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceItemFrame rejected permissions from {0}", args.Player.Name));
 				NetMessage.SendData((int)PacketTypes.UpdateTileEntity, -1, -1, NetworkText.Empty, args.ItemFrame.ID, 0, 1);
 				args.Handled = true;
@@ -2867,6 +2868,44 @@ namespace TShockAPI
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFoodPlatterTryPlacing rejected range checks from {0}", args.Player.Name));
 				args.Player.SendTileSquareCentered(args.TileX, args.TileY, 1);
 				args.Handled = true;
+				return;
+			}
+		}
+
+		/// <summary>
+		/// Called when a player is trying to put an item into chest through Quick Stack.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
+		internal void OnChestOnQuickStack(object sender, OTAPI.Hooks.Chest.QuickStackEventArgs args)
+		{
+			var id = args.ChestIndex;
+			var plr = TShock.Players[args.PlayerId];
+
+			if (plr is not { Active: true })
+			{
+				args.Result = HookResult.Cancel;
+				return;
+			}
+
+			if (plr.IsBeingDisabled())
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnQuickStack rejected from disable from {0}", plr.Name));
+				args.Result = HookResult.Cancel;
+				return;
+			}
+
+			if (!plr.HasBuildPermission(Main.chest[id].x, Main.chest[id].y) && TShock.Config.Settings.RegionProtectChests)
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnQuickStack rejected from region protection? from {0}", plr.Name));
+				args.Result = HookResult.Cancel;
+				return;
+			}
+
+			if (!plr.IsInRange(Main.chest[id].x, Main.chest[id].y, 600/16))
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnQuickStack rejected from range check from {0}", plr.Name));
+				args.Result = HookResult.Cancel;
 				return;
 			}
 		}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -130,7 +130,6 @@ namespace TShockAPI
 					{ PacketTypes.NumberOfAnglerQuestsCompleted, HandleNumberOfAnglerQuestsCompleted },
 					{ PacketTypes.PlaceObject, HandlePlaceObject },
 					{ PacketTypes.LoadNetModule, HandleLoadNetModule },
-					{ PacketTypes.ForceItemIntoNearestChest, HandleForceItemIntoNearestChest },
 					{ PacketTypes.PlaceTileEntity, HandlePlaceTileEntity },
 					{ PacketTypes.PlaceItemFrame, HandlePlaceItemFrame },
 					{ PacketTypes.UpdateItemDrop, HandleItemDrop },
@@ -1788,30 +1787,6 @@ namespace TShockAPI
 			};
 
 			PlaceObject.Invoke(null, args);
-			return args.Handled;
-		}
-
-		/// <summary>For use in a ForceItemIntoNearestChest event.</summary>
-		public class ForceItemIntoNearestChestEventArgs : GetDataHandledEventArgs
-		{
-			/// <summary>The slot index of the item being attempted to put into a chest.</summary>
-			public short Slot { get; set; }
-
-		}
-
-		/// <summary>Fired when a ForceItemIntoNearestChest event occurs.</summary>
-		public static HandlerList<ForceItemIntoNearestChestEventArgs> ForceItemIntoNearestChest = new HandlerList<ForceItemIntoNearestChestEventArgs>();
-		private static bool OnForceItemIntoNearest(TSPlayer player, MemoryStream data, short slot)
-		{
-
-			var args = new ForceItemIntoNearestChestEventArgs
-			{
-				Player = player,
-				Data = data,
-				Slot = slot
-			};
-
-			ForceItemIntoNearestChest.Invoke(null, args);
 			return args.Handled;
 		}
 
@@ -4106,18 +4081,6 @@ namespace TShockAPI
 			short moduleId = args.Data.ReadInt16();
 
 			if (OnReadNetModule(args.Player, args.Data, (NetModuleType)moduleId))
-			{
-				return true;
-			}
-
-			return false;
-		}
-
-		private static bool HandleForceItemIntoNearestChest(GetDataHandlerArgs args)
-		{
-			var slot  = args.Data.ReadInt16();
-
-			if (OnForceItemIntoNearest(args.Player, args.Data, slot))
 			{
 				return true;
 			}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -130,6 +130,7 @@ namespace TShockAPI
 					{ PacketTypes.NumberOfAnglerQuestsCompleted, HandleNumberOfAnglerQuestsCompleted },
 					{ PacketTypes.PlaceObject, HandlePlaceObject },
 					{ PacketTypes.LoadNetModule, HandleLoadNetModule },
+					{ PacketTypes.ForceItemIntoNearestChest, HandleForceItemIntoNearestChest },
 					{ PacketTypes.PlaceTileEntity, HandlePlaceTileEntity },
 					{ PacketTypes.PlaceItemFrame, HandlePlaceItemFrame },
 					{ PacketTypes.UpdateItemDrop, HandleItemDrop },
@@ -1787,6 +1788,30 @@ namespace TShockAPI
 			};
 
 			PlaceObject.Invoke(null, args);
+			return args.Handled;
+		}
+
+		/// <summary>For use in a ForceItemIntoNearestChest event.</summary>
+		public class ForceItemIntoNearestChestEventArgs : GetDataHandledEventArgs
+		{
+			/// <summary>The slot index of the item being attempted to put into a chest.</summary>
+			public short Slot { get; set; }
+
+		}
+
+		/// <summary>Fired when a ForceItemIntoNearestChest event occurs.</summary>
+		public static HandlerList<ForceItemIntoNearestChestEventArgs> ForceItemIntoNearestChest = new HandlerList<ForceItemIntoNearestChestEventArgs>();
+		private static bool OnForceItemIntoNearest(TSPlayer player, MemoryStream data, short slot)
+		{
+
+			var args = new ForceItemIntoNearestChestEventArgs
+			{
+				Player = player,
+				Data = data,
+				Slot = slot
+			};
+
+			ForceItemIntoNearestChest.Invoke(null, args);
 			return args.Handled;
 		}
 
@@ -4081,6 +4106,18 @@ namespace TShockAPI
 			short moduleId = args.Data.ReadInt16();
 
 			if (OnReadNetModule(args.Player, args.Data, (NetModuleType)moduleId))
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		private static bool HandleForceItemIntoNearestChest(GetDataHandlerArgs args)
+		{
+			var slot  = args.Data.ReadInt16();
+
+			if (OnForceItemIntoNearest(args.Player, args.Data, slot))
 			{
 				return true;
 			}


### PR DESCRIPTION
**Fixed players bypass region protection and build permissions when using Quick Stack**
## Problem
- Players who aren't logged in can use Quick Stack to put items into chests.
- Many players report stacking items into protected regions when using Quick Stack.
![image](https://github.com/user-attachments/assets/b57277b6-c38f-4e5e-aeb5-dbd5a08bbb22)
