### PR TITLE
feat: Reject SyncTilePicking based on build permission/range check

### DIFF
--- a/TShockAPI/Handlers/SyncTilePickingHandler.cs
+++ b/TShockAPI/Handlers/SyncTilePickingHandler.cs
@@ -24,6 +24,14 @@ namespace TShockAPI.Handlers
 				args.Handled = true;
 				return;
 			}
+
+			if (!args.Player.HasBuildPermission(args.TileX, args.TileY) || !args.Player.IsInRange(args.TileX, args.TileY))
+			{
+				// Reject silently without logging. This packet is sent when TileEdit is sent, no need to double-log.
+				// It's not possible to send correcting data for this packet.
+				args.Handled = true;
+				return;
+			}
 		}
 	}
 }

--- a/TShockAPI/Handlers/SyncTilePickingHandler.cs
+++ b/TShockAPI/Handlers/SyncTilePickingHandler.cs
@@ -25,7 +25,8 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			if (!args.Player.HasBuildPermission(args.TileX, args.TileY) || !args.Player.IsInRange(args.TileX, args.TileY))
+			if (args.Player.IsBeingDisabled() || args.Player.IsBouncerThrottled() ||
+				!args.Player.HasBuildPermission(args.TileX, args.TileY) || !args.Player.IsInRange(args.TileX, args.TileY))
 			{
 				// Reject silently without logging. This packet is sent when TileEdit is sent, no need to double-log.
 				// It's not possible to send correcting data for this packet.

--- a/TShockAPI/Handlers/SyncTilePickingHandler.cs
+++ b/TShockAPI/Handlers/SyncTilePickingHandler.cs
@@ -25,8 +25,8 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			if (args.Player.IsBeingDisabled() || args.Player.IsBouncerThrottled() ||
-				!args.Player.HasBuildPermission(args.TileX, args.TileY) || !args.Player.IsInRange(args.TileX, args.TileY))
+			if (args.Player.IsBeingDisabled() || args.Player.IsBouncerThrottled()
+				|| !args.Player.HasBuildPermission(args.TileX, args.TileY) || !args.Player.IsInRange(args.TileX, args.TileY))
 			{
 				// Reject silently without logging. This packet is sent when TileEdit is sent, no need to double-log.
 				// It's not possible to send correcting data for this packet.


### PR DESCRIPTION
- Added rejection of the ``SyncTilePicking`` packet based on the player 's build permission & range check. Prevents tile cracks from appearing for other clients when a player tries to mine when they have no permission to/are too far away.

Changelog:
- Cracks no longer appear on tiles for other clients when a player tries to mine in a protected region they do not have access to.