### PR TITLE
fix: allow evil grass to grow during world generation even when `Allow...Creep` is `false`

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1263,6 +1263,11 @@ namespace TShockAPI
 		/// <returns>True if allowed, otherwise false</returns>
 		private bool OnCreep(int tileType)
 		{
+			if (WorldGen.generatingWorld)
+			{
+				return true;
+			}
+
 			if (!Config.Settings.AllowCrimsonCreep && (tileType == TileID.Dirt || tileType == TileID.CrimsonGrass
 				|| TileID.Sets.Crimson[tileType]))
 			{


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

## Generate a world with the same seed

### Normal
![img](https://github.com/user-attachments/assets/af50a0dc-5ace-44ed-8a09-a8e8da3bd4f6)


### `AllowCrimsonCreep` or `AllowCorruptionCreep` is `false`
![img](https://github.com/user-attachments/assets/9053c332-8b4f-4a02-8055-6ef664e99601)




<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. -->
### Changelog
**Fixed evil grass growth blocked during world generation when `Allow...Creep` is `false`**