### PR TITLE
fix: ignore `respawnTimer` when players are spawning into the world

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2734,8 +2734,11 @@ namespace TShockAPI
 
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnX, spawnY, respawnTimer, numberOfDeathsPVE, numberOfDeathsPVP, context))
 				return true;
-			
-			args.Player.Dead = respawnTimer > 0;
+
+			if (!Main.ServerSideCharacter || context != PlayerSpawnContext.SpawningIntoWorld)
+			{
+				args.Player.Dead = respawnTimer > 0;
+			}
 
 			if (Main.ServerSideCharacter)
 			{


### PR DESCRIPTION
**Fixed interact actions not working in the SSC server after dying without respawning in single-player mode**

* Players who die in single-player mode without respawning should not be marked as Dead on the SSC server.

* In my tests, only the SSC server receives a non-zero `respawnTimer`. Therefore, this may be a client-side bug (? 

closed: #3151


