### PR TITLE
fix(GetDataHandler): fix unable to use sprayer items in Void Bag for painting

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3773,7 +3773,8 @@ namespace TShockAPI
 				args.Player.SelectedItem.type != ItemID.SpectrePaintScraper &&
 				args.Player.SelectedItem.type != ItemID.SpectrePaintbrush &&
 				!args.Player.Accessories.Any(HasPaintSprayerAbilities) &&
-				!args.Player.Inventory.Any(HasPaintSprayerAbilities))
+				!args.Player.Inventory.Any(HasPaintSprayerAbilities) &&
+				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities)) //Void Bag
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePaintTile rejected select consistency {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.PaintTile, "", x, y, Main.tile[x, y].color());
@@ -3821,7 +3822,8 @@ namespace TShockAPI
 				args.Player.SelectedItem.type != ItemID.SpectrePaintScraper &&
 				args.Player.SelectedItem.type != ItemID.SpectrePaintbrush &&
 				!args.Player.Accessories.Any(HasPaintSprayerAbilities) &&
-				!args.Player.Inventory.Any(HasPaintSprayerAbilities))
+				!args.Player.Inventory.Any(HasPaintSprayerAbilities)&&
+				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities)) //Void Bag
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePaintWall rejected selector consistency {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.PaintWall, "", x, y, Main.tile[x, y].wallColor());


### PR DESCRIPTION
**Fixed unable to use sprayer-ability items in Void Bag for painting**
## Bug Example
### Sprayer-ability Item(eg.Hand Of Creation) In Inventory (Indended)
Tiles are automatically painted white.
![6a11110f8d95eef7ac631e15e6c36ec4](https://github.com/user-attachments/assets/bd466300-1e06-4ed1-bb9e-2a98b2197c7b)
![75d66b7a7e6a2b83163ab41c2ee2a3f3](https://github.com/user-attachments/assets/9e87566a-5c91-4e4e-97bc-9404c4ebbc4d)

### Sprayer-ability Item In Void Bag (Unintentionally blocked by `GetDataHandler`)
`GetDataHandler` rejects tile painting.
![90333a1631be152e9b1478ce93dd1536](https://github.com/user-attachments/assets/48c242d2-f63c-46fb-919d-6dddec6a159e)
![87af60b372cad83140b349654052e06d](https://github.com/user-attachments/assets/f77cd90d-41a9-4904-b253-848945655d1b)
![image](https://github.com/user-attachments/assets/477b302f-78da-4ea5-be7c-879f2b2e459b)