### PR TITLE
fix: allow dead hardcore players to move as ghosts

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -602,7 +602,7 @@ namespace TShockAPI
 				}
 
 				// Corpses don't move, but ghost
-				if (args.Player.Dead && args.Player.Difficulty != 2)
+				if (args.Player.Dead && !args.Player.TPlayer.ghost)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
 					args.Handled = true;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -601,8 +601,8 @@ namespace TShockAPI
 					return;
 				}
 
-				// Corpses don't move
-				if (args.Player.Dead)
+				// Corpses don't move, but ghost
+				if (args.Player.Dead && args.Player.Difficulty != 2)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
 					args.Handled = true;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1645,8 +1645,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if ((player.State < (int)ConnectionState.Complete || player.Dead) &&
-			    (type != PacketTypes.PlayerUpdate || player.Difficulty != 2 || !player.Dead) &&
+			if ((player.State < (int)ConnectionState.Complete) &&
 			    type > PacketTypes.PlayerSpawn && type != PacketTypes.PlayerHp && type != PacketTypes.PlayerMana &&
 			    type != PacketTypes.PlayerBuff && type != PacketTypes.PasswordSend && type != PacketTypes.ItemDrop &&
 			    type != PacketTypes.ItemOwner && type != PacketTypes.SyncLoadout)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1652,12 +1652,8 @@ namespace TShockAPI
 				return;
 			}
 
-			int length = e.Length - 1;
-			if (length < 0)
-			{
-				length = 0;
-			}
-			using (var data = new MemoryStream(e.Msg.readBuffer, e.Index, e.Length - 1))
+			int length = Math.Max(e.Length - 1, 0);
+			using (var data = new MemoryStream(e.Msg.readBuffer, e.Index, length))
 			{
 				// Exceptions are already handled
 				e.Handled = GetDataHandlers.HandlerGetData(type, player, data);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1645,7 +1645,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if ((player.State < (int)ConnectionState.Complete || player.Dead) && (int)type > 12 && (int)type != 16 && (int)type != 42 && (int)type != 50 &&
+			if ((player.State < (int)ConnectionState.Complete || player.Dead) && (type != PacketTypes.PlayerUpdate || player.Difficulty != 2 || !player.Dead) && (int)type > 12 && (int)type != 16 && (int)type != 42 && (int)type != 50 &&
 				(int)type != 38 && (int)type != 21 && (int)type != 22 && type != PacketTypes.SyncLoadout)
 			{
 				e.Handled = true;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1645,8 +1645,11 @@ namespace TShockAPI
 				return;
 			}
 
-			if ((player.State < (int)ConnectionState.Complete || player.Dead) && (type != PacketTypes.PlayerUpdate || player.Difficulty != 2 || !player.Dead) && (int)type > 12 && (int)type != 16 && (int)type != 42 && (int)type != 50 &&
-				(int)type != 38 && (int)type != 21 && (int)type != 22 && type != PacketTypes.SyncLoadout)
+			if ((player.State < (int)ConnectionState.Complete || player.Dead) &&
+			    (type != PacketTypes.PlayerUpdate || player.Difficulty != 2 || !player.Dead) &&
+			    type > PacketTypes.PlayerSpawn && type != PacketTypes.PlayerHp && type != PacketTypes.PlayerMana &&
+			    type != PacketTypes.PlayerBuff && type != PacketTypes.PasswordSend && type != PacketTypes.ItemDrop &&
+			    type != PacketTypes.ItemOwner && type != PacketTypes.SyncLoadout)
 			{
 				e.Handled = true;
 				return;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1623,6 +1623,23 @@ namespace TShockAPI
 			args.Handled = true;
 		}
 
+		private static readonly HashSet<PacketTypes> AllowedEarlyPackets =
+		[
+			PacketTypes.ConnectRequest,
+			PacketTypes.PlayerInfo,
+			PacketTypes.PlayerSlot,
+			PacketTypes.ContinueConnecting2,
+			PacketTypes.TileGetSection,
+			PacketTypes.PlayerSpawn,
+			PacketTypes.PlayerHp,
+			PacketTypes.PlayerMana,
+			PacketTypes.PlayerBuff,
+			PacketTypes.PasswordSend,
+			PacketTypes.ItemDrop,
+			PacketTypes.ItemOwner,
+			PacketTypes.SyncLoadout
+		];
+
 		/// <summary>OnGetData - Called when the server gets raw data packets.</summary>
 		/// <param name="e">e - The GetDataEventArgs object.</param>
 		private void OnGetData(GetDataEventArgs e)
@@ -1645,10 +1662,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if ((player.State < (int)ConnectionState.Complete) &&
-			    type > PacketTypes.PlayerSpawn && type != PacketTypes.PlayerHp && type != PacketTypes.PlayerMana &&
-			    type != PacketTypes.PlayerBuff && type != PacketTypes.PasswordSend && type != PacketTypes.ItemDrop &&
-			    type != PacketTypes.ItemOwner && type != PacketTypes.SyncLoadout)
+			if (player.State < (int)ConnectionState.Complete && !AllowedEarlyPackets.Contains(type))
 			{
 				e.Handled = true;
 				return;


### PR DESCRIPTION
### Fixed hardcore ghosts don't move server-side

1. In `HandlePlayerKillMeV2`, set the player's dead state to true:
https://github.com/Pryaxis/TShock/blob/a867772116d3c5f80347250c48052163214ae581/TShockAPI/GetDataHandlers.cs#L4325-L4326
3. The player respawns and turns into a ghost, but no respawn packet is sent.
4. In `OnGetData`, most packets from "dead" ghost players are filtered out, so the server cannot detect player movement and fails to send the correct `TileSquare` packet.
https://github.com/Pryaxis/TShock/blob/a867772116d3c5f80347250c48052163214ae581/TShockAPI/TShock.cs#L1643-L1648

<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. -->
