### PR TITLE
Add Options to Disable Certain TileEdit/PlaceObject Checks, Configurable Max Chat Message Length, + Fix Incorrect Rejection of Magical Ice in Some Cases

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -690,7 +690,7 @@ namespace TShockAPI
 					var actualItemPlaceStyle = selectedItem.placeStyle;
 
 					// The client has requested to place a style that does not match their held item's actual place style
-					if (requestedPlaceStyle != actualItemPlaceStyle)
+					if (requestedPlaceStyle != actualItemPlaceStyle && TShock.Config.Settings.PreventInvalidPlaceStyle)
 					{
 						var tplayer = args.Player.TPlayer;
 						// Search for an extraneous tile corrector
@@ -717,7 +717,11 @@ namespace TShockAPI
 					}
 				}
 
-				if (action == EditAction.KillTile && !Main.tileCut[tile.type] && !breakableTiles.Contains(tile.type) && args.Player.RecentFuse == 0)
+				// Players can only place magical ice if they have recently created an ice block projectile
+				var tryingToPlaceIce = action == EditAction.PlaceTile && editData == TileID.MagicalIceBlock &&
+					args.Player.RecentlyCreatedProjectiles.Any(p => p.Type == ProjectileID.IceBlock && !p.Killed);
+
+				if (action == EditAction.KillTile && !Main.tileCut[tile.type] && !breakableTiles.Contains(tile.type) && args.Player.RecentFuse == 0 && TShock.Config.Settings.PreventInvalidBreaking)
 				{
 					// If the tile is an axe tile and they aren't selecting an axe, they're hacking.
 					if (Main.tileAxe[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.axe == 0) && !ItemID.Sets.Explosives[selectedItem.netID]))
@@ -754,7 +758,7 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.KillWall)
+				else if (action == EditAction.KillWall && TShock.Config.Settings.PreventInvalidBreaking)
 				{
 					// If they aren't selecting a hammer, they could be hacking.
 					if (selectedItem.hammer == 0 && !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0 && selectedItem.createWall == 0)
@@ -776,7 +780,8 @@ namespace TShockAPI
 					// projectile should be the same X coordinate as all tile places (Note by @Olink)
 					if (ropeCoilPlacements.ContainsKey(selectedItem.netID) &&
 						!args.Player.RecentlyCreatedProjectiles.Any(p => GetDataHandlers.projectileCreatesTile.ContainsKey(p.Type) && GetDataHandlers.projectileCreatesTile[p.Type] == editData &&
-						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)))
+						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)) &&
+						TShock.Config.Settings.PreventMismatchedPlace)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
@@ -795,18 +800,23 @@ namespace TShockAPI
 						return;
 					}
 
-					/// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
-					if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock)
+					// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
+					if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock && TShock.Config.Settings.PreventMismatchedPlace)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from using ice rod but not placing ice block {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
 						args.Handled = true;
+						return;
 					}
-					/// If they aren't selecting the item which creates the tile, they're hacking.
-					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
+
+					// If they aren't selecting the item which creates the tile, they're hacking.
+					// We need to exclude ice block as it's checked above.
+					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && !tryingToPlaceIce && editData != selectedItem.createTile &&
+						TShock.Config.Settings.PreventMismatchedPlace)
 					{
-						/// These would get caught up in the below check because Terraria does not set their createTile field.
-						if (selectedItem.netID != ItemID.IceRod && selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb && (args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
+						// These would get caught up in the below check because Terraria does not set their createTile field.
+						if (selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb &&
+							(args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
 						{
 							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
 							args.Player.SendTileSquareCentered(tileX, tileY, 4);
@@ -814,8 +824,8 @@ namespace TShockAPI
 							return;
 						}
 					}
-					/// If they aren't selecting the item which creates the wall, they're hacking.
-					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
+					// If they aren't selecting the item which creates the wall, they're hacking.
+					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall && TShock.Config.Settings.PreventMismatchedPlace)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createWall));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
@@ -834,7 +844,7 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (action == EditAction.PlaceWire || action == EditAction.PlaceWire2 || action == EditAction.PlaceWire3)
+				else if (action == EditAction.PlaceWire || action == EditAction.PlaceWire2 || action == EditAction.PlaceWire3 && TShock.Config.Settings.PreventMismatchedPlace)
 				{
 					// If they aren't selecting a wrench, they're hacking.
 					// WireKite = The Grand Design
@@ -857,7 +867,7 @@ namespace TShockAPI
 					// If they aren't selecting the wire cutter, they're hacking.
 					if (selectedItem.type != ItemID.WireCutter
 						&& selectedItem.type != ItemID.WireKite
-						&& selectedItem.type != ItemID.MulticolorWrench)
+						&& selectedItem.type != ItemID.MulticolorWrench && TShock.Config.Settings.PreventInvalidBreaking)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wire cutter from {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
@@ -865,7 +875,7 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.PlaceActuator)
+				else if (action == EditAction.PlaceActuator && TShock.Config.Settings.PreventMismatchedPlace)
 				{
 					// If they aren't selecting the actuator and don't have the Presserator equipped, they're hacking.
 					if (selectedItem.type != ItemID.Actuator && !args.Player.TPlayer.autoActuator)
@@ -908,8 +918,8 @@ namespace TShockAPI
 					return;
 				}
 
-				//make sure it isnt a snake coil related edit so it doesnt spam debug logs with range check failures
-				if (((action == EditAction.PlaceTile && editData != TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type != TileID.MysticSnakeRope)) && !args.Player.IsInRange(tileX, tileY))
+				//make sure it isnt a snake coil related edit so it doesnt spam debug logs with range check failures. This includes magical ice blocks.
+				if (((action == EditAction.PlaceTile && editData != TileID.MysticSnakeRope) || (action == EditAction.KillTile && tile.type != TileID.MysticSnakeRope)) && !tryingToPlaceIce && !args.Player.IsInRange(tileX, tileY))
 				{
 					if (action == EditAction.PlaceTile && (editData == TileID.Rope || editData == TileID.SilkRope || editData == TileID.VineRope || editData == TileID.WebRope || editData == TileID.MysticSnakeRope))
 					{
@@ -2124,7 +2134,7 @@ namespace TShockAPI
 				if (detectedNPCBuffTimeCheat)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNPCAddBuff rejected abnormal buff ({0}, last for {4}) added to {1} ({2}) from {3}.", type, npc.TypeName, npc.netID, args.Player.Name, time));
-					args.Player.Kick(GetString($"Added buff to {npc.TypeName} NPC abnormally."), true);
+					args.Player.SendData(PacketTypes.NpcUpdateBuff, number: id);
 					args.Handled = true;
 				}
 			}
@@ -2244,7 +2254,6 @@ namespace TShockAPI
 			void rejectForCritterNotReleasedFromItem()
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnReleaseNPC released different critter from {0}", args.Player.Name));
-				args.Player.Kick(GetString("Released critter was not from its item."), true);
 				args.Handled = true;
 			}
 
@@ -2333,7 +2342,7 @@ namespace TShockAPI
 
 			//style 52 and 53 are used by ItemID.Fake_newchest1 and ItemID.Fake_newchest2
 			//These two items cause localised lag and rendering issues
-			if (type == TileID.FakeContainers && (style == 52 || style == 53))
+			if (type == TileID.FakeContainers && (style == 52 || style == 53) && !TShock.Config.Settings.AllowFakeNewChest)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected fake containers from {0}", args.Player.Name));
 				args.Player.SendTileSquareCentered(x, y, 4);
@@ -2370,7 +2379,8 @@ namespace TShockAPI
 			if (args.Player.SelectedItem.type is ItemID.RubblemakerSmall or ItemID.RubblemakerMedium or ItemID.RubblemakerLarge)
 			{
 				if (type != TileID.LargePilesEcho && type != TileID.LargePiles2Echo && type != TileID.SmallPiles2x1Echo &&
-					type != TileID.SmallPiles1x1Echo && type != TileID.PlantDetritus3x2Echo && type != TileID.PlantDetritus2x2Echo)
+					type != TileID.SmallPiles1x1Echo && type != TileID.PlantDetritus3x2Echo && type != TileID.PlantDetritus2x2Echo &&
+					TShock.Config.Settings.PreventMismatchedPlace)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected rubblemaker I can't believe it's not rubble! from {0}",
 						args.Player.Name));
@@ -2381,7 +2391,7 @@ namespace TShockAPI
 			}
 			else if (args.Player.SelectedItem.type == ItemID.AcornAxe)
 			{
-				if (type != TileID.Saplings)
+				if (type != TileID.Saplings && TShock.Config.Settings.PreventMismatchedPlace)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected Axe of Regrowth only places saplings {0}", args.Player.Name));
 					args.Player.SendTileSquareCentered(x, y, 4);
@@ -2394,7 +2404,7 @@ namespace TShockAPI
 				// This is necessary to check in order to prevent special tiles such as
 				// queen bee larva, paintings etc that use this packet from being placed
 				// without selecting the right item.
-				if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile)
+				if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile && TShock.Config.Settings.PreventMismatchedPlace)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected awkward tile creation/selection from {0}", args.Player.Name));
 					args.Player.SendTileSquareCentered(x, y, 4);
@@ -2402,7 +2412,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if (args.Player.SelectedItem.placeStyle != style)
+				if (args.Player.SelectedItem.placeStyle != style && TShock.Config.Settings.PreventInvalidPlaceStyle)
 				{
 					var validTorch = args.Player.SelectedItem.createTile == TileID.Torches && args.Player.TPlayer.BiomeTorchPlaceStyle(args.Player.SelectedItem.placeStyle) == style;
 					var validCampfire = args.Player.SelectedItem.createTile == TileID.Campfire && args.Player.TPlayer.BiomeCampfirePlaceStyle(args.Player.SelectedItem.placeStyle) == style;
@@ -2792,10 +2802,9 @@ namespace TShockAPI
 			// This was formerly marked as a crash check; does not actually crash on this specific packet.
 			if (playerDeathReason != null)
 			{
-				if (playerDeathReason.GetDeathText(TShock.Players[id].Name).ToString().Length > 500)
+				if (playerDeathReason.GetDeathText(TShock.Players[id].Name).ToString().Length > Math.Clamp(TShock.Config.Settings.MaximumChatMessageLength, 256, 2048))
 				{
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected bad length death text from {0}", args.Player.Name));
-					TShock.Players[id].Kick(GetString("Death reason outside of normal bounds."), true);
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected excessive length death text from {0}", args.Player.Name));
 					args.Handled = true;
 					return;
 				}
@@ -2954,7 +2963,7 @@ namespace TShockAPI
 		/// Returns the max <see cref="Item.placeStyle"/> associated with the given <paramref name="tileID"/>. Or -1 if there's no association
 		/// </summary>
 		/// <param name="tileID">Tile ID to query for</param>
-		/// <returns>The max <see cref="Item.placeStyle"/>, otherwise -1 if there's no association</returns>
+		/// <returns>The max <see cref="Item.placeStyle"/>, otherwise 0 if there's no association</returns>
 		internal static int GetMaxPlaceStyle(int tileID)
 		{
 			int result;
@@ -2965,7 +2974,7 @@ namespace TShockAPI
 			}
 			else
 			{
-				return -1;
+				return 0; // 0 is equivalent of no place style/default place style. Returning -1 breaks the PreventMismatchedPlace config option.
 			}
 		}
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -721,7 +721,7 @@ namespace TShockAPI
 				var tryingToPlaceIce = action == EditAction.PlaceTile && editData == TileID.MagicalIceBlock &&
 					args.Player.RecentlyCreatedProjectiles.Any(p => p.Type == ProjectileID.IceBlock && !p.Killed);
 
-				if (action == EditAction.KillTile && !Main.tileCut[tile.type] && !breakableTiles.Contains(tile.type) && args.Player.RecentFuse == 0 && TShock.Config.Settings.PreventInvalidBreaking)
+				if (action == EditAction.KillTile && !Main.tileCut[tile.type] && !breakableTiles.Contains(tile.type) && args.Player.RecentFuse == 0 && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// If the tile is an axe tile and they aren't selecting an axe, they're hacking.
 					if (Main.tileAxe[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.axe == 0) && !ItemID.Sets.Explosives[selectedItem.netID]))
@@ -758,7 +758,7 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.KillWall && TShock.Config.Settings.PreventInvalidBreaking)
+				else if (action == EditAction.KillWall && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// If they aren't selecting a hammer, they could be hacking.
 					if (selectedItem.hammer == 0 && !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0 && selectedItem.createWall == 0)
@@ -773,15 +773,14 @@ namespace TShockAPI
 				{
 					args.Player.LastKilledProjectile = 0;
 				}
-				else if (CoilTileIds.Contains(editData))
+				else if (CoilTileIds.Contains(editData) && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// Handle placement if the user is placing rope that comes from a ropecoil,
 					// but have not created the ropecoil projectile recently or the projectile was not at the correct coordinate, or the tile that the projectile places does not match the rope it is suposed to place
 					// projectile should be the same X coordinate as all tile places (Note by @Olink)
 					if (ropeCoilPlacements.ContainsKey(selectedItem.netID) &&
 						!args.Player.RecentlyCreatedProjectiles.Any(p => GetDataHandlers.projectileCreatesTile.ContainsKey(p.Type) && GetDataHandlers.projectileCreatesTile[p.Type] == editData &&
-						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)) &&
-						TShock.Config.Settings.PreventMismatchedPlace)
+						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)))
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
@@ -800,38 +799,41 @@ namespace TShockAPI
 						return;
 					}
 
-					// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
-					if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock && TShock.Config.Settings.PreventMismatchedPlace)
+					if (!args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from using ice rod but not placing ice block {0} {1} {2}", args.Player.Name, action, editData));
-						args.Player.SendTileSquareCentered(tileX, tileY, 4);
-						args.Handled = true;
-						return;
-					}
-
-					// If they aren't selecting the item which creates the tile, they're hacking.
-					// We need to exclude ice block as it's checked above.
-					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && !tryingToPlaceIce && editData != selectedItem.createTile &&
-						TShock.Config.Settings.PreventMismatchedPlace)
-					{
-						// These would get caught up in the below check because Terraria does not set their createTile field.
-						if (selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb &&
-							(args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
+						// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
+						if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock)
 						{
-							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from using ice rod but not placing ice block {0} {1} {2}", args.Player.Name, action, editData));
+							args.Player.SendTileSquareCentered(tileX, tileY, 4);
+							args.Handled = true;
+							return;
+						}
+
+						// If they aren't selecting the item which creates the tile, they're hacking.
+						// We need to exclude ice block as it's checked above.
+						if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && !tryingToPlaceIce && editData != selectedItem.createTile)
+						{
+							// These would get caught up in the below check because Terraria does not set their createTile field.
+							if (selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb &&
+								(args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
+							{
+								TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
+								args.Player.SendTileSquareCentered(tileX, tileY, 4);
+								args.Handled = true;
+								return;
+							}
+						}
+						// If they aren't selecting the item which creates the wall, they're hacking.
+						if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
+						{
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createWall));
 							args.Player.SendTileSquareCentered(tileX, tileY, 4);
 							args.Handled = true;
 							return;
 						}
 					}
-					// If they aren't selecting the item which creates the wall, they're hacking.
-					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall && TShock.Config.Settings.PreventMismatchedPlace)
-					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createWall));
-						args.Player.SendTileSquareCentered(tileX, tileY, 4);
-						args.Handled = true;
-						return;
-					}
+
 					if (action == EditAction.PlaceTile && (editData == TileID.Containers || editData == TileID.Containers2))
 					{
 						if (TShock.Utils.HasWorldReachedMaxChests())
@@ -844,7 +846,7 @@ namespace TShockAPI
 						}
 					}
 				}
-				else if (action == EditAction.PlaceWire || action == EditAction.PlaceWire2 || action == EditAction.PlaceWire3 && TShock.Config.Settings.PreventMismatchedPlace)
+				else if (action == EditAction.PlaceWire || action == EditAction.PlaceWire2 || action == EditAction.PlaceWire3 && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// If they aren't selecting a wrench, they're hacking.
 					// WireKite = The Grand Design
@@ -861,13 +863,13 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.KillActuator || action == EditAction.KillWire ||
-					action == EditAction.KillWire2 || action == EditAction.KillWire3)
+				else if ((action == EditAction.KillActuator || action == EditAction.KillWire ||
+					action == EditAction.KillWire2 || action == EditAction.KillWire3) && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// If they aren't selecting the wire cutter, they're hacking.
 					if (selectedItem.type != ItemID.WireCutter
 						&& selectedItem.type != ItemID.WireKite
-						&& selectedItem.type != ItemID.MulticolorWrench && TShock.Config.Settings.PreventInvalidBreaking)
+						&& selectedItem.type != ItemID.MulticolorWrench)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wire cutter from {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
@@ -875,7 +877,7 @@ namespace TShockAPI
 						return;
 					}
 				}
-				else if (action == EditAction.PlaceActuator && TShock.Config.Settings.PreventMismatchedPlace)
+				else if (action == EditAction.PlaceActuator && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					// If they aren't selecting the actuator and don't have the Presserator equipped, they're hacking.
 					if (selectedItem.type != ItemID.Actuator && !args.Player.TPlayer.autoActuator)
@@ -2380,7 +2382,7 @@ namespace TShockAPI
 			{
 				if (type != TileID.LargePilesEcho && type != TileID.LargePiles2Echo && type != TileID.SmallPiles2x1Echo &&
 					type != TileID.SmallPiles1x1Echo && type != TileID.PlantDetritus3x2Echo && type != TileID.PlantDetritus2x2Echo &&
-					TShock.Config.Settings.PreventMismatchedPlace)
+					!args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected rubblemaker I can't believe it's not rubble! from {0}",
 						args.Player.Name));
@@ -2391,7 +2393,7 @@ namespace TShockAPI
 			}
 			else if (args.Player.SelectedItem.type == ItemID.AcornAxe)
 			{
-				if (type != TileID.Saplings && TShock.Config.Settings.PreventMismatchedPlace)
+				if (type != TileID.Saplings && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected Axe of Regrowth only places saplings {0}", args.Player.Name));
 					args.Player.SendTileSquareCentered(x, y, 4);
@@ -2404,7 +2406,7 @@ namespace TShockAPI
 				// This is necessary to check in order to prevent special tiles such as
 				// queen bee larva, paintings etc that use this packet from being placed
 				// without selecting the right item.
-				if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile && TShock.Config.Settings.PreventMismatchedPlace)
+				if (type != args.Player.TPlayer.inventory[args.Player.TPlayer.selectedItem].createTile && !args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected awkward tile creation/selection from {0}", args.Player.Name));
 					args.Player.SendTileSquareCentered(x, y, 4);
@@ -2960,7 +2962,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Returns the max <see cref="Item.placeStyle"/> associated with the given <paramref name="tileID"/>. Or -1 if there's no association
+		/// Returns the max <see cref="Item.placeStyle"/> associated with the given <paramref name="tileID"/>. Or 0 if there's no association
 		/// </summary>
 		/// <param name="tileID">Tile ID to query for</param>
 		/// <returns>The max <see cref="Item.placeStyle"/>, otherwise 0 if there's no association</returns>
@@ -2974,7 +2976,9 @@ namespace TShockAPI
 			}
 			else
 			{
-				return 0; // 0 is equivalent of no place style/default place style. Returning -1 breaks the PreventMismatchedPlace config option.
+				// Returning -1 interferes with Permissions.ignoreitemsafetychecks.
+				// Because we only use this method in OnTileEdit, the requested place style can never be -1, so it would incorrectly reject someone with permission to ignore item safety.
+				return 0;
 			}
 		}
 

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -243,14 +243,6 @@ namespace TShockAPI.Configuration
 		[Description("Prevents players from placing tiles with an invalid style.")]
 		public bool PreventInvalidPlaceStyle = true;
 
-		/// <summary>Prevents players from placing tiles, walls, or wiring that don't match what their held item places.</summary>
-		[Description("Prevents players from placing tiles, walls, or wiring that don't match what their held item places.")]
-		public bool PreventMismatchedPlace = true;
-
-		/// <summary>Prevents players from breaking tiles, walls, or wiring that their held item is unable to break.</summary>
-		[Description("Prevents players from breaking tiles, walls, or wiring that their held item is unable to break.")]
-		public bool PreventInvalidBreaking = true;
-
 		/// <summary>Allows placement of the Fake_NewChest items.</summary>
 		[Description("Allows placement of the Fake_NewChest items.")]
 		public bool AllowFakeNewChest = false;
@@ -388,10 +380,6 @@ namespace TShockAPI.Configuration
 		[Description("The minimum password length for new user accounts. Can never be lower than 4.")]
 		public int MinimumPasswordLength = 4;
 
-		/// <summary>The maximum allowed length for chat messages. Valid range: 256 characters to 2048 characters.</summary>
-		[Description("The maximum allowed length for chat messages. Valid range: 256 characters to 2048 characters.")]
-		public int MaximumChatMessageLength = 500;
-
 		/// <summary>Determines the BCrypt work factor to use. If increased, all passwords will be upgraded to new work-factor on verify.
 		/// The number of computational rounds is 2^n. Increase with caution. Range: 5-31.</summary>
 		[Description("Determines the BCrypt work factor to use. If increased, all passwords will be upgraded to new work-factor on verify. The number of computational rounds is 2^n. Increase with caution. Range: 5-31.")]
@@ -494,6 +482,14 @@ namespace TShockAPI.Configuration
 		/// Note: Will not function properly if the string length is bigger than 1.</summary>
 		[Description("Specifies which string starts a command silently.\nNote: Will not function properly if the string length is bigger than 1.")]
 		public string CommandSilentSpecifier = ".";
+
+		/// <summary>The maximum allowed length for chat messages. Valid range: 250 characters to 2048 characters.</summary>
+		[Description("The maximum allowed length for chat messages. Valid range: 250 characters to 2048 characters.")]
+		public int MaximumChatMessageLength = 500;
+
+		/// <summary>If a chat message that exceeds MaximumChatMessageLength should be truncated or not.</summary>
+		[Description("If a chat message that exceeds MaximumChatMessageLength should be truncated or not.")]
+		public bool TruncateExcessiveChatMessages = true;
 
 		/// <summary>Disables sending logs as messages to players with the log permission.</summary>
 		[Description("Disables sending logs as messages to players with the log permission.")]

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -243,6 +243,18 @@ namespace TShockAPI.Configuration
 		[Description("Prevents players from placing tiles with an invalid style.")]
 		public bool PreventInvalidPlaceStyle = true;
 
+		/// <summary>Prevents players from placing tiles, walls, or wiring that don't match what their held item places.</summary>
+		[Description("Prevents players from placing tiles, walls, or wiring that don't match what their held item places.")]
+		public bool PreventMismatchedPlace = true;
+
+		/// <summary>Prevents players from breaking tiles, walls, or wiring that their held item is unable to break.</summary>
+		[Description("Prevents players from breaking tiles, walls, or wiring that their held item is unable to break.")]
+		public bool PreventInvalidBreaking = true;
+
+		/// <summary>Allows placement of the Fake_NewChest items.</summary>
+		[Description("Allows placement of the Fake_NewChest items.")]
+		public bool AllowFakeNewChest = false;
+
 		/// <summary>Forces Christmas-only events to occur all year.</summary>
 		[Description("Forces Christmas-only events to occur all year.")]
 		public bool ForceXmas = false;
@@ -375,6 +387,10 @@ namespace TShockAPI.Configuration
 		/// <summary>The minimum password length for new user accounts. Can never be lower than 4.</summary>
 		[Description("The minimum password length for new user accounts. Can never be lower than 4.")]
 		public int MinimumPasswordLength = 4;
+
+		/// <summary>The maximum allowed length for chat messages. Valid range: 256 characters to 2048 characters.</summary>
+		[Description("The maximum allowed length for chat messages. Valid range: 256 characters to 2048 characters.")]
+		public int MaximumChatMessageLength = 500;
 
 		/// <summary>Determines the BCrypt work factor to use. If increased, all passwords will be upgraded to new work-factor on verify.
 		/// The number of computational rounds is 2^n. Increase with caution. Range: 5-31.</summary>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3777,7 +3777,8 @@ namespace TShockAPI
 				args.Player.SelectedItem.type != ItemID.SpectrePaintbrush &&
 				!args.Player.Accessories.Any(HasPaintSprayerAbilities) &&
 				!args.Player.Inventory.Any(HasPaintSprayerAbilities) &&
-				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities)) //Void Bag
+				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities) && //Void Bag
+				!args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePaintTile rejected select consistency {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.PaintTile, "", x, y, Main.tile[x, y].color());
@@ -3826,7 +3827,8 @@ namespace TShockAPI
 				args.Player.SelectedItem.type != ItemID.SpectrePaintbrush &&
 				!args.Player.Accessories.Any(HasPaintSprayerAbilities) &&
 				!args.Player.Inventory.Any(HasPaintSprayerAbilities)&&
-				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities)) //Void Bag
+				!args.TPlayer.bank4.item.Any(HasPaintSprayerAbilities) && //Void Bag
+				!args.Player.HasPermission(Permissions.ignoreitemsafetychecks))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePaintWall rejected selector consistency {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.PaintWall, "", x, y, Main.tile[x, y].wallColor());

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -149,6 +149,9 @@ namespace TShockAPI
 		[Description("Prevents you from being disabled by paint abuse detection.")]
 		public static readonly string ignorepaintdetection = "tshock.ignore.paint";
 
+		[Description("Allows you to ignore safety checks on incorrect item usage for world manipulation.")]
+		public static readonly string ignoreitemsafetychecks = "tshock.ignore.itemsafety";
+
 		[Description("Prevents you from being disabled by stack hack detection.")]
 		public static readonly string ignorestackhackdetection = "tshock.ignore.itemstack";
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1466,16 +1466,16 @@ namespace TShockAPI
 				return;
 			}
 
-			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 256, 2048);
-			if (args.Text.Length > maxLength)
+			string text = args.Text;
+
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			if (text.Length > maxLength && !Config.Settings.TruncateExcessiveChatMessages)
 			{
 				Log.ConsoleDebug(GetString("TShock / OnChat rejected due to length of {0}/{1} from {2}", args.Text.Length, maxLength, tsplr.Name));
 				tsplr.SendErrorMessage(GetString("Your chat message exceeds the maximum length of {1} characters. ({0}/{1}).", args.Text.Length, maxLength));
 				args.Handled = true;
 				return;
 			}
-
-			string text = args.Text;
 
 			// Terraria now has chat commands on the client side.
 			// These commands remove the commands prefix (e.g. /me /playing) and send the command id instead
@@ -1526,13 +1526,15 @@ namespace TShockAPI
 					tsplr.SendErrorMessage(GetString("You are muted!"));
 					args.Handled = true;
 				}
-				else if (!TShock.Config.Settings.EnableChatAboveHeads)
+				else if (!Config.Settings.EnableChatAboveHeads)
 				{
+					var realText = TruncateChatMessageIfNecessary(args);
+
 					text = String.Format(Config.Settings.ChatFormat, tsplr.Group.Name, tsplr.Group.Prefix, tsplr.Name, tsplr.Group.Suffix,
-											 args.Text);
+											 realText);
 
 					//Invoke the PlayerChat hook. If this hook event is handled then we need to prevent sending the chat message
-					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, args.Text, ref text);
+					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, realText, ref text);
 					args.Handled = true;
 
 					if (cancelChat)
@@ -1623,6 +1625,24 @@ namespace TShockAPI
 				Commands.HandleCommand(TSPlayer.Server, "/" + args.Command);
 			}
 			args.Handled = true;
+		}
+
+
+		/// <summary>
+		/// Truncates a chat message if it exceeds the <see cref="TShockSettings.MaximumChatMessageLength"/>.
+		/// </summary>
+		/// <param name="args">args - The ServerChatEventArgs object.</param>
+		/// <returns></returns>
+		private string TruncateChatMessageIfNecessary(ServerChatEventArgs args)
+		{
+			string chatMsg = args.Text;
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			if (chatMsg.Length > maxLength)
+			{
+				Log.ConsoleDebug(GetString("TShock / OnChat truncating excessive chat message length of {0}/{1} from {2}", args.Text.Length, maxLength, Players[args.Who].Name));
+				chatMsg = chatMsg.Substring(0, Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048)) + "...";
+			}
+			return chatMsg;
 		}
 
 		/// <summary>OnGetData - Called when the server gets raw data packets.</summary>

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1639,7 +1639,7 @@ namespace TShockAPI
 			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
 			if (chatMsg.Length > maxLength)
 			{
-				Log.ConsoleDebug(GetString("TShock / OnChat truncating excessive chat message length of {0}/{1} from {2}", args.Text.Length, maxLength, Players[args.Who].Name));
+				Log.ConsoleDebug(GetString("TShock / TruncateChatMessageIfNecessary truncating excessive chat message length of {0}/{1} from {2}", args.Text.Length, maxLength, Players[args.Who].Name));
 				chatMsg = chatMsg.Substring(0, Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048)) + "...";
 			}
 			return chatMsg;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1466,9 +1466,11 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Text.Length > 500)
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 256, 2048);
+			if (args.Text.Length > maxLength)
 			{
-				tsplr.Kick(GetString("Crash attempt via long chat packet."), true);
+				Log.ConsoleDebug(GetString("TShock / OnChat rejected due to length of {0}/{1} from {2}", args.Text.Length, maxLength, tsplr.Name));
+				tsplr.SendErrorMessage(GetString("Your chat message exceeds the maximum length of {1} characters. ({0}/{1}).", args.Text.Length, maxLength));
 				args.Handled = true;
 				return;
 			}


### PR DESCRIPTION
This one's a pretty decently sized PR. The 3 new options were added in response to #3013.
``PreventMismatchedPlace`` and ``PreventInvalidBreaking`` are enabled by default to not cause any changes to existing security. Servers can now choose to disable these options if they are okay with such a risk, similar to the existing option of ``PreventInvalidPlaceStyle``.
``AllowFakeNewChest`` is false by default. Enabling this will allow players to place the normally disallowed ``Fake_NewChest`` items. These items do have genuine use for technical players of the game, so this was added to benefit those types of players. Of course there is risk, so it must be manually enabled to not compromise security.
Magical Ice placement is now validated by making sure the player has recently created an ice block projectile. This should prevent cases where a player switches their held item immediately after using an Ice Rod and their ice doesn't place.
The kicks from ``NPCAddBuff`` & ``OnReleaseNPC`` have been removed for consistency with almost all other parts of the Bouncer, and in case of false positives for the (currently upcoming) 1.4.5 update.
``MaximumChatMessageLength`` is a new option that replaces the old hard limit of 500 characters on chat messages. The substring issue on mobile clients is supposed to be fixed in 1.4.5 (I can not find the original post but I believe it is on the Terraria Community Forums). The hard limit of 500 characters didn't prevent the issue whatsoever and instead caused frustration for players (primarily on mobile) who sent long messages. Instead of kicking them now, they recieve an error message that their message was too long.
If there's any concerns about changes here, please let me know. I ensured that none of the new options caused issues with existing anti-cheat checks, but there IS a possibility some cases were missed and no longer function properly.

The changelog is as follows:
- Added ``PreventMismatchedPlace``, ``PreventInvalidBreaking``, and ``AllowFakeNewChest`` options to the config.
  - ``PreventMismatchedPlace`` prevents players from placing tiles, walls, or wiring that do not match their held item. Enabled by default. **Disabling this may compromise security on your server, and is not recommended.**
  - ``PreventInvalidBreaking`` prevents players from mining tiles/walls or removing wiring with incorrect items/tools. Enabled by default. **Disabling this may compromise security on your server, and is not recommended.**
  - ``AllowFakeNewChest`` allows for placing of the unobtainable ``Fake_NewChest`` items. Disabled by default.
- Fixed Magical Ice from the Ice Rod getting rejected from placing if player switched items or teleported away.
- Players are no longer kicked from adding buffs to NPCs abnormally. Instead, it will be rejected.
- Players are no longer kicked when releasing a critter from the wrong item. Instead, no critter will be spawned.
- Added a new ``MaximumChatMessageLength`` option to the config, replacing previous limit of 500. Applies to chat messages & player death reasons.
  - Players will now recieve an error message if they send a chat message that exceeds the ``MaximumChatMessageLength``.