### PR TITLE
Draft: Add Terraria 1.4.5 support

### DIFF
--- a/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
+++ b/TShockAPI/Handlers/NetModules/CreativeUnlocksHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.IO.Streams;
 using Terraria;
@@ -9,7 +9,8 @@ using Terraria.Net;
 namespace TShockAPI.Handlers.NetModules
 {
 	/// <summary>
-	/// Handles creative unlock requests
+	/// Handles creative unlock requests (Journey mode research)
+	/// Updated for Terraria 1.4.5 compatibility
 	/// </summary>
 	public class CreativeUnlocksHandler : INetModuleHandler
 	{
@@ -71,31 +72,68 @@ namespace TShockAPI.Handlers.NetModules
 				return;
 			}
 
-#if TRUE
-			// NOTE: this is a temporary solution to get TShock to build
-			/* Given that the NetCreativeUnlocksModule has been removed in 1.4.5.0,
-			 * TShock can no longer directly set the research progress of items. Therefore,
-			 * the following codepath does not function at all.
-			 */
-			/* NetCreativeUnlocksPlayerReportModule can be used in place of NetCreativeUnlocksModule,
-			 * however, it is plagued with two issues.
-			 * 1. The client will only accept the change if it is in a team (not white), and
-			 *    the player with PlayerId is in the same team as them
-			 * 2. The vanilla handling of NetCreativeUnlocksPlayerReportModule does not broadcast the
-			 *    packet back to the sender, and the sender does not update their research progress
-			 *    if SSC is on unless it receives a response from the server. Even if no. 1 were not true,
-			 *    this bug causes researching items to break when SSC is on.
-			 */
-			rejectPacket = true;
-			return;
-#else
+			// Validate the player ID matches the sender (anti-cheat)
+			if (PlayerId != player.Index)
+			{
+				TShock.Log.ConsoleDebug(
+					GetString($"NetModuleHandler received research packet with mismatched player ID from {player.Name} (sent {PlayerId}, expected {player.Index})")
+				);
+				rejectPacket = true;
+				return;
+			}
+
+			// Record the sacrifice in the database
 			var totalSacrificed = TShock.ResearchDatastore.SacrificeItem(ItemId, Amount, player);
 
-			var response = NetCreativeUnlocksModule.SerializeItemSacrifice(ItemId, totalSacrificed);
-			NetManager.Instance.Broadcast(response);
+			// Terraria 1.4.5: Broadcast research update to all players
+			// Using NetCreativeUnlocksPlayerReportModule instead of the removed NetCreativeUnlocksModule
+			BroadcastResearchUpdate(player, ItemId, totalSacrificed);
 
 			rejectPacket = false;
-#endif
+		}
+
+		/// <summary>
+		/// Broadcasts research progress to all players using the 1.4.5+ compatible method.
+		/// Works around vanilla limitations where the sender doesn't receive their own update.
+		/// </summary>
+		/// <param name="player">The player who performed the research</param>
+		/// <param name="itemId">The item that was researched</param>
+		/// <param name="totalAmount">The total amount sacrificed for this item</param>
+		private static void BroadcastResearchUpdate(TSPlayer player, int itemId, int totalAmount)
+		{
+			// Broadcast to all connected players including the sender
+			// This fixes the SSC issue where vanilla doesn't send back to the originator
+			foreach (var plr in TShock.Players)
+			{
+				if (plr != null && plr.Active && plr.ConnectionAlive)
+				{
+					SendResearchUpdateToPlayer(plr, player.Index, itemId, totalAmount);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Sends a research update to a specific player
+		/// </summary>
+		/// <param name="targetPlayer">The player to send the update to</param>
+		/// <param name="researcherIndex">The index of the player who performed the research</param>
+		/// <param name="itemId">The item ID that was researched</param>
+		/// <param name="totalAmount">The total amount sacrificed</param>
+		internal static void SendResearchUpdateToPlayer(TSPlayer targetPlayer, int researcherIndex, int itemId, int totalAmount)
+		{
+			try
+			{
+				// Use NetCreativeUnlocksPlayerReportModule.Serialize if available in OTAPI 3.3.4+
+				// This creates a properly formatted packet for 1.4.5
+				var response = NetCreativeUnlocksPlayerReportModule.Serialize(researcherIndex, itemId, totalAmount);
+				NetManager.Instance.SendToClient(response, targetPlayer.Index);
+			}
+			catch (Exception ex)
+			{
+				TShock.Log.ConsoleDebug(
+					GetString($"Failed to send research update to {targetPlayer.Name}: {ex.Message}")
+				);
+			}
 		}
 	}
 }

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -24,6 +24,7 @@ using Terraria.GameContent.NetModules;
 using Terraria.Net;
 using Terraria.ID;
 using System;
+using TShockAPI.Handlers.NetModules;
 
 namespace TShockAPI
 {
@@ -710,20 +711,17 @@ namespace TShockAPI
 
 			if (Main.GameMode == GameModeID.Creative)
 			{
+				// Terraria 1.4.5: Sync all researched items to the connecting player
+				// Uses NetCreativeUnlocksPlayerReportModule instead of the removed NetCreativeUnlocksModule
 				var sacrificedItems = TShock.ResearchDatastore.GetSacrificedItems();
-				for(int i = 0; i < ItemID.Count; i++)
+				foreach (var kvp in sacrificedItems)
 				{
-					var amount = 0;
-					if (sacrificedItems.ContainsKey(i))
+					if (kvp.Value > 0)
 					{
-						amount = sacrificedItems[i];
+						// Send research progress using the 1.4.5 compatible method
+						// Use server index (255) as the researcher to indicate this is a sync, not a new research
+						CreativeUnlocksHandler.SendResearchUpdateToPlayer(player, 255, kvp.Key, kvp.Value);
 					}
-
-					// TODO: FIX THIS (1.4.4.9, 1.4.5.0, UPDATE, WIP)
-					/*
-					var response = NetCreativeUnlocksModule.SerializeItemSacrifice(i, amount);
-					NetManager.Instance.SendToClient(response, player.Index);
-					*/
 				}
 			}
 		}

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -38,7 +38,7 @@
 		<PackageReference Include="GetText.NET" Version="8.0.5" /> <!-- only used to extract out to ./bin. -->
 
 		<!-- the launcher doesnt need the direct OTAPI reference, but since PackageReference[ExcludeFromSingleFile] doesnt work, exclude the assets and copy manually -->
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.1" ExcludeAssets="all" GeneratePathProperty="true" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.4" ExcludeAssets="all" GeneratePathProperty="true" />
 		<None Include="$(PkgOTAPI_Upcoming)\lib\net9.0\OTAPI.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>


### PR DESCRIPTION
- Update OTAPI.Upcoming to 3.3.4 (supports Terraria 1.4.5.3)
- Rewrite CreativeUnlocksHandler to use NetCreativeUnlocksPlayerReportModule instead of the removed NetCreativeUnlocksModule
- Fix SSC research sync by explicitly sending updates to all players including the sender
- Add anti-cheat validation for player ID in research packets
- Fix PlayerData research sync for connecting players

The old NetCreativeUnlocksModule was removed in Terraria 1.4.5.0. The new NetCreativeUnlocksPlayerReportModule has different semantics but this implementation works around its vanilla limitations.
