### PR TITLE
Fix SSC (Server Side Characters) for Terraria 1.4.5

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2677,7 +2677,7 @@ namespace TShockAPI
 
 			// Players send a slot update packet for each inventory slot right after they've joined.
 			bool bypassTrashCanCheck = false;
-			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Loadout3_Dye_0 + NetItem.LoadoutDyeSlots - 1) // equals to 989, avoid hardcoding
+			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Count - 1) // equals to 989, avoid hardcoding
 			{
 				args.Player.HasSentInventory = true;
 				bypassTrashCanCheck = true;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2676,8 +2676,9 @@ namespace TShockAPI
 			bool blockedSlot = slotFlags[1];
 
 			// Players send a slot update packet for each inventory slot right after they've joined.
+			// The last slot the client sends is Count - 1 (Count is total slots, so Count - 1 is the last index)
 			bool bypassTrashCanCheck = false;
-			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Count - 1) // equals to 989, avoid hardcoding
+			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Count - 1)
 			{
 				args.Player.HasSentInventory = true;
 				bypassTrashCanCheck = true;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2676,15 +2676,16 @@ namespace TShockAPI
 			bool blockedSlot = slotFlags[1];
 
 			// Players send a slot update packet for each inventory slot right after they've joined.
+			// 1.4.5: The last actual item slot is Loadout3_Dye_0 + LoadoutDyeSlots - 1
 			bool bypassTrashCanCheck = false;
-			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == NetItem.MaxInventory)
+			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Loadout3_Dye_0 + NetItem.LoadoutDyeSlots - 1)
 			{
 				args.Player.HasSentInventory = true;
 				bypassTrashCanCheck = true;
 			}
 
 			if (OnPlayerSlot(args.Player, args.Data, plr, slot, stack, prefix, type, favorited, blockedSlot)
-				|| plr != args.Player.Index || slot < 0 || slot > NetItem.MaxInventory)
+				|| plr != args.Player.Index || slot < 0 || slot >= PlayerItemSlotID.Count)
 				return true;
 			if (args.Player.IgnoreSSCPackets)
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2676,9 +2676,8 @@ namespace TShockAPI
 			bool blockedSlot = slotFlags[1];
 
 			// Players send a slot update packet for each inventory slot right after they've joined.
-			// 1.4.5: The last actual item slot is Loadout3_Dye_0 + LoadoutDyeSlots - 1
 			bool bypassTrashCanCheck = false;
-			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Loadout3_Dye_0 + NetItem.LoadoutDyeSlots - 1)
+			if (plr == args.Player.Index && !args.Player.HasSentInventory && slot == PlayerItemSlotID.Loadout3_Dye_0 + NetItem.LoadoutDyeSlots - 1) // equals to 989, avoid hardcoding
 			{
 				args.Player.HasSentInventory = true;
 				bypassTrashCanCheck = true;
@@ -2701,7 +2700,11 @@ namespace TShockAPI
 
 			if (args.Player.IsLoggedIn)
 			{
-				args.Player.PlayerData.StoreSlot(slot, type, prefix, stack, favorited);
+				int internalSlot = NetworkSlotToInternalSlot(slot);
+				if (internalSlot >= 0)
+				{
+					args.Player.PlayerData.StoreSlot(internalSlot, type, prefix, stack, favorited);
+				}
 			}
 			else if (Main.ServerSideCharacter && TShock.Config.Settings.DisableLoginBeforeJoin && !bypassTrashCanCheck &&
 					 args.Player.HasSentInventory && !args.Player.HasPermission(Permissions.bypassssc))
@@ -2717,6 +2720,63 @@ namespace TShockAPI
 			}
 
 			return false;
+		}
+		// 1.4.5 reserved 40+160 slots per bank in network protocol instead of 40.
+		// This function maps the network slot IDs(0-989) to the internal NetItem slot IDs(0-349).
+		private static int NetworkSlotToInternalSlot(int networkSlot)
+		{
+			if (networkSlot < PlayerItemSlotID.Bank1_0)
+				return networkSlot;
+
+			if (networkSlot < PlayerItemSlotID.Bank1_0 + NetItem.PiggySlots)
+				return NetItem.PiggyIndex.Item1 + (networkSlot - PlayerItemSlotID.Bank1_0);
+
+			if (networkSlot < PlayerItemSlotID.Bank2_0)
+				return -1;
+
+			if (networkSlot < PlayerItemSlotID.Bank2_0 + NetItem.SafeSlots)
+				return NetItem.SafeIndex.Item1 + (networkSlot - PlayerItemSlotID.Bank2_0);
+
+			if (networkSlot < PlayerItemSlotID.TrashItem)
+				return -1;
+
+			if (networkSlot == PlayerItemSlotID.TrashItem)
+				return NetItem.TrashIndex.Item1;
+
+			if (networkSlot < PlayerItemSlotID.Bank3_0)
+				return -1;
+
+			if (networkSlot < PlayerItemSlotID.Bank3_0 + NetItem.ForgeSlots)
+				return NetItem.ForgeIndex.Item1 + (networkSlot - PlayerItemSlotID.Bank3_0);
+
+			if (networkSlot < PlayerItemSlotID.Bank4_0)
+				return -1;
+
+			if (networkSlot < PlayerItemSlotID.Bank4_0 + NetItem.VoidSlots)
+				return NetItem.VoidIndex.Item1 + (networkSlot - PlayerItemSlotID.Bank4_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout1_Armor_0)
+				return -1;
+
+			if (networkSlot < PlayerItemSlotID.Loadout1_Armor_0 + NetItem.LoadoutArmorSlots)
+				return NetItem.Loadout1Armor.Item1 + (networkSlot - PlayerItemSlotID.Loadout1_Armor_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout1_Dye_0 + NetItem.LoadoutDyeSlots)
+				return NetItem.Loadout1Dye.Item1 + (networkSlot - PlayerItemSlotID.Loadout1_Dye_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout2_Armor_0 + NetItem.LoadoutArmorSlots)
+				return NetItem.Loadout2Armor.Item1 + (networkSlot - PlayerItemSlotID.Loadout2_Armor_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout2_Dye_0 + NetItem.LoadoutDyeSlots)
+				return NetItem.Loadout2Dye.Item1 + (networkSlot - PlayerItemSlotID.Loadout2_Dye_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout3_Armor_0 + NetItem.LoadoutArmorSlots)
+				return NetItem.Loadout3Armor.Item1 + (networkSlot - PlayerItemSlotID.Loadout3_Armor_0);
+
+			if (networkSlot < PlayerItemSlotID.Loadout3_Dye_0 + NetItem.LoadoutDyeSlots)
+				return NetItem.Loadout3Dye.Item1 + (networkSlot - PlayerItemSlotID.Loadout3_Dye_0);
+
+			return -1;
 		}
 
 		private static bool HandleConnecting(GetDataHandlerArgs args)

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -714,9 +714,13 @@ namespace TShockAPI
 				}
 			}
 			}
+			catch (Exception ex)
+			{
+				TShock.Log.ConsoleError(GetString($"SSC restore failed for {player.Name}: {ex.Message}"));
+				player.Kick(GetString("SSC restore failed. Please rejoin."));
+			}
 			finally
 			{
-				// Ensure IgnoreSSCPackets is reset even if an exception occurs
 				player.IgnoreSSCPackets = false;
 			}
 		}

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -277,6 +277,8 @@ namespace TShockAPI
 			// Start ignoring SSC-related packets! This is critical so that we don't send or receive dirty data!
 			player.IgnoreSSCPackets = true;
 
+			try
+			{
 			player.TPlayer.statLife = this.health;
 			player.TPlayer.statLifeMax = this.maxHealth;
 			player.TPlayer.statMana = this.maxMana;
@@ -712,6 +714,12 @@ namespace TShockAPI
 					NetManager.Instance.SendToClient(response, player.Index);
 					*/
 				}
+			}
+			}
+			finally
+			{
+				// Ensure IgnoreSSCPackets is reset even if an exception occurs
+				player.IgnoreSSCPackets = false;
 			}
 		}
 	}

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -552,7 +552,7 @@ namespace TShockAPI
 			}
 			for (int k = 0; k < NetItem.DyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, PlayerItemSlotID.Dye0 + k, (float)Main.player[player.Index].dye[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Dye0 + k);
 			}
 			for (int k = 0; k < NetItem.MiscEquipSlots; k++)
 			{

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -541,14 +541,13 @@ namespace TShockAPI
 			NetMessage.SendData((int)PacketTypes.SyncLoadout, remoteClient: player.Index, number: player.Index, number2: player.TPlayer.CurrentLoadoutIndex);
 			NetMessage.SendData((int)PacketTypes.SyncLoadout, ignoreClient: player.Index, number: player.Index, number2: player.TPlayer.CurrentLoadoutIndex);
 
-			// 1.4.5: Use PlayerItemSlotID constants for correct network slot indices
 			for (int k = 0; k < NetItem.InventorySlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, PlayerItemSlotID.Inventory0 + k, (float)Main.player[player.Index].inventory[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Inventory0 + k);
 			}
 			for (int k = 0; k < NetItem.ArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, PlayerItemSlotID.Armor0 + k, (float)Main.player[player.Index].armor[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Armor0 + k);
 			}
 			for (int k = 0; k < NetItem.DyeSlots; k++)
 			{
@@ -556,52 +555,52 @@ namespace TShockAPI
 			}
 			for (int k = 0; k < NetItem.MiscEquipSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, PlayerItemSlotID.Misc0 + k, (float)Main.player[player.Index].miscEquips[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Misc0 + k);
 			}
 			for (int k = 0; k < NetItem.MiscDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, PlayerItemSlotID.MiscDye0 + k, (float)Main.player[player.Index].miscDyes[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.MiscDye0 + k);
 			}
 			for (int k = 0; k < NetItem.PiggySlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, PlayerItemSlotID.Bank1_0 + k, (float)Main.player[player.Index].bank.item[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank1_0 + k);
 			}
 			for (int k = 0; k < NetItem.SafeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, PlayerItemSlotID.Bank2_0 + k, (float)Main.player[player.Index].bank2.item[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank2_0 + k);
 			}
-			NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, PlayerItemSlotID.TrashItem, (float)Main.player[player.Index].trashItem.prefix);
+			NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.TrashItem);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, PlayerItemSlotID.Bank3_0 + k, (float)Main.player[player.Index].bank3.item[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank3_0 + k);
 			}
 			for (int k = 0; k < NetItem.VoidSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, PlayerItemSlotID.Bank4_0 + k, (float)Main.player[player.Index].bank4.item[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank4_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
+				NetMessage.SendData(5, -1, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k);
 			}
 
 
@@ -609,67 +608,66 @@ namespace TShockAPI
 			NetMessage.SendData(42, -1, -1, NetworkText.Empty, player.Index, 0f, 0f, 0f, 0);
 			NetMessage.SendData(16, -1, -1, NetworkText.Empty, player.Index, 0f, 0f, 0f, 0);
 
-			// 1.4.5: Send to this player using PlayerItemSlotID constants
 			for (int k = 0; k < NetItem.InventorySlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, PlayerItemSlotID.Inventory0 + k, (float)Main.player[player.Index].inventory[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Inventory0 + k);
 			}
 			for (int k = 0; k < NetItem.ArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, PlayerItemSlotID.Armor0 + k, (float)Main.player[player.Index].armor[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Armor0 + k);
 			}
 			for (int k = 0; k < NetItem.DyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, PlayerItemSlotID.Dye0 + k, (float)Main.player[player.Index].dye[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Dye0 + k);
 			}
 			for (int k = 0; k < NetItem.MiscEquipSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, PlayerItemSlotID.Misc0 + k, (float)Main.player[player.Index].miscEquips[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Misc0 + k);
 			}
 			for (int k = 0; k < NetItem.MiscDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, PlayerItemSlotID.MiscDye0 + k, (float)Main.player[player.Index].miscDyes[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.MiscDye0 + k);
 			}
 			for (int k = 0; k < NetItem.PiggySlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, PlayerItemSlotID.Bank1_0 + k, (float)Main.player[player.Index].bank.item[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank1_0 + k);
 			}
 			for (int k = 0; k < NetItem.SafeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, PlayerItemSlotID.Bank2_0 + k, (float)Main.player[player.Index].bank2.item[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank2_0 + k);
 			}
-			NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, PlayerItemSlotID.TrashItem, (float)Main.player[player.Index].trashItem.prefix);
+			NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.TrashItem);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, PlayerItemSlotID.Bank3_0 + k, (float)Main.player[player.Index].bank3.item[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank3_0 + k);
 			}
 			for (int k = 0; k < NetItem.VoidSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, PlayerItemSlotID.Bank4_0 + k, (float)Main.player[player.Index].bank4.item[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Bank4_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
+				NetMessage.SendData(5, player.Index, -1, NetworkText.Empty, player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k);
 			}
 
 

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -539,82 +539,67 @@ namespace TShockAPI
 			NetMessage.SendData((int)PacketTypes.SyncLoadout, remoteClient: player.Index, number: player.Index, number2: player.TPlayer.CurrentLoadoutIndex);
 			NetMessage.SendData((int)PacketTypes.SyncLoadout, ignoreClient: player.Index, number: player.Index, number2: player.TPlayer.CurrentLoadoutIndex);
 
-			float slot = 0f;
+			// 1.4.5: Use PlayerItemSlotID constants for correct network slot indices
 			for (int k = 0; k < NetItem.InventorySlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, slot, (float)Main.player[player.Index].inventory[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, PlayerItemSlotID.Inventory0 + k, (float)Main.player[player.Index].inventory[k].prefix);
 			}
 			for (int k = 0; k < NetItem.ArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, slot, (float)Main.player[player.Index].armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, PlayerItemSlotID.Armor0 + k, (float)Main.player[player.Index].armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.DyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, slot, (float)Main.player[player.Index].dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, PlayerItemSlotID.Dye0 + k, (float)Main.player[player.Index].dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.MiscEquipSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, slot, (float)Main.player[player.Index].miscEquips[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, PlayerItemSlotID.Misc0 + k, (float)Main.player[player.Index].miscEquips[k].prefix);
 			}
 			for (int k = 0; k < NetItem.MiscDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, slot, (float)Main.player[player.Index].miscDyes[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, PlayerItemSlotID.MiscDye0 + k, (float)Main.player[player.Index].miscDyes[k].prefix);
 			}
 			for (int k = 0; k < NetItem.PiggySlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, PlayerItemSlotID.Bank1_0 + k, (float)Main.player[player.Index].bank.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.SafeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank2.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, PlayerItemSlotID.Bank2_0 + k, (float)Main.player[player.Index].bank2.item[k].prefix);
 			}
-			NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, slot++, (float)Main.player[player.Index].trashItem.prefix);
+			NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, PlayerItemSlotID.TrashItem, (float)Main.player[player.Index].trashItem.prefix);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank3.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, PlayerItemSlotID.Bank3_0 + k, (float)Main.player[player.Index].bank3.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.VoidSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank4.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, PlayerItemSlotID.Bank4_0 + k, (float)Main.player[player.Index].bank4.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, -1, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
 			}
 
 
@@ -622,82 +607,67 @@ namespace TShockAPI
 			NetMessage.SendData(42, -1, -1, NetworkText.Empty, player.Index, 0f, 0f, 0f, 0);
 			NetMessage.SendData(16, -1, -1, NetworkText.Empty, player.Index, 0f, 0f, 0f, 0);
 
-			slot = 0f;
+			// 1.4.5: Send to this player using PlayerItemSlotID constants
 			for (int k = 0; k < NetItem.InventorySlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, slot, (float)Main.player[player.Index].inventory[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].inventory[k].Name), player.Index, PlayerItemSlotID.Inventory0 + k, (float)Main.player[player.Index].inventory[k].prefix);
 			}
 			for (int k = 0; k < NetItem.ArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, slot, (float)Main.player[player.Index].armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].armor[k].Name), player.Index, PlayerItemSlotID.Armor0 + k, (float)Main.player[player.Index].armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.DyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, slot, (float)Main.player[player.Index].dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].dye[k].Name), player.Index, PlayerItemSlotID.Dye0 + k, (float)Main.player[player.Index].dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.MiscEquipSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, slot, (float)Main.player[player.Index].miscEquips[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscEquips[k].Name), player.Index, PlayerItemSlotID.Misc0 + k, (float)Main.player[player.Index].miscEquips[k].prefix);
 			}
 			for (int k = 0; k < NetItem.MiscDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, slot, (float)Main.player[player.Index].miscDyes[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].miscDyes[k].Name), player.Index, PlayerItemSlotID.MiscDye0 + k, (float)Main.player[player.Index].miscDyes[k].prefix);
 			}
 			for (int k = 0; k < NetItem.PiggySlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank.item[k].Name), player.Index, PlayerItemSlotID.Bank1_0 + k, (float)Main.player[player.Index].bank.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.SafeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank2.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank2.item[k].Name), player.Index, PlayerItemSlotID.Bank2_0 + k, (float)Main.player[player.Index].bank2.item[k].prefix);
 			}
-			NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, slot++, (float)Main.player[player.Index].trashItem.prefix);
+			NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].trashItem.Name), player.Index, PlayerItemSlotID.TrashItem, (float)Main.player[player.Index].trashItem.prefix);
 			for (int k = 0; k < NetItem.ForgeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank3.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank3.item[k].Name), player.Index, PlayerItemSlotID.Bank3_0 + k, (float)Main.player[player.Index].bank3.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.VoidSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, slot, (float)Main.player[player.Index].bank4.item[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].bank4.item[k].Name), player.Index, PlayerItemSlotID.Bank4_0 + k, (float)Main.player[player.Index].bank4.item[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout1_Armor_0 + k, (float)Main.player[player.Index].Loadouts[0].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[0].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout1_Dye_0 + k, (float)Main.player[player.Index].Loadouts[0].Dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout2_Armor_0 + k, (float)Main.player[player.Index].Loadouts[1].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[1].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout2_Dye_0 + k, (float)Main.player[player.Index].Loadouts[1].Dye[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutArmorSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Armor[k].Name), player.Index, PlayerItemSlotID.Loadout3_Armor_0 + k, (float)Main.player[player.Index].Loadouts[2].Armor[k].prefix);
 			}
 			for (int k = 0; k < NetItem.LoadoutDyeSlots; k++)
 			{
-				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Dye[k].Name), player.Index, slot, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
-				slot++;
+				NetMessage.SendData(5, player.Index, -1, NetworkText.FromLiteral(Main.player[player.Index].Loadouts[2].Dye[k].Name), player.Index, PlayerItemSlotID.Loadout3_Dye_0 + k, (float)Main.player[player.Index].Loadouts[2].Dye[k].prefix);
 			}
 
 


### PR DESCRIPTION
ssc mode broken in 1.4.5
`/uploadssc` throwing `IndexOutOfRangeException` in log
ssc failed. Players can join an ssc-enabled server without being reset, but when they click on items in their inventory, those items turn into whatever ssc already has in that slot. Also, the items can't actually be picked up.
etc.

Root Cause:
1.4.5 source code:
<img width="1206" height="814" alt="image" src="https://github.com/user-attachments/assets/13fc1831-aad8-434d-a247-6bc548d91f75" />
1.4.4.9 source code:
<img width="1212" height="754" alt="image" src="https://github.com/user-attachments/assets/c91c6f2c-8f3b-4142-8026-4fbc994a3316" />
They allocate 200 slots per bank instead of 40.

Changes:
Use `PlayerItemSlotID` constants instead of sequential slot counter in `RestoreCharacter`
Add try-finally to ensure `IgnoreSSCPackets` is reset even if exception occurs
Update `HandlePlayerSlot` slot validation to use `PlayerItemSlotID.Count` (990) instead of `NetItem.MaxInventory` (350)
