### PR TITLE
fix(ci): correct self-contained flag in publish

### DIFF
--- a/.github/workflows/ci-otapi3.yml
+++ b/.github/workflows/ci-otapi3.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Produce installer
         run: |
             cd TShockInstaller
-            dotnet publish -r ${{ matrix.arch }} -f net9.0 -c Release -p:PublishSingleFile=true --self-contained true
+            dotnet publish -r ${{ matrix.arch }} -f net9.0 -c Release -p:PublishSingleFile=true --self-contained
 
       - name: Produce build
         run: |
             cd TShockLauncher
-            dotnet publish -r ${{ matrix.arch }} -f net9.0 -c Release -p:PublishSingleFile=true --self-contained false
+            dotnet publish -r ${{ matrix.arch }} -f net9.0 -c Release -p:PublishSingleFile=true --no-self-contained
 
       - name: Chmod scripts
         if: ${{ matrix.arch != 'win-x64' }}


### PR DESCRIPTION
### Related Document
https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish

```text
dotnet publish ...
    [--sc|--self-contained] [--no-self-contained]
```
### Related workflow:
https://github.com/Pryaxis/TShock/actions/runs/21106857505


**Corrected self-contained flag in publish workflow**
