### PR TITLE
Bump TSAPI + Configurable Chat Message Length

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2906,19 +2906,28 @@ namespace TShockAPI
 			// This was formerly marked as a crash check; does not actually crash on this specific packet.
 			if (playerDeathReason != null)
 			{
-				if (playerDeathReason.GetDeathText(TShock.Players[id].Name).ToString().Length > 500)
-				{
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected bad length death text from {0}", args.Player.Name));
-					TShock.Players[id].Kick(GetString("Death reason outside of normal bounds."), true);
-					args.Handled = true;
-					return;
-				}
 				if (TShock.Config.Settings.DisableCustomDeathMessages && playerDeathReason._sourceCustomReason != null)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected custom death message from {0}", args.Player.Name));
-					args.Handled = true;
+					Reject();
 					return;
 				}
+
+				if (playerDeathReason.GetDeathText(TShock.Players[id].Name).ToString().Length > Math.Clamp(TShock.Config.Settings.MaximumChatMessageLength, 250, 2000))
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected excessive length death text from {0}", args.Player.Name));
+					Reject();
+					return;
+				}
+			}
+
+			// Would be nice to handle all logic, should we move handling of custom death messages and excessive length to GetDataHandlers?
+			void Reject()
+			{
+				args.Player.TPlayer.KillMe(PlayerDeathReason.LegacyDefault(), damage, args.Direction, args.Pvp);
+				args.Player.Dead = true;
+				args.Player.RespawnTimer = TShock.Config.Settings.RespawnSeconds;
+				args.Handled = true;
 			}
 		}
 

--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -479,6 +479,14 @@ namespace TShockAPI.Configuration
 		[Description("Specifies which string starts a command silently.\nNote: Will not function properly if the string length is bigger than 1.")]
 		public string CommandSilentSpecifier = ".";
 
+		/// <summary>The maximum allowed length for chat messages. Valid range: 250 characters to 2000 characters.</summary>
+		[Description("The maximum allowed length for chat messages. Valid range: 250 characters to 2000 characters.")]
+		public int MaximumChatMessageLength = 500;
+
+		/// <summary>If a chat message that exceeds MaximumChatMessageLength should be truncated or rejected.</summary>
+		[Description("If a chat message that exceeds MaximumChatMessageLength should be truncated or rejected.")]
+		public bool TruncateExcessiveChatMessages = false;
+
 		/// <summary>Disables sending logs as messages to players with the log permission.</summary>
 		[Description("Disables sending logs as messages to players with the log permission.")]
 		public bool DisableSpewLogs = true;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1466,7 +1466,7 @@ namespace TShockAPI
 				return;
 			}
 
-			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2000);
 			if (args.Text.Length > maxLength && !Config.Settings.TruncateExcessiveChatMessages)
 			{
 				Log.ConsoleDebug(GetString("TShock / OnChat rejected due to length of {0}/{1} from {2}", args.Text.Length, maxLength, tsplr.Name));
@@ -1636,11 +1636,11 @@ namespace TShockAPI
 		private string TruncateChatMessageIfNecessary(ServerChatEventArgs args)
 		{
 			string chatMsg = args.Text;
-			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2000);
 			if (chatMsg.Length > maxLength)
 			{
 				Log.ConsoleDebug(GetString("TShock / TruncateChatMessageIfNecessary truncating excessive chat message length of {0}/{1} from {2}", args.Text.Length, maxLength, Players[args.Who].Name));
-				chatMsg = chatMsg.Substring(0, Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048)) + "...";
+				chatMsg = chatMsg.Substring(0, maxLength) + "...";
 			}
 			return chatMsg;
 		}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1466,14 +1466,19 @@ namespace TShockAPI
 				return;
 			}
 
-			if (args.Text.Length > 500)
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			if (args.Text.Length > maxLength && !Config.Settings.TruncateExcessiveChatMessages)
 			{
-				tsplr.Kick(GetString("Crash attempt via long chat packet."), true);
+				Log.ConsoleDebug(GetString("TShock / OnChat rejected due to length of {0}/{1} from {2}", args.Text.Length, maxLength, tsplr.Name));
+				tsplr.SendErrorMessage(GetString("Your chat message exceeds the maximum length of {1} characters. ({0}/{1}).", args.Text.Length, maxLength));
 				args.Handled = true;
 				return;
 			}
 
-			string text = args.Text;
+			string text = TruncateChatMessageIfNecessary(args);
+			// We should now use the truncated message instead of the original, we don't want anything to fire off on text that has been "removed"...
+			// Yes, double assignment like this looks bad...
+			var chatText = text;
 
 			// Terraria now has chat commands on the client side.
 			// These commands remove the commands prefix (e.g. /me /playing) and send the command id instead
@@ -1527,10 +1532,10 @@ namespace TShockAPI
 				else if (!TShock.Config.Settings.EnableChatAboveHeads)
 				{
 					text = String.Format(Config.Settings.ChatFormat, tsplr.Group.Name, tsplr.Group.Prefix, tsplr.Name, tsplr.Group.Suffix,
-											 args.Text);
+											 chatText);
 
 					//Invoke the PlayerChat hook. If this hook event is handled then we need to prevent sending the chat message
-					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, args.Text, ref text);
+					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, chatText, ref text);
 					args.Handled = true;
 
 					if (cancelChat)
@@ -1551,7 +1556,7 @@ namespace TShockAPI
 					//Give that poor player their name back :'c
 					ply.name = name;
 
-					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, args.Text, ref text);
+					bool cancelChat = PlayerHooks.OnPlayerChat(tsplr, chatText, ref text);
 					if (cancelChat)
 					{
 						args.Handled = true;
@@ -1621,6 +1626,23 @@ namespace TShockAPI
 				Commands.HandleCommand(TSPlayer.Server, "/" + args.Command);
 			}
 			args.Handled = true;
+		}
+
+		/// <summary>
+		/// Truncates a chat message if it exceeds the <see cref="TShockSettings.MaximumChatMessageLength"/>.
+		/// </summary>
+		/// <param name="args">args - The ServerChatEventArgs object.</param>
+		/// <returns></returns>
+		private string TruncateChatMessageIfNecessary(ServerChatEventArgs args)
+		{
+			string chatMsg = args.Text;
+			var maxLength = Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048);
+			if (chatMsg.Length > maxLength)
+			{
+				Log.ConsoleDebug(GetString("TShock / TruncateChatMessageIfNecessary truncating excessive chat message length of {0}/{1} from {2}", args.Text.Length, maxLength, Players[args.Who].Name));
+				chatMsg = chatMsg.Substring(0, Math.Clamp(Config.Settings.MaximumChatMessageLength, 250, 2048)) + "...";
+			}
+			return chatMsg;
 		}
 
 		/// <summary>OnGetData - Called when the server gets raw data packets.</summary>


### PR DESCRIPTION
This PR removes the fixed 500 character limit on chat messages and instead uses a config option. Also bumps TSAPI.
Changelog:
- Removed fixed 500 character chat message length. Servers can now configure it.
- Added ``TruncateExcessiveChatMessages``, which will truncate a message which exceeds the ``MaximumChatMessageLength`` instead of rejecting it outright.