### PR TITLE
Update OTAPI and initial issue fixes

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3011,19 +3011,11 @@ namespace TShockAPI
 			{ BuffID.Daybreak, 300 },               // BuffID: 189 Solar Eruption Item ID: 3473, Daybreak Item ID: 3543
 			{ BuffID.BetsysCurse, 600 },            // BuffID: 203
 			{ BuffID.Oiled, 540 },                  // BuffID: 204
-			{ BuffID.BlandWhipEnemyDebuff, 240  },  // BuffID: 307
-			{ BuffID.SwordWhipNPCDebuff, 240  },    // BuffID: 309
 			{ BuffID.ScytheWhipEnemyDebuff, 240  }, // BuffID: 310
-			{ BuffID.FlameWhipEnemyDebuff, 240  },  // BuffID: 313
-			{ BuffID.ThornWhipNPCDebuff, 240  },    // BuffID: 315
-			{ BuffID.RainbowWhipNPCDebuff, 240  },  // BuffID: 316
-			{ BuffID.MaceWhipNPCDebuff, 240  },     // BuffID: 319
 			{ BuffID.GelBalloonBuff, 1800  },       // BuffID: 320
 			{ BuffID.OnFire3, 1200 },               // BuffID: 323
 			{ BuffID.Frostburn2, 1200 },            // BuffID: 324
-			{ BuffID.BoneWhipNPCDebuff, 240 },      // BuffID: 326
 			{ BuffID.TentacleSpike, 540 },          // BuffID: 337
-			{ BuffID.CoolWhipNPCDebuff, 240 },      // BuffID: 340
 			{ BuffID.BloodButcherer, 540 },         // BuffID: 344
 			{ BuffID.Shimmer, 100 },		        // BuffID: 353
 		};

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -165,7 +165,12 @@ namespace TShockAPI
 						var usingBiomeTorches = player.UsingBiomeTorches;
 						player.UsingBiomeTorches = true;
 						// BiomeTorchPlaceStyle returns the place style of the player's current biome's biome torch
-						var biomeTorchPlaceStyle = player.BiomeTorchPlaceStyle(actualItemPlaceStyle);
+						int biomeTorchPlaceStyle = actualItemPlaceStyle;
+						{
+							// Prevent modification of original variable because it is passed by reference
+							var placeStyle = actualItemPlaceStyle;
+							player.BiomeTorchPlaceStyle(ref placeStyle, ref biomeTorchPlaceStyle);
+						}
 						// Reset UsingBiomeTorches value
 						player.UsingBiomeTorches = usingBiomeTorches;
 
@@ -2404,8 +2409,20 @@ namespace TShockAPI
 
 				if (args.Player.SelectedItem.placeStyle != style)
 				{
-					var validTorch = args.Player.SelectedItem.createTile == TileID.Torches && args.Player.TPlayer.BiomeTorchPlaceStyle(args.Player.SelectedItem.placeStyle) == style;
-					var validCampfire = args.Player.SelectedItem.createTile == TileID.Campfire && args.Player.TPlayer.BiomeCampfirePlaceStyle(args.Player.SelectedItem.placeStyle) == style;
+					int biomeTorchPlaceStyle = args.Player.SelectedItem.placeStyle;
+					{
+						// Prevent modification of original variable because it is passed by reference
+						int typeCopy = biomeTorchPlaceStyle;
+						args.Player.TPlayer.BiomeTorchPlaceStyle(ref typeCopy, ref biomeTorchPlaceStyle);
+					}
+					int biomeCampfirePlaceStyle = args.Player.SelectedItem.placeStyle;
+					{
+						// Prevent modification of original variable because it is passed by reference
+						int typeCopy = biomeCampfirePlaceStyle;
+						args.Player.TPlayer.BiomeCampfirePlaceStyle(ref typeCopy, ref biomeCampfirePlaceStyle);
+					}
+					var validTorch = args.Player.SelectedItem.createTile == TileID.Torches && biomeTorchPlaceStyle == style;
+					var validCampfire = args.Player.SelectedItem.createTile == TileID.Campfire && biomeCampfirePlaceStyle == style;
 					if (!args.Player.TPlayer.unlockedBiomeTorches || (!validTorch && !validCampfire))
 					{
 						TShock.Log.ConsoleError(GetString("Bouncer / OnPlaceObject rejected object placement with invalid style {1} (expected {2}) from {0}", args.Player.Name, style, args.Player.SelectedItem.placeStyle));

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -720,7 +720,7 @@ namespace TShockAPI
 				if (action == EditAction.KillTile && !Main.tileCut[tile.type] && !breakableTiles.Contains(tile.type) && args.Player.RecentFuse == 0)
 				{
 					// If the tile is an axe tile and they aren't selecting an axe, they're hacking.
-					if (Main.tileAxe[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.axe == 0) && !ItemID.Sets.Explosives[selectedItem.netID]))
+					if (Main.tileAxe[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.axe == 0) && !ItemID.Sets.Explosives[selectedItem.type]))
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (axe) {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
@@ -728,7 +728,7 @@ namespace TShockAPI
 						return;
 					}
 					// If the tile is a hammer tile and they aren't selecting a hammer, they're hacking.
-					else if (Main.tileHammer[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.hammer == 0) && !ItemID.Sets.Explosives[selectedItem.netID]))
+					else if (Main.tileHammer[tile.type] && ((args.Player.TPlayer.mount.Type != MountID.Drill && selectedItem.hammer == 0) && !ItemID.Sets.Explosives[selectedItem.type]))
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (hammer) {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
@@ -740,7 +740,7 @@ namespace TShockAPI
 					// also add an exception for snake coils, they can be removed when the player places a new one or after x amount of time
 					// If the tile is part of the breakable when placing set, it might be getting broken by a placement.
 					else if (tile.type != TileID.ItemFrame && tile.type != TileID.MysticSnakeRope
-														   && !ItemID.Sets.Explosives[selectedItem.netID]
+														   && !ItemID.Sets.Explosives[selectedItem.type]
 														   && !TileID.Sets.BreakableWhenPlacing[tile.type]
 														   && !Main.tileAxe[tile.type] && !Main.tileHammer[tile.type] && tile.wall == 0
 														   && selectedItem.pick == 0 && selectedItem.type != ItemID.GravediggerShovel
@@ -757,7 +757,7 @@ namespace TShockAPI
 				else if (action == EditAction.KillWall)
 				{
 					// If they aren't selecting a hammer, they could be hacking.
-					if (selectedItem.hammer == 0 && !ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0 && selectedItem.createWall == 0)
+					if (selectedItem.hammer == 0 && !ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0 && selectedItem.createWall == 0)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (hammer2) {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
@@ -774,11 +774,11 @@ namespace TShockAPI
 					// Handle placement if the user is placing rope that comes from a ropecoil,
 					// but have not created the ropecoil projectile recently or the projectile was not at the correct coordinate, or the tile that the projectile places does not match the rope it is suposed to place
 					// projectile should be the same X coordinate as all tile places (Note by @Olink)
-					if (ropeCoilPlacements.ContainsKey(selectedItem.netID) &&
+					if (ropeCoilPlacements.ContainsKey(selectedItem.type) &&
 						!args.Player.RecentlyCreatedProjectiles.Any(p => GetDataHandlers.projectileCreatesTile.ContainsKey(p.Type) && GetDataHandlers.projectileCreatesTile[p.Type] == editData &&
 						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)))
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
 						args.Player.SendTileSquareCentered(tileX, tileY, 1);
 						args.Handled = true;
 						return;
@@ -796,7 +796,7 @@ namespace TShockAPI
 					}
 
 					/// Handle placement action if the player is using an Ice Rod but not placing the iceblock.
-					if (selectedItem.netID == ItemID.IceRod && editData != TileID.MagicalIceBlock)
+					if (selectedItem.type == ItemID.IceRod && editData != TileID.MagicalIceBlock)
 					{
 						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from using ice rod but not placing ice block {0} {1} {2}", args.Player.Name, action, editData));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
@@ -806,9 +806,9 @@ namespace TShockAPI
 					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
 					{
 						/// These would get caught up in the below check because Terraria does not set their createTile field.
-						if (selectedItem.netID != ItemID.IceRod && selectedItem.netID != ItemID.DirtBomb && selectedItem.netID != ItemID.StickyBomb && (args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
+						if (selectedItem.type != ItemID.IceRod && selectedItem.type != ItemID.DirtBomb && selectedItem.type != ItemID.StickyBomb && (args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart || editData != TileID.MinecartTrack))
 						{
-							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createTile));
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
 							args.Player.SendTileSquareCentered(tileX, tileY, 4);
 							args.Handled = true;
 							return;
@@ -817,7 +817,7 @@ namespace TShockAPI
 					/// If they aren't selecting the item which creates the wall, they're hacking.
 					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.netID, selectedItem.createWall));
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from wall placement not matching selected item createWall {0} {1} {2} selectedItemID:{3} createWall:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createWall));
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
 						args.Handled = true;
 						return;
@@ -917,7 +917,7 @@ namespace TShockAPI
 						return;
 					}
 
-					if (action == EditAction.KillTile || action == EditAction.KillWall && ItemID.Sets.Explosives[selectedItem.netID] && args.Player.RecentFuse == 0)
+					if (action == EditAction.KillTile || action == EditAction.KillWall && ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0)
 					{
 						args.Handled = false;
 						return;
@@ -1156,7 +1156,7 @@ namespace TShockAPI
 
 			// stop the client from changing the item type of a drop but
 			// only if the client isn't picking up the item
-			if (Main.item[id].active && Main.item[id].netID != type)
+			if (Main.item[id].active && Main.item[id].type != type)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from item drop/pickup check from {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.ItemDrop, "", id);

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -1265,7 +1265,7 @@ namespace TShockAPI
 			args.Player.SendInfoMessage(GetString($"Name: {(TShock.Config.Settings.UseServerName ? TShock.Config.Settings.ServerName : Main.worldName)}"));
 			args.Player.SendInfoMessage(GetString("Size: {0}x{1}", Main.maxTilesX, Main.maxTilesY));
 			args.Player.SendInfoMessage(GetString($"ID: {Main.worldID}"));
-			args.Player.SendInfoMessage(GetString($"Seed: {WorldGen.currentWorldSeed}"));
+			args.Player.SendInfoMessage(GetString($"Seed: {Main.ActiveWorldFileData.Seed}"));
 			args.Player.SendInfoMessage(GetString($"Mode: {Main.GameMode}"));
 			args.Player.SendInfoMessage(GetString($"Path: {Main.worldPathName}"));
 		}

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -5919,7 +5919,7 @@ namespace TShockAPI
 
 							if (Main.item[i].active && dX * dX + dY * dY <= radius * radius * 256f)
 							{
-								Main.item[i].active = false;
+								Main.item[i].TurnToAir();
 								everyone.SendData(PacketTypes.ItemDrop, "", i);
 								cleared++;
 							}

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -3841,7 +3841,7 @@ namespace TShockAPI
 						}
 						else if (items.Count > 1)
 						{
-							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.netID})"));
+							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.type})"));
 						}
 						else
 						{
@@ -3892,7 +3892,7 @@ namespace TShockAPI
 						}
 						else if (items.Count > 1)
 						{
-							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.netID})"));
+							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.type})"));
 						}
 						else
 						{
@@ -3937,7 +3937,7 @@ namespace TShockAPI
 						}
 						else if (items.Count > 1)
 						{
-							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.netID})"));
+							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.type})"));
 						}
 						else
 						{
@@ -3963,7 +3963,7 @@ namespace TShockAPI
 						}
 						else if (items.Count > 1)
 						{
-							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.netID})"));
+							args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.type})"));
 						}
 						else
 						{
@@ -6162,7 +6162,7 @@ namespace TShockAPI
 			}
 			else if (matchedItems.Count > 1)
 			{
-				args.Player.SendMultipleMatchError(matchedItems.Select(i => $"{i.Name}({i.netID})"));
+				args.Player.SendMultipleMatchError(matchedItems.Select(i => $"{i.Name}({i.type})"));
 				return;
 			}
 			else
@@ -6310,7 +6310,7 @@ namespace TShockAPI
 			}
 			else if (items.Count > 1)
 			{
-				args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.netID})"));
+				args.Player.SendMultipleMatchError(items.Select(i => $"{i.Name}({i.type})"));
 			}
 			else
 			{

--- a/TShockAPI/DB/UserManager.cs
+++ b/TShockAPI/DB/UserManager.cs
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+extern alias BCrypt;
+
 using System;
 using System.Data;
 using System.Collections.Generic;
@@ -23,7 +25,7 @@ using System.Linq;
 using System.Text;
 using MySql.Data.MySqlClient;
 using System.Text.RegularExpressions;
-using BCrypt.Net;
+using BCrypt::BCrypt.Net;
 using System.Security.Cryptography;
 using TShockAPI.DB.Queries;
 using TShockAPI.Hooks;
@@ -465,7 +467,7 @@ namespace TShockAPI.DB
 		{
 			try
 			{
-				if (BCrypt.Net.BCrypt.Verify(password, Password))
+				if (BCrypt::BCrypt.Net.BCrypt.Verify(password, Password))
 				{
 					// If necessary, perform an upgrade to the highest work factor.
 					UpgradePasswordWorkFactor(password);
@@ -520,12 +522,12 @@ namespace TShockAPI.DB
 			}
 			try
 			{
-				Password = BCrypt.Net.BCrypt.HashPassword(password.Trim(), TShock.Config.Settings.BCryptWorkFactor);
+				Password = BCrypt::BCrypt.Net.BCrypt.HashPassword(password.Trim(), TShock.Config.Settings.BCryptWorkFactor);
 			}
 			catch (ArgumentOutOfRangeException)
 			{
 				TShock.Log.ConsoleError(GetString("Invalid BCrypt work factor in config file! Creating new hash using default work factor."));
-				Password = BCrypt.Net.BCrypt.HashPassword(password.Trim());
+				Password = BCrypt::BCrypt.Net.BCrypt.HashPassword(password.Trim());
 			}
 		}
 
@@ -539,7 +541,7 @@ namespace TShockAPI.DB
 				int minLength = TShock.Config.Settings.MinimumPasswordLength;
 				throw new ArgumentOutOfRangeException("password", GetString($"Password must be at least {minLength} characters."));
 			}
-			Password = BCrypt.Net.BCrypt.HashPassword(password.Trim(), workFactor);
+			Password = BCrypt::BCrypt.Net.BCrypt.HashPassword(password.Trim(), workFactor);
 		}
 
 		#region IEquatable

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2124,6 +2124,26 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Represents the ID of an inventory inside a <see cref="TEDisplayDoll"/>.
+		/// </summary>
+		public enum DisplayDollInventoryID
+		{
+			/// <summary>
+			/// The ID of the inventory holding the equipment items.
+			/// </summary>
+			Equipment = 0,
+
+			/// <summary>
+			/// The ID of the inventory holding the dyes.
+			/// </summary>
+			Dyes = 1,
+
+			/// <summary>
+			/// The ID of the inventory holding the miscellaneous items (mounts, pets, etc.).
+			/// </summary>
+			Misc = 2,
+		}
+		/// <summary>
 		/// For use in a TileEntityDisplayDollItemSync event.
 		/// </summary>
 		public class DisplayDollItemSyncEventArgs : GetDataHandledEventArgs
@@ -2147,7 +2167,19 @@ namespace TShockAPI
 			/// <summary>
 			/// Whether or not the slot that is being modified is a Dye slot.
 			/// </summary>
-			public bool IsDye { get; set; }
+			[Obsolete($"Use {nameof(InventoryID)} instead.")]
+			public bool IsDye
+			{
+				get => InventoryID == DisplayDollInventoryID.Dyes;
+				set => InventoryID = value
+					? DisplayDollInventoryID.Dyes
+					: DisplayDollInventoryID.Equipment
+					;
+			}
+			/// <summary>
+			/// The ID of the inventory that is being modified.
+			/// </summary>
+			public DisplayDollInventoryID InventoryID { get; set; }
 			/// <summary>
 			/// The current item that is present in the slot before the modification.
 			/// </summary>
@@ -2161,7 +2193,7 @@ namespace TShockAPI
 		/// Called when a player modifies a DisplayDoll (Mannequin) item slot.
 		/// </summary>
 		public static HandlerList<DisplayDollItemSyncEventArgs> DisplayDollItemSync = new HandlerList<DisplayDollItemSyncEventArgs>();
-		private static bool OnDisplayDollItemSync(TSPlayer player, MemoryStream data, byte playerIndex, int tileEntityID, TEDisplayDoll displayDollEntity, int slot, bool isDye, Item oldItem, Item newItem)
+		private static bool OnDisplayDollItemSync(TSPlayer player, MemoryStream data, byte playerIndex, int tileEntityID, TEDisplayDoll displayDollEntity, int slot, DisplayDollInventoryID inventoryID, Item oldItem, Item newItem)
 		{
 			if (DisplayDollItemSync == null)
 				return false;
@@ -2174,11 +2206,55 @@ namespace TShockAPI
 				TileEntityID = tileEntityID,
 				DisplayDollEntity = displayDollEntity,
 				Slot = slot,
-				IsDye = isDye,
+				InventoryID = inventoryID,
 				OldItem = oldItem,
 				NewItem = newItem
 			};
 			DisplayDollItemSync.Invoke(null, args);
+			return args.Handled;
+		}
+
+		/// <summary>
+		/// For use in a <see cref="DisplayDollPoseSync"/> event.
+		/// </summary>
+		public class DisplayDollPoseSyncEventArgs : GetDataHandledEventArgs
+		{
+			/// <summary>
+			/// The player index in the packet who modifies the DisplayDoll item slot.
+			/// </summary>
+			public byte PlayerIndex { get; set; }
+			/// <summary>
+			/// The ID of the TileEntity that is being modified.
+			/// </summary>
+			public int TileEntityID { get; set; }
+			/// <summary>
+			/// The TEDisplayDoll object that is being modified.
+			/// </summary>
+			public TEDisplayDoll DisplayDollEntity { get; set; }
+			/// <summary>
+			/// The incoming pose ID of the TEDisplayDoll.
+			/// </summary>
+			public byte Pose { get; set; }
+		}
+		/// <summary>
+		/// Called when a player modifies a DisplayDoll (Mannequin) pose.
+		/// </summary>
+		public static HandlerList<DisplayDollPoseSyncEventArgs> DisplayDollPoseSync = new();
+		private static bool OnDisplayDollPoseSync(TSPlayer player, MemoryStream data, byte playerIndex, int tileEntityID, TEDisplayDoll displayDollEntity, byte pose)
+		{
+			if (DisplayDollPoseSync == null)
+				return false;
+
+			var args = new DisplayDollPoseSyncEventArgs
+			{
+				Player = player,
+				Data = data,
+				PlayerIndex = playerIndex,
+				TileEntityID = tileEntityID,
+				DisplayDollEntity = displayDollEntity,
+				Pose = pose,
+			};
+			DisplayDollPoseSync.Invoke(null, args);
 			return args.Handled;
 		}
 
@@ -4402,41 +4478,51 @@ namespace TShockAPI
 			byte playerIndex = args.Data.ReadInt8();
 			int tileEntityID = args.Data.ReadInt32();
 			int slot = args.Data.ReadByte();
-			bool isDye = false;
-			if (slot >= 8)
-			{
-				isDye = true;
-				slot -= 8;
-			}
+			int subtype = args.Data.ReadByte();
 
-			Item newItem = new Item();
-			Item oldItem = new Item();
-
-			if (!TileEntity.ByID.TryGetValue(tileEntityID, out TileEntity tileEntity))
+			if (!TileEntity.TryGet(tileEntityID, out TEDisplayDoll displayDoll))
 				return false;
 
-			TEDisplayDoll displayDoll = tileEntity as TEDisplayDoll;
-			if (displayDoll != null)
+			switch (subtype)
 			{
-				oldItem = displayDoll._items[slot];
-				if (isDye)
-					oldItem = displayDoll._dyes[slot];
+				case 0:
+					return HandleItemSync(DisplayDollInventoryID.Equipment, displayDoll._equip);
+				case 1:
+					return HandleItemSync(DisplayDollInventoryID.Dyes, displayDoll._dyes);
+				case 3:
+					return HandleItemSync(DisplayDollInventoryID.Misc, displayDoll._misc);
+
+				case 2:
+				{
+					byte pose = (byte)args.Data.ReadByte();
+					return OnDisplayDollPoseSync(args.Player, args.Data, playerIndex, tileEntityID, displayDoll, pose);
+				}
+
+				default:
+					return false;
+			}
+
+			bool HandleItemSync(DisplayDollInventoryID inventoryID, Item[] items)
+			{
+				Item oldItem = items[slot];
 
 				ushort itemType = args.Data.ReadUInt16();
 				ushort stack = args.Data.ReadUInt16();
 				int prefix = args.Data.ReadByte();
 
-				if (oldItem.type == 0 && newItem.type == 0)
+				if (oldItem.type == 0 && itemType == 0)
 					return false;
 
+				Item newItem = new Item();
 				newItem.SetDefaults(itemType);
 				newItem.stack = stack;
 				newItem.Prefix(prefix);
 
-				if (OnDisplayDollItemSync(args.Player, args.Data, playerIndex, tileEntityID, displayDoll, slot, isDye, oldItem, newItem))
+				if (OnDisplayDollItemSync(args.Player, args.Data, playerIndex, tileEntityID, displayDoll, slot, inventoryID, oldItem, newItem))
 					return true;
+
+				return false;
 			}
-			return false;
 		}
 
 		private static bool HandleRequestTileEntityInteraction(GetDataHandlerArgs args)

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -2,6 +2,7 @@
 using System.IO.Streams;
 using Terraria;
 using Terraria.GameContent.NetModules;
+using Terraria.ID;
 using Terraria.Net;
 
 namespace TShockAPI.Handlers.NetModules
@@ -49,7 +50,7 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="rejectPacket"></param>
 		public void HandlePacket(TSPlayer player, out bool rejectPacket)
 		{
-			if (!Main.GameModeInfo.IsJourneyMode)
+			if (Main.GameMode != GameModeID.Creative)
 			{
 				TShock.Log.ConsoleDebug(
 					GetString($"NetModuleHandler received attempt to unlock sacrifice while not in journey mode from {player.Name}")

--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.IO.Streams;
 using Terraria;
 using Terraria.GameContent.NetModules;
@@ -13,9 +14,18 @@ namespace TShockAPI.Handlers.NetModules
 	public class CreativeUnlocksHandler : INetModuleHandler
 	{
 		/// <summary>
-		/// An unknown field. If this does not have a value of '0' the packet should be rejected.
+		/// This field used to always be 0 in 1.4.4.9. Starting 1.4.5, this field now contains the ID of the player researching/sacrificing the item.
 		/// </summary>
-		public byte UnknownField { get; set; }
+		[Obsolete($"Use {nameof(PlayerId)} instead. This field used to always be 0 in 1.4.4.9. Starting 1.4.5, this field now contains the ID of the player researching/sacrificing the item.")]
+		public byte UnknownField
+		{
+			get => PlayerId;
+			set => PlayerId = value;
+		}
+		/// <summary>
+		/// ID of the player researching/sacrificing the item.
+		/// </summary>
+		public byte PlayerId { get; set; }
 		/// <summary>
 		/// ID of the item being sacrificed
 		/// </summary>
@@ -31,15 +41,9 @@ namespace TShockAPI.Handlers.NetModules
 		/// <param name="data"></param>
 		public void Deserialize(MemoryStream data)
 		{
-			// For whatever reason Terraria writes '0' to the stream at the beginning of this packet.
-			// If this value is not 0 then its been crafted by a non-vanilla client.
-			// We don't actually know why the 0 is written, so we're just going to call this UnknownField for now
-			UnknownField = data.ReadInt8();
-			if (UnknownField == 0)
-			{
-				ItemId = data.ReadUInt16();
-				Amount = data.ReadUInt16();
-			}
+			PlayerId = data.ReadInt8();
+			ItemId = data.ReadUInt16();
+			Amount = data.ReadUInt16();
 		}
 
 		/// <summary>
@@ -60,16 +64,6 @@ namespace TShockAPI.Handlers.NetModules
 				return;
 			}
 
-			if (UnknownField != 0)
-			{
-				TShock.Log.ConsoleDebug(
-					GetString($"CreativeUnlocksHandler received non-vanilla unlock request. Random field value: {UnknownField} but should be 0 from {player.Name}")
-				);
-
-				rejectPacket = true;
-				return;
-			}
-
 			if (!player.HasPermission(Permissions.journey_contributeresearch))
 			{
 				player.SendErrorMessage(GetString("You do not have permission to contribute research."));
@@ -77,12 +71,31 @@ namespace TShockAPI.Handlers.NetModules
 				return;
 			}
 
+#if TRUE
+			// NOTE: this is a temporary solution to get TShock to build
+			/* Given that the NetCreativeUnlocksModule has been removed in 1.4.5.0,
+			 * TShock can no longer directly set the research progress of items. Therefore,
+			 * the following codepath does not function at all.
+			 */
+			/* NetCreativeUnlocksPlayerReportModule can be used in place of NetCreativeUnlocksModule,
+			 * however, it is plagued with two issues.
+			 * 1. The client will only accept the change if it is in a team (not white), and
+			 *    the player with PlayerId is in the same team as them
+			 * 2. The vanilla handling of NetCreativeUnlocksPlayerReportModule does not broadcast the
+			 *    packet back to the sender, and the sender does not update their research progress
+			 *    if SSC is on unless it receives a response from the server. Even if no. 1 were not true,
+			 *    this bug causes researching items to break when SSC is on.
+			 */
+			rejectPacket = true;
+			return;
+#else
 			var totalSacrificed = TShock.ResearchDatastore.SacrificeItem(ItemId, Amount, player);
 
 			var response = NetCreativeUnlocksModule.SerializeItemSacrifice(ItemId, totalSacrificed);
 			NetManager.Instance.Broadcast(response);
 
 			rejectPacket = false;
+#endif
 		}
 	}
 }

--- a/TShockAPI/ItemBans.cs
+++ b/TShockAPI/ItemBans.cs
@@ -88,7 +88,7 @@ namespace TShockAPI
 				UnTaint(player);
 
 				// No matter the player type, we do a check when a player is holding an item that's banned.
-				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[player.TPlayer.selectedItem].netID), player))
+				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[player.TPlayer.selectedItem].type), player))
 				{
 					string itemName = player.TPlayer.inventory[player.TPlayer.selectedItem].Name;
 					player.Disable(GetString($"holding banned item: {itemName}"), disableFlags);
@@ -157,7 +157,7 @@ namespace TShockAPI
 			TSPlayer player = args.Player;
 			string itemName = player.TPlayer.inventory[args.SelectedItem].Name;
 
-			if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[args.SelectedItem].netID), args.Player))
+			if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[args.SelectedItem].type), args.Player))
 			{
 				player.TPlayer.controlUseItem = false;
 				player.Disable(GetString($"holding banned item: {itemName}"), disableFlags);
@@ -204,7 +204,7 @@ namespace TShockAPI
 					return;
 				}
 
-				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(args.Player.SelectedItem.netID), args.Player))
+				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(args.Player.SelectedItem.type), args.Player))
 				{
 					args.Player.SendTileSquareCentered(args.X, args.Y, 4);
 					args.Handled = true;

--- a/TShockAPI/NetItem.cs
+++ b/TShockAPI/NetItem.cs
@@ -168,7 +168,7 @@ namespace TShockAPI
 		/// <param name="item">Item in the game.</param>
 		public NetItem(Item item)
 		{
-			_netId = item.netID;
+			_netId = item.type;
 			_stack = item.stack;
 			_prefixId = item.prefix;
 		}
@@ -229,7 +229,7 @@ namespace TShockAPI
 		{
 			return item == null
 				? new NetItem()
-				: new NetItem(item.netID, item.stack, item.prefix);
+				: new NetItem(item.type, item.stack, item.prefix);
 		}
 	}
 }

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -345,7 +345,7 @@ namespace TShockAPI
 					var index = i - NetItem.ArmorIndex.Item1;
 					player.TPlayer.armor[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.armor[index].netID != 0)
+					if (player.TPlayer.armor[index].type != 0)
 					{
 						player.TPlayer.armor[index].stack = this.inventory[i].Stack;
 						player.TPlayer.armor[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -357,7 +357,7 @@ namespace TShockAPI
 					var index = i - NetItem.DyeIndex.Item1;
 					player.TPlayer.dye[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.dye[index].netID != 0)
+					if (player.TPlayer.dye[index].type != 0)
 					{
 						player.TPlayer.dye[index].stack = this.inventory[i].Stack;
 						player.TPlayer.dye[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -369,7 +369,7 @@ namespace TShockAPI
 					var index = i - NetItem.MiscEquipIndex.Item1;
 					player.TPlayer.miscEquips[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.miscEquips[index].netID != 0)
+					if (player.TPlayer.miscEquips[index].type != 0)
 					{
 						player.TPlayer.miscEquips[index].stack = this.inventory[i].Stack;
 						player.TPlayer.miscEquips[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -381,7 +381,7 @@ namespace TShockAPI
 					var index = i - NetItem.MiscDyeIndex.Item1;
 					player.TPlayer.miscDyes[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.miscDyes[index].netID != 0)
+					if (player.TPlayer.miscDyes[index].type != 0)
 					{
 						player.TPlayer.miscDyes[index].stack = this.inventory[i].Stack;
 						player.TPlayer.miscDyes[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -393,7 +393,7 @@ namespace TShockAPI
 					var index = i - NetItem.PiggyIndex.Item1;
 					player.TPlayer.bank.item[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.bank.item[index].netID != 0)
+					if (player.TPlayer.bank.item[index].type != 0)
 					{
 						player.TPlayer.bank.item[index].stack = this.inventory[i].Stack;
 						player.TPlayer.bank.item[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -405,7 +405,7 @@ namespace TShockAPI
 					var index = i - NetItem.SafeIndex.Item1;
 					player.TPlayer.bank2.item[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.bank2.item[index].netID != 0)
+					if (player.TPlayer.bank2.item[index].type != 0)
 					{
 						player.TPlayer.bank2.item[index].stack = this.inventory[i].Stack;
 						player.TPlayer.bank2.item[index].prefix = (byte)this.inventory[i].PrefixId;
@@ -417,7 +417,7 @@ namespace TShockAPI
 					var index = i - NetItem.TrashIndex.Item1;
 					player.TPlayer.trashItem.netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.trashItem.netID != 0)
+					if (player.TPlayer.trashItem.type != 0)
 					{
 						player.TPlayer.trashItem.stack = this.inventory[i].Stack;
 						player.TPlayer.trashItem.prefix = (byte)this.inventory[i].PrefixId;
@@ -429,7 +429,7 @@ namespace TShockAPI
 					var index = i - NetItem.ForgeIndex.Item1;
 					player.TPlayer.bank3.item[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.bank3.item[index].netID != 0)
+					if (player.TPlayer.bank3.item[index].type != 0)
 					{
 						player.TPlayer.bank3.item[index].stack = this.inventory[i].Stack;
 						player.TPlayer.bank3.item[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -441,7 +441,7 @@ namespace TShockAPI
 					var index = i - NetItem.VoidIndex.Item1;
 					player.TPlayer.bank4.item[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.bank4.item[index].netID != 0)
+					if (player.TPlayer.bank4.item[index].type != 0)
 					{
 						player.TPlayer.bank4.item[index].stack = this.inventory[i].Stack;
 						player.TPlayer.bank4.item[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -452,7 +452,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout1Armor.Item1;
 					player.TPlayer.Loadouts[0].Armor[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[0].Armor[index].netID != 0)
+					if (player.TPlayer.Loadouts[0].Armor[index].type != 0)
 					{
 						player.TPlayer.Loadouts[0].Armor[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[0].Armor[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -463,7 +463,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout1Dye.Item1;
 					player.TPlayer.Loadouts[0].Dye[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[0].Dye[index].netID != 0)
+					if (player.TPlayer.Loadouts[0].Dye[index].type != 0)
 					{
 						player.TPlayer.Loadouts[0].Dye[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[0].Dye[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -474,7 +474,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout2Armor.Item1;
 					player.TPlayer.Loadouts[1].Armor[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[1].Armor[index].netID != 0)
+					if (player.TPlayer.Loadouts[1].Armor[index].type != 0)
 					{
 						player.TPlayer.Loadouts[1].Armor[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[1].Armor[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -485,7 +485,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout2Dye.Item1;
 					player.TPlayer.Loadouts[1].Dye[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[1].Dye[index].netID != 0)
+					if (player.TPlayer.Loadouts[1].Dye[index].type != 0)
 					{
 						player.TPlayer.Loadouts[1].Dye[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[1].Dye[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -496,7 +496,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout3Armor.Item1;
 					player.TPlayer.Loadouts[2].Armor[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[2].Armor[index].netID != 0)
+					if (player.TPlayer.Loadouts[2].Armor[index].type != 0)
 					{
 						player.TPlayer.Loadouts[2].Armor[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[2].Armor[index].Prefix((byte)this.inventory[i].PrefixId);
@@ -507,7 +507,7 @@ namespace TShockAPI
 					var index = i - NetItem.Loadout3Dye.Item1;
 					player.TPlayer.Loadouts[2].Dye[index].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.Loadouts[2].Dye[index].netID != 0)
+					if (player.TPlayer.Loadouts[2].Dye[index].type != 0)
 					{
 						player.TPlayer.Loadouts[2].Dye[index].stack = this.inventory[i].Stack;
 						player.TPlayer.Loadouts[2].Dye[index].Prefix((byte)this.inventory[i].PrefixId);

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -708,7 +708,7 @@ namespace TShockAPI
 
 			NetMessage.SendData(39, player.Index, -1, NetworkText.Empty, 400);
 
-			if (Main.GameModeInfo.IsJourneyMode)
+			if (Main.GameMode == GameModeID.Creative)
 			{
 				var sacrificedItems = TShock.ResearchDatastore.GetSacrificedItems();
 				for(int i = 0; i < ItemID.Count; i++)

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -333,7 +333,7 @@ namespace TShockAPI
 					//0-58
 					player.TPlayer.inventory[i].netDefaults(this.inventory[i].NetId);
 
-					if (player.TPlayer.inventory[i].netID != 0)
+					if (player.TPlayer.inventory[i].type != 0)
 					{
 						player.TPlayer.inventory[i].stack = this.inventory[i].Stack;
 						player.TPlayer.inventory[i].prefix = this.inventory[i].PrefixId;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -719,8 +719,11 @@ namespace TShockAPI
 						amount = sacrificedItems[i];
 					}
 
+					// TODO: FIX THIS (1.4.4.9, 1.4.5.0, UPDATE, WIP)
+					/*
 					var response = NetCreativeUnlocksModule.SerializeItemSacrifice(i, amount);
 					NetManager.Instance.SendToClient(response, player.Index);
+					*/
 				}
 			}
 		}

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -989,7 +989,7 @@ namespace TShockAPI
 				{"muted", player.mute },
 				{"position", player.TileX + "," + player.TileY},
 				{"inventory", string.Join(", ", inventory.Select(p => (p.Name + ":" + p.stack)))},
-				{"armor", string.Join(", ", equipment.Select(p => (p.netID + ":" + p.prefix)))},
+				{"armor", string.Join(", ", equipment.Select(p => (p.type + ":" + p.prefix)))},
 				{"dyes", string.Join(", ", dyes.Select(p => (p.Name)))},
 				{"buffs", string.Join(", ", player.TPlayer.buffType)}
 			};

--- a/TShockAPI/Sockets/LinuxTcpSocket.cs
+++ b/TShockAPI/Sockets/LinuxTcpSocket.cs
@@ -123,10 +123,6 @@ namespace TShockAPI.Sockets
 			}
 		}
 
-		void ISocket.SendQueuedPackets()
-		{
-		}
-
 		void ISocket.AsyncSend(byte[] data, int offset, int size, SocketSendCallback callback, object state)
 		{
 			byte[] array = LegacyNetBufferPool.RequestBuffer(data, offset, size);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1759,7 +1759,7 @@ namespace TShockAPI
 		private Item GiveItemDirectly_FillIntoOccupiedSlot(Item item, int slot)
 		{
 			var inv = this.TPlayer.inventory;
-			if (inv[slot].type <= 0 || inv[slot].stack >= inv[slot].maxStack || !item.IsTheSameAs(inv[slot]))
+			if (inv[slot].type <= 0 || inv[slot].stack >= inv[slot].maxStack || item.type != inv[slot].type)
 				return item;
 
 			if (item.stack + inv[slot].stack <= inv[slot].maxStack)

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -494,9 +494,9 @@ namespace TShockAPI
 					// From above: this is slots 0-58 in the inventory.
 					// 0-58
 					Item item = new Item();
-					if (inventory[i] != null && inventory[i].netID != 0)
+					if (inventory[i] != null && inventory[i].type != 0)
 					{
-						item.netDefaults(inventory[i].netID);
+						item.netDefaults(inventory[i].type);
 						item.Prefix(inventory[i].prefix);
 						item.AffixName();
 						if (inventory[i].stack > item.maxStack || inventory[i].stack < 0)
@@ -514,9 +514,9 @@ namespace TShockAPI
 					// 59-78
 					var index = i - NetItem.ArmorIndex.Item1;
 					Item item = new Item();
-					if (armor[index] != null && armor[index].netID != 0)
+					if (armor[index] != null && armor[index].type != 0)
 					{
-						item.netDefaults(armor[index].netID);
+						item.netDefaults(armor[index].type);
 						item.Prefix(armor[index].prefix);
 						item.AffixName();
 						if (armor[index].stack > item.maxStack || armor[index].stack < 0)
@@ -534,9 +534,9 @@ namespace TShockAPI
 					// 79-88
 					var index = i - NetItem.DyeIndex.Item1;
 					Item item = new Item();
-					if (dye[index] != null && dye[index].netID != 0)
+					if (dye[index] != null && dye[index].type != 0)
 					{
-						item.netDefaults(dye[index].netID);
+						item.netDefaults(dye[index].type);
 						item.Prefix(dye[index].prefix);
 						item.AffixName();
 						if (dye[index].stack > item.maxStack || dye[index].stack < 0)
@@ -554,9 +554,9 @@ namespace TShockAPI
 					// 89-93
 					var index = i - NetItem.MiscEquipIndex.Item1;
 					Item item = new Item();
-					if (miscEquips[index] != null && miscEquips[index].netID != 0)
+					if (miscEquips[index] != null && miscEquips[index].type != 0)
 					{
-						item.netDefaults(miscEquips[index].netID);
+						item.netDefaults(miscEquips[index].type);
 						item.Prefix(miscEquips[index].prefix);
 						item.AffixName();
 						if (miscEquips[index].stack > item.maxStack || miscEquips[index].stack < 0)
@@ -574,9 +574,9 @@ namespace TShockAPI
 					// 93-98
 					var index = i - NetItem.MiscDyeIndex.Item1;
 					Item item = new Item();
-					if (miscDyes[index] != null && miscDyes[index].netID != 0)
+					if (miscDyes[index] != null && miscDyes[index].type != 0)
 					{
-						item.netDefaults(miscDyes[index].netID);
+						item.netDefaults(miscDyes[index].type);
 						item.Prefix(miscDyes[index].prefix);
 						item.AffixName();
 						if (miscDyes[index].stack > item.maxStack || miscDyes[index].stack < 0)
@@ -594,9 +594,9 @@ namespace TShockAPI
 					// 98-138
 					var index = i - NetItem.PiggyIndex.Item1;
 					Item item = new Item();
-					if (piggy[index] != null && piggy[index].netID != 0)
+					if (piggy[index] != null && piggy[index].type != 0)
 					{
-						item.netDefaults(piggy[index].netID);
+						item.netDefaults(piggy[index].type);
 						item.Prefix(piggy[index].prefix);
 						item.AffixName();
 
@@ -615,9 +615,9 @@ namespace TShockAPI
 					// 138-178
 					var index = i - NetItem.SafeIndex.Item1;
 					Item item = new Item();
-					if (safe[index] != null && safe[index].netID != 0)
+					if (safe[index] != null && safe[index].type != 0)
 					{
-						item.netDefaults(safe[index].netID);
+						item.netDefaults(safe[index].type);
 						item.Prefix(safe[index].prefix);
 						item.AffixName();
 
@@ -635,9 +635,9 @@ namespace TShockAPI
 				{
 					// 178-179
 					Item item = new Item();
-					if (trash != null && trash.netID != 0)
+					if (trash != null && trash.type != 0)
 					{
-						item.netDefaults(trash.netID);
+						item.netDefaults(trash.type);
 						item.Prefix(trash.prefix);
 						item.AffixName();
 
@@ -656,9 +656,9 @@ namespace TShockAPI
 					// 179-220
 					var index = i - NetItem.ForgeIndex.Item1;
 					Item item = new Item();
-					if (forge[index] != null && forge[index].netID != 0)
+					if (forge[index] != null && forge[index].type != 0)
 					{
-						item.netDefaults(forge[index].netID);
+						item.netDefaults(forge[index].type);
 						item.Prefix(forge[index].prefix);
 						item.AffixName();
 
@@ -677,9 +677,9 @@ namespace TShockAPI
 					// 220-260
 					var index = i - NetItem.VoidIndex.Item1;
 					Item item = new Item();
-					if (voidVault[index] != null && voidVault[index].netID != 0)
+					if (voidVault[index] != null && voidVault[index].type != 0)
 					{
-						item.netDefaults(voidVault[index].netID);
+						item.netDefaults(voidVault[index].type);
 						item.Prefix(voidVault[index].prefix);
 						item.AffixName();
 
@@ -697,9 +697,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout1Armor.Item1;
 					Item item = new Item();
-					if (loadout1Armor[index] != null && loadout1Armor[index].netID != 0)
+					if (loadout1Armor[index] != null && loadout1Armor[index].type != 0)
 					{
-						item.netDefaults(loadout1Armor[index].netID);
+						item.netDefaults(loadout1Armor[index].type);
 						item.Prefix(loadout1Armor[index].prefix);
 						item.AffixName();
 
@@ -717,9 +717,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout1Dye.Item1;
 					Item item = new Item();
-					if (loadout1Dye[index] != null && loadout1Dye[index].netID != 0)
+					if (loadout1Dye[index] != null && loadout1Dye[index].type != 0)
 					{
-						item.netDefaults(loadout1Dye[index].netID);
+						item.netDefaults(loadout1Dye[index].type);
 						item.Prefix(loadout1Dye[index].prefix);
 						item.AffixName();
 
@@ -737,9 +737,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout2Armor.Item1;
 					Item item = new Item();
-					if (loadout2Armor[index] != null && loadout2Armor[index].netID != 0)
+					if (loadout2Armor[index] != null && loadout2Armor[index].type != 0)
 					{
-						item.netDefaults(loadout2Armor[index].netID);
+						item.netDefaults(loadout2Armor[index].type);
 						item.Prefix(loadout2Armor[index].prefix);
 						item.AffixName();
 
@@ -757,9 +757,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout2Dye.Item1;
 					Item item = new Item();
-					if (loadout2Dye[index] != null && loadout2Dye[index].netID != 0)
+					if (loadout2Dye[index] != null && loadout2Dye[index].type != 0)
 					{
-						item.netDefaults(loadout2Dye[index].netID);
+						item.netDefaults(loadout2Dye[index].type);
 						item.Prefix(loadout2Dye[index].prefix);
 						item.AffixName();
 
@@ -777,9 +777,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout3Armor.Item1;
 					Item item = new Item();
-					if (loadout3Armor[index] != null && loadout3Armor[index].netID != 0)
+					if (loadout3Armor[index] != null && loadout3Armor[index].type != 0)
 					{
-						item.netDefaults(loadout3Armor[index].netID);
+						item.netDefaults(loadout3Armor[index].type);
 						item.Prefix(loadout3Armor[index].prefix);
 						item.AffixName();
 
@@ -797,9 +797,9 @@ namespace TShockAPI
 				{
 					var index = i - NetItem.Loadout3Dye.Item1;
 					Item item = new Item();
-					if (loadout3Dye[index] != null && loadout3Dye[index].netID != 0)
+					if (loadout3Dye[index] != null && loadout3Dye[index].type != 0)
 					{
-						item.netDefaults(loadout3Dye[index].netID);
+						item.netDefaults(loadout3Dye[index].type);
 						item.Prefix(loadout3Dye[index].prefix);
 						item.AffixName();
 

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" Aliases="BCrypt" />
     <PackageReference Include="GetText.NET" Version="8.0.5" />
     <PackageReference Include="MySql.Data" Version="9.1.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -931,7 +931,7 @@ namespace TShockAPI
 		/// <returns>The <paramref name="item"/> NetID surrounded by the item tag with proper stack/prefix data.</returns>
 		public string ItemTag(Item item)
 		{
-			int netID = item.netID;
+			int netID = item.type;
 			int stack = item.stack;
 			int prefix = item.prefix;
 			string options = stack > 1 ? "/s" + stack : prefix != 0 ? "/p" + prefix : "";

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -34,11 +34,11 @@
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
         <PackageReference Include="Npgsql" Version="9.0.3" />
         
-		<PackageReference Include="ModFramework" Version="1.1.13" GeneratePathProperty="true" /> <!-- only used to extract out to ./bin. -->
+		<PackageReference Include="ModFramework" Version="1.1.15" GeneratePathProperty="true" /> <!-- only used to extract out to ./bin. -->
 		<PackageReference Include="GetText.NET" Version="8.0.5" /> <!-- only used to extract out to ./bin. -->
 
 		<!-- the launcher doesnt need the direct OTAPI reference, but since PackageReference[ExcludeFromSingleFile] doesnt work, exclude the assets and copy manually -->
-		<PackageReference Include="OTAPI.Upcoming" Version="3.2.4" ExcludeAssets="all" GeneratePathProperty="true" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.1" ExcludeAssets="all" GeneratePathProperty="true" />
 		<None Include="$(PkgOTAPI_Upcoming)\lib\net9.0\OTAPI.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/TShockPluginManager/Nuget.cs
+++ b/TShockPluginManager/Nuget.cs
@@ -108,7 +108,7 @@ namespace TShockPluginManager
 
 			var knownBundles = new[] {
 				new PackageIdentity("GetText.NET", NuGetVersion.Parse("1.6.6")),
-				new PackageIdentity("OTAPI.Upcoming", NuGetVersion.Parse("3.1.8-alpha")),
+				new PackageIdentity("OTAPI.Upcoming", NuGetVersion.Parse("3.3.1")),
 				new PackageIdentity("TSAPI", NuGetVersion.Parse("5.0.0-beta")),
 				new PackageIdentity("TShock", NuGetVersion.Parse("5.0.0-beta")),
 			};


### PR DESCRIPTION
<!-- Warning: If you create a pull request and wish to remain anonymous, you are highly advised to use Tails (https://tails.boum.org/) or a fresh git environment. We will *not* be able to help with anonymization after your pull request has been created. -->

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. -->
- Updated `ModFramework` to `1.1.15`
- Updated `OTAPI.Upcoming` to `3.3.1`

The following changes were made:
- Replaced references to `Item.netID` with `Item.type`
- Replaced hook to `Item.SetDefaults(int, bool, ItemVariant)` with `Item.SetDefaults(int, ItemVariant)`. The flag for disabling the material check was removed. Material checks are always done now
- Removed the explicit interface implementation for `ISocket.SendQueuedPackets`, because it was removed from the interface
- Explicitly aliased our reference of BCrypt to `BCrypt`, such that references to it are now `BCrypt::BCrypt.Net.BCrypt`. Terraria also includes a copy of a different version of BCrypt, therefore, referencing it normally causes an ambiguity error. We can consider removing our reference in the future, but for now, this fixes the ambiguity error at the surface level
- Implemented handling for the new `TEDisplayDoll` sync packet. Added a new `DisplayDollPoseSync` event that is triggered whenever a client requests to change a `TEDisplayDoll`'s pose
- Obsoleted `DisplayDollItemSyncEventArgs`'s `IsDye` in favor of `InventoryID`. Mannequins can now also hold miscellaneous equipment (mounts, pets, etc.), therefore, there are three total inventories(equipment, dyes, misc) that can be touched. Three inventories cannot be represented by a boolean `IsDye`, so it was obsoleted
- Removed the NPC whip debuffs from the maximum buff time dictionary. The `BuffID` class marks them as obsolete with the reason "Removed." I have separately verified that the game no longer uses these IDs for `AddBuff`
- Added a temporary fix for `CreativeUnlocksHandler` that rejects all research packets until the issues mentioned in the comment can be resolved
- Obsoleted `CreativeUnlocksHandler`'s `UnknownField` in favor of `PlayerId`. Client versions 1.4.5.0 and above now use this field to communicate the ID of the player sacrificing the item

see commit log for other fixes

Items for future work:
- Reimplement NPC whip debuff checking with the whip tags system
- Remove the temporary fix in `CreativeUnlocksHandler`
- Fix `RestoreCharacter` being unable to restore research progress
- Diff existing packets for changes, update Bouncer and GetDataHandlers
- Handle new packets in Bouncer and GetDataHandlers