### PR TITLE
feat: Synchronize server-side respawn timer to clients in SSC + Instant Respawn config option

### DIFF
--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -269,7 +269,7 @@ namespace TShockAPI.Configuration
 
 		/// <summary>If players should be instantly respawned upon death when a boss is nearby.</summary>
 		[Description("If players should be instantly respawned upon death when a boss is nearby.")]
-		public bool InstantRespawnBoss = false;
+		public bool InstantRespawnDuringBoss = false;
 
 		/// <summary>Whether or not to announce boss spawning or invasion starts.</summary>
 		[Description("Whether or not to announce boss spawning or invasion starts.")]

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -263,6 +263,14 @@ namespace TShockAPI.Configuration
 		[Description("The number of seconds a player must wait before being respawned if there is a boss nearby. Valid range: 0 (default) to 30 seconds. Use at your own risk.")]
 		public int RespawnBossSeconds = 0;
 
+		/// <summary>If players should be instantly respawned upon death when a boss is NOT nearby.</summary>
+		[Description("If players should be instantly respawned upon death when a boss is NOT nearby.")]
+		public bool InstantRespawn = false;
+
+		/// <summary>If players should be instantly respawned upon death when a boss is nearby.</summary>
+		[Description("If players should be instantly respawned upon death when a boss is nearby.")]
+		public bool InstantRespawnBoss = false;
+
 		/// <summary>Whether or not to announce boss spawning or invasion starts.</summary>
 		[Description("Whether or not to announce boss spawning or invasion starts.")]
 		public bool AnonymousBossInvasions = true;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4383,10 +4383,11 @@ namespace TShockAPI
 				args.Player.Dead = false;
 				args.Player.RespawnTimer = 0;
 
-				// Fake the player's death. Doing otherwise will cause minor desyncs.
+				// Fake the player's death. Not doing so will cause minor desyncs.
 				args.Player.FakeDeath(playerDeathReason, dmg, direction);
 				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 
+				// Handled to prevent vanilla behavior
 				return true;
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4329,6 +4329,7 @@ namespace TShockAPI
 
 			args.Player.Dead = true;
 			args.Player.RespawnTimer = TShock.Config.Settings.RespawnSeconds;
+			bool instantRespawn = TShock.Config.Settings.InstantRespawn;
 
 			foreach (NPC npc in Main.npc)
 			{
@@ -4336,6 +4337,7 @@ namespace TShockAPI
 					Math.Abs(args.TPlayer.Center.X - npc.Center.X) + Math.Abs(args.TPlayer.Center.Y - npc.Center.Y) < 4000f)
 				{
 					args.Player.RespawnTimer = TShock.Config.Settings.RespawnBossSeconds;
+					instantRespawn = TShock.Config.Settings.InstantRespawnDuringBoss;
 					break;
 				}
 			}
@@ -4376,14 +4378,12 @@ namespace TShockAPI
 
 			// Slight warning: Instant respawn allows for malicious clients to spam death messages.
 			// It may be possible for certain vanilla circumstances to spam death messages as well. Use with caution.
-			if (args.TPlayer.difficulty != 2 && // Not hardcore
-				(args.Player.RespawnTimer == TShock.Config.Settings.RespawnSeconds && TShock.Config.Settings.InstantRespawn ||
-				args.Player.RespawnTimer == TShock.Config.Settings.RespawnBossSeconds && TShock.Config.Settings.InstantRespawnDuringBoss))
+			if (args.TPlayer.difficulty != 2 && instantRespawn) // Not in hardcore
 			{
 				args.Player.Dead = false;
 				args.Player.RespawnTimer = 0;
 				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
-				args.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath); // Slight server desync if we don't
+				args.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath); // Slight server desync if we don't do this, for some reason. Re-evaluate necessity.
 				return false;
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4382,10 +4382,11 @@ namespace TShockAPI
 			{
 				args.Player.Dead = false;
 				args.Player.RespawnTimer = 0;
-				args.Player.TPlayer.KillMe(playerDeathReason, dmg, direction, pvp); // Simulate the death & respawn, causes slight server desync if we don't.
-				args.Player.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath);
 
-				// Handled to prevent desync
+				// Fake the player's death. Doing otherwise will cause minor desyncs.
+				args.Player.FakeDeath(playerDeathReason, dmg, direction);
+				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
+
 				return true;
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4378,7 +4378,7 @@ namespace TShockAPI
 			// It may be possible for certain vanilla circumstances to spam death messages as well. Use with caution.
 			if (args.TPlayer.difficulty != 2 && // Not hardcore
 				(args.Player.RespawnTimer == TShock.Config.Settings.RespawnSeconds && TShock.Config.Settings.InstantRespawn ||
-				args.Player.RespawnTimer == TShock.Config.Settings.RespawnBossSeconds && TShock.Config.Settings.InstantRespawnBoss))
+				args.Player.RespawnTimer == TShock.Config.Settings.RespawnBossSeconds && TShock.Config.Settings.InstantRespawnDuringBoss))
 			{
 				args.Player.Dead = false;
 				args.Player.RespawnTimer = 0;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2725,10 +2725,10 @@ namespace TShockAPI
 
 			if (args.Player.Dead && args.Player.RespawnTimer > 0)
 			{
-				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
 				// Prevent fast-spawn.
 				if (respawnTimer <= 0 && Main.ServerSideCharacter)
 				{
+					TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
 					args.Player.SyncRespawnTimer();
 				}
 				return true;
@@ -4382,9 +4382,11 @@ namespace TShockAPI
 			{
 				args.Player.Dead = false;
 				args.Player.RespawnTimer = 0;
-				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
-				args.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath); // Slight server desync if we don't do this, for some reason. Re-evaluate necessity.
-				return false;
+				args.Player.TPlayer.KillMe(playerDeathReason, dmg, direction, pvp); // Simulate the death & respawn, causes slight server desync if we don't.
+				args.Player.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath);
+
+				// Handled to prevent desync
+				return true;
 			}
 
 			// We can sync the respawn timer in SSC. Otherwise the client refuses the HP packet, which is necessary to sync it properly.

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4384,7 +4384,7 @@ namespace TShockAPI
 				args.Player.RespawnTimer = 0;
 
 				// Fake the player's death. Not doing so will cause minor desyncs.
-				args.Player.FakeDeath(playerDeathReason, dmg, direction);
+				args.Player.FakeDeath(playerDeathReason, dmg, direction, pvp);
 				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 
 				// Handled to prevent vanilla behavior

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2715,12 +2715,6 @@ namespace TShockAPI
 
 		private static bool HandleSpawn(GetDataHandlerArgs args)
 		{
-			if (args.Player.Dead && args.Player.RespawnTimer > 0)
-			{
-				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
-				return true;
-			}
-
 			byte player = args.Data.ReadInt8();
 			short spawnX = args.Data.ReadInt16();
 			short spawnY = args.Data.ReadInt16();
@@ -2728,6 +2722,17 @@ namespace TShockAPI
 			short numberOfDeathsPVE = args.Data.ReadInt16();
 			short numberOfDeathsPVP = args.Data.ReadInt16();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
+
+			if (args.Player.Dead && args.Player.RespawnTimer > 0)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
+				// Prevent fast-spawn.
+				if (respawnTimer <= 0 && Main.ServerSideCharacter)
+				{
+					args.Player.SyncRespawnTimer();
+				}
+				return true;
+			}
 
 			if (args.Player.State >= (int)ConnectionState.RequestingWorldData && !args.Player.FinishedHandshake)
 				args.Player.FinishedHandshake = true; //If the player has requested world data before sending spawn player, they should be at the obvious ClientRequestedWorldData state. Also only set this once to remove redundant updates.
@@ -2835,7 +2840,7 @@ namespace TShockAPI
 			var cur = args.Data.ReadInt16();
 			var max = args.Data.ReadInt16();
 
-			if (OnPlayerHP(args.Player, args.Data, plr, cur, max) || cur <= 0 || max <= 0 || args.Player.IgnoreSSCPackets)
+			if (OnPlayerHP(args.Player, args.Data, plr, cur, max) || cur <= 0 || max <= 0 || args.Player.IgnoreSSCPackets || args.Player.State == 10 && args.Player.Dead && args.Player.RespawnTimer > 0)
 				return true;
 
 			if (max > TShock.Config.Settings.MaxHP && !args.Player.HasPermission(Permissions.ignorehp))
@@ -4367,6 +4372,25 @@ namespace TShockAPI
 					args.Player.SendErrorMessage(GetString("You have fallen in hardcore mode, and your items have been lost forever."));
 					TShock.CharacterDB.SeedInitialData(args.Player.Account);
 				}
+			}
+
+			// Slight warning: Instant respawn allows for malicious clients to spam death messages.
+			// It may be possible for certain vanilla circumstances to spam death messages as well. Use with caution.
+			if (args.TPlayer.difficulty != 2 && // Not hardcore
+				(args.Player.RespawnTimer == TShock.Config.Settings.RespawnSeconds && TShock.Config.Settings.InstantRespawn ||
+				args.Player.RespawnTimer == TShock.Config.Settings.RespawnBossSeconds && TShock.Config.Settings.InstantRespawnBoss))
+			{
+				args.Player.Dead = false;
+				args.Player.RespawnTimer = 0;
+				args.Player.Spawn(PlayerSpawnContext.ReviveFromDeath);
+				args.TPlayer.Spawn(PlayerSpawnContext.ReviveFromDeath); // Slight server desync if we don't
+				return false;
+			}
+
+			// We can sync the respawn timer in SSC. Otherwise the client refuses the HP packet, which is necessary to sync it properly.
+			if (args.Player.RespawnTimer > 0 && Main.ServerSideCharacter)
+			{
+				args.Player.SyncRespawnTimer();
 			}
 
 			return false;

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1490,11 +1490,15 @@ namespace TShockAPI
 		/// <summary>
 		/// Broadcasts the player's death message and drops a tombstone if <see cref="Configuration.TShockSettings.DisableTombstones"/> is disabled.
 		/// </summary>
-		/// <param name="reason"></param>
-		/// <param name="damage"></param>
-		/// <param name="direction"></param>
-		public void FakeDeath(PlayerDeathReason reason, int damage, int direction)
+		/// <param name="reason">The reason for dying/</param>
+		/// <param name="damage">The amount of damage recieved</param>
+		/// <param name="direction">The direction the damage is from/</param>
+		/// <param name="pvp">If the death occured from a PvP action.</param>
+		public void FakeDeath(PlayerDeathReason reason, int damage, int direction, bool pvp = false)
 		{
+			// Send their death to other clients, but not to them
+			NetMessage.SendPlayerDeath(Index, reason, damage, direction, pvp, -1, Index);
+
 			NetworkText nT = reason.GetDeathText(Name);
 			Terraria.Chat.ChatHelper.BroadcastChatMessage(nT, new Color(225, 25, 25));
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1470,6 +1470,37 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Synchronizes the player's <see cref="RespawnTimer"/> by spawning the player, teleporting them to where they died, and setting their HP to 0.
+		/// <br/>Requires SSC to function.
+		/// </summary>
+		public bool SyncRespawnTimer()
+		{
+			if (!Main.ServerSideCharacter)
+				return false;
+
+			// The client will respawn from this and no longer be dead. By not using SpawningIntoWorld, the respawn timer is set but not cleared.
+			// By doing this, we can set their HP to 0 and sync that to them, which makes them appear dead on their end. Results in proper sync of the RespawnTimer.
+			Spawn(PlayerSpawnContext.RecallFromItem, TPlayer.respawnTimer);
+			SendData(PacketTypes.PlayerUpdate, number: Index);
+			SyncDead();
+			return true;
+		}
+
+		/// <summary>
+		/// Forces the player to be dead on their client by setting their HP to 0.
+		/// Intended for synchronizing the respawn timer.
+		/// <br/>Requires SSC to function.
+		/// </summary>
+		public void SyncDead()
+		{
+			if (!Main.ServerSideCharacter)
+				return;
+
+			TPlayer.statLife = 0;
+			SendData(PacketTypes.PlayerHp, number: Index);
+		}
+
+		/// <summary>
 		/// Spawns the player at the given coordinates.
 		/// </summary>
 		/// <param name="tilex">The X coordinate.</param>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1482,22 +1482,9 @@ namespace TShockAPI
 			// By doing this, we can set their HP to 0 and sync that to them, which makes them appear dead on their end. Results in proper sync of the RespawnTimer.
 			Spawn(PlayerSpawnContext.RecallFromItem, TPlayer.respawnTimer);
 			SendData(PacketTypes.PlayerUpdate, number: Index);
-			SyncDead();
-			return true;
-		}
-
-		/// <summary>
-		/// Forces the player to be dead on their client by setting their HP to 0.
-		/// Intended for synchronizing the respawn timer.
-		/// <br/>Requires SSC to function.
-		/// </summary>
-		public void SyncDead()
-		{
-			if (!Main.ServerSideCharacter)
-				return;
-
 			TPlayer.statLife = 0;
 			SendData(PacketTypes.PlayerHp, number: Index);
+			return true;
 		}
 
 		/// <summary>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1488,6 +1488,22 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Broadcasts the player's death message and drops a tombstone if <see cref="Configuration.TShockSettings.DisableTombstones"/> is disabled.
+		/// </summary>
+		/// <param name="reason"></param>
+		/// <param name="damage"></param>
+		/// <param name="direction"></param>
+		public void FakeDeath(PlayerDeathReason reason, int damage, int direction)
+		{
+			NetworkText nT = reason.GetDeathText(Name);
+			Terraria.Chat.ChatHelper.BroadcastChatMessage(nT, new Color(225, 25, 25));
+
+			if (!TShock.Config.Settings.DisableTombstones)
+				TPlayer.DropTombstone(Terraria.Utils.CoinsCount(out bool _, TPlayer.inventory), nT, direction);
+
+		}
+
+		/// <summary>
 		/// Spawns the player at the given coordinates.
 		/// </summary>
 		/// <param name="tilex">The X coordinate.</param>

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1765,7 +1765,7 @@ namespace TShockAPI
 		{
 			if (e.MsgId == PacketTypes.PlayerHp)
 			{
-				if (Main.player[(byte)e.number].statLife <= 0)
+				if (Main.player[(byte)e.number].statLife <= 0 && !Players[e.number].Dead)
 				{
 					e.Handled = true;
 					return;


### PR DESCRIPTION
Through clever usage of packets, TShock's server-side respawn timer can be synced to remote clients when they die.
Setting a client's respawn timer in the spawn packet doesn't do anything usually, since the client chooses to spawn regardless. However, the client still sets its respawn timer from the packet. It only gets reset to 0 when using the spawn context ``SpawningIntoWorld`` due to the way the spawn timer is adjusted. The trick is to set the client's HP to 0 through the ``PlayerHp`` packet right after sending the ``PlayerSpawn`` packet with the desired respawn timer. This forces the client to be dead, and they will then use the respawn timer the server sent over.
Unfortunately, this approach **only works in SSC**, not without. You could spawn the client & teleport them without using the ``PlayerUpdate`` packet (I chose to use this to try and limit screen movement), but they will ignore the ``PlayerHp`` packet, which kills this approach.
This PR also prevents clients who are fully connected from sending ``PlayerHp`` while dead to make themself appear as not being dead, plus forced correction of the client's respawn timer when they attempt to respawn too quickly (SSC only).

This PR additionally adds ``InstantRespawn`` and ``InstantRespawnDuringBoss`` configuration options. When enabled, the player will immediately be respawned on death, ignoring the respawn seconds. Previously, you could only do 1 second at minimum. Trying to do 0 wouldn't work and would instead just enable vanilla respawn behavior. The addition of these options **does not** change the behavior of setting ``RespawnSeconds``/``RespawnBossSeconds`` to 0. If this should be changed at all, please let me know. I threw these options together rather quickly.

I'll need some further testing to catch edge cases where this may cause bugs, especially when multiple players are involved. I am aware this causes a brief black flash on the client if they die away from their spawn point which may be visually unpleasing. Not sure how to work around this, so it's a drawback of this approach for now. Maybe a debuff can be applied to darken the screen for longer to prevent the harsh flash.

Changelog as follows:
- Server-side respawn timer is now synchronized to clients in SSC.
- Added ``InstantRespawn`` and ``InstantRespawnDuringBoss`` configuration options.
