### PR TITLE
Improvements to TSPlayer.Teleport, more coordinate utiils, Spawn command respects team-based spawn seed

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -585,10 +585,7 @@ namespace TShockAPI
 							args.Player.SendErrorMessage(GetString("You need to rejoin to ensure your trash can is cleared!"));
 						}
 
-						// ??
-						var lastTileX = args.Player.LastNetPosition.X;
-						var lastTileY = args.Player.LastNetPosition.Y - 48;
-						if (!args.Player.Teleport(lastTileX, lastTileY))
+						if (!args.Player.Teleport(args.Player.LastNetPosition))
 						{
 							args.Player.Spawn(PlayerSpawnContext.RecallFromItem);
 						}

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -3011,7 +3011,7 @@ namespace TShockAPI
 
 		private static void Spawn(CommandArgs args)
 		{
-			if (args.Player.Teleport(Main.spawnTileX * 16, (Main.spawnTileY * 16) - 48))
+			if (args.Player.TeleportToWorldSpawn())
 				args.Player.SendSuccessMessage(GetString("Teleported to the map's spawn point."));
 		}
 
@@ -3041,7 +3041,7 @@ namespace TShockAPI
 						args.Player.SendErrorMessage(GetString("{0} has disabled incoming teleports.", target.Name));
 						return;
 					}
-					if (args.Player.Teleport(target.TPlayer.position.X, target.TPlayer.position.Y))
+					if (args.Player.Teleport(target.TPlayer.Bottom, true))
 					{
 						args.Player.SendSuccessMessage(GetString("Teleported to {0}.", target.Name));
 						if (!args.Player.HasPermission(Permissions.tpsilent))
@@ -3079,7 +3079,7 @@ namespace TShockAPI
 						{
 							if (!target.TPAllow && !args.Player.HasPermission(Permissions.tpoverride))
 								continue;
-							if (source.Teleport(target.TPlayer.position.X, target.TPlayer.position.Y))
+							if (source.Teleport(target.TPlayer.Bottom, true))
 							{
 								if (args.Player != source)
 								{
@@ -3119,7 +3119,7 @@ namespace TShockAPI
 						return;
 					}
 					args.Player.SendSuccessMessage(GetString("Teleported {0} to {1}.", source.Name, target.Name));
-					if (source.Teleport(target.TPlayer.position.X, target.TPlayer.position.Y))
+					if (source.Teleport(target.TPlayer.Bottom, true))
 					{
 						if (args.Player != source)
 						{
@@ -3166,7 +3166,7 @@ namespace TShockAPI
 					{
 						if (player != null && player.Active && player.Index != args.Player.Index)
 						{
-							if (player.Teleport(args.TPlayer.position.X, args.TPlayer.position.Y))
+							if (player.Teleport(args.Player.TPlayer.Bottom, true))
 								player.SendSuccessMessage(GetString("You were teleported to {0}.", args.Player.Name));
 						}
 					}
@@ -3180,7 +3180,7 @@ namespace TShockAPI
 			else
 			{
 				var plr = players[0];
-				if (plr.Teleport(args.TPlayer.position.X, args.TPlayer.position.Y))
+				if (plr.Teleport(args.Player.TPlayer.Bottom, true))
 				{
 					plr.SendInfoMessage(GetString("You were teleported to {0}.", args.Player.Name));
 					args.Player.SendSuccessMessage(GetString("Teleported {0} to yourself.", plr.Name));
@@ -3225,7 +3225,7 @@ namespace TShockAPI
 			}
 
 			var target = matches[0];
-			args.Player.Teleport(target.position.X, target.position.Y);
+			args.Player.Teleport(target.Bottom, true);
 			args.Player.SendSuccessMessage(GetString("Teleported to the '{0}'.", target.FullName));
 		}
 
@@ -3333,7 +3333,8 @@ namespace TShockAPI
 					{
 						args.Player.SendErrorMessage(GetString("Invalid warp name. The names 'list', 'hide', 'del' and 'add' are reserved for commands."));
 					}
-					else if (TShock.Warps.Add(args.Player.TileX, args.Player.TileY, warpName))
+					// For compatibility, warps are technically floating, so we have to add it at the player's Y position without any mount influence.
+					else if (TShock.Warps.Add(args.Player.CenterTileX, args.Player.UnmountedTileY, warpName))
 					{
 						args.Player.SendSuccessMessage(GetString($"Warp added: {warpName}."));
 					}
@@ -3415,7 +3416,8 @@ namespace TShockAPI
 				var plr = foundplr[0];
 				if (warp != null)
 				{
-					if (plr.Teleport(warp.Position.X * 16, warp.Position.Y * 16))
+					// For compatibility, warps are technically floating, so we have to move the target position down by 3 blocks.
+					if (plr.Teleport(new Point(warp.Position.X, warp.Position.Y + 3), true))
 					{
 						plr.SendSuccessMessage(GetString("{0} warped you to {1}.", args.Player.Name, warpName));
 						args.Player.SendSuccessMessage(GetString("You warped {0} to {1}.", plr.Name, warpName));
@@ -3433,7 +3435,8 @@ namespace TShockAPI
 				var warp = TShock.Warps.Find(warpName);
 				if (warp != null)
 				{
-					if (args.Player.Teleport(warp.Position.X * 16, warp.Position.Y * 16))
+					// For compatibility, warps are technically floating, so we have to move the target position down by 3 blocks.
+					if (args.Player.Teleport(new Point(warp.Position.X, warp.Position.Y + 3), true))
 						args.Player.SendSuccessMessage(GetString($"Warped to {warpName}."));
 				}
 				else
@@ -5261,7 +5264,7 @@ namespace TShockAPI
 							break;
 						}
 
-						args.Player.Teleport(region.Area.Center.X * 16, region.Area.Center.Y * 16);
+						args.Player.TeleportCentered(region.Area.Center.ToWorldCoordinates());
 						break;
 					}
 				case "help":

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4053,7 +4053,7 @@ namespace TShockAPI
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleTeleport rejected rod type {0} {1}", args.Player.Name, type));
 				args.Player.SendErrorMessage(GetString("You do not have permission to teleport using items.")); // Was going to write using RoD but Hook of Disonnance and Potion of Return both use the same teleport packet as RoD.
-				args.Player.Teleport(args.TPlayer.position.X, args.TPlayer.position.Y); // Suggest renaming rod permission unless someone plans to add separate perms for the other 2 tp items.
+				args.Player.Teleport(args.Player.TPlayer.position); // Suggest renaming rod permission unless someone plans to add separate perms for the other 2 tp items.
 				return true;
 			}
 
@@ -4077,7 +4077,7 @@ namespace TShockAPI
 				{
 					TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleTeleport rejected p2p wormhole permission {0} {1}", args.Player.Name, type));
 					args.Player.SendErrorMessage(GetString("You do not have permission to teleport using Wormhole Potions."));
-					args.Player.Teleport(args.TPlayer.position.X, args.TPlayer.position.Y);
+					args.Player.Teleport(args.Player.TPlayer.position);
 					return true;
 				}
 			}

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1246,7 +1246,7 @@ namespace TShockAPI
 		public bool Hostile => TPlayer.hostile;
 
 		/// <summary>
-		/// Gets the player's X coordinate.
+		/// Gets the player's X coordinate. May be influenced by mounts.
 		/// </summary>
 		public float X
 		{
@@ -1254,7 +1254,39 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Gets the player's Y coordinate.
+		/// Gets the player's X coordinate without mount influence.
+		/// </summary>
+		public float UnmountedX
+		{
+			get { return RealPlayer ? TPlayer.Center.X - 10 : Main.spawnTileX * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's centered X coordinate. Not influenced by mounts.
+		/// </summary>
+		public float CenterX
+		{
+			get { return RealPlayer ? TPlayer.Center.X : Main.spawnTileX * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's right X coordinate. May be influenced by mounts.
+		/// </summary>
+		public float RightX
+		{
+			get { return RealPlayer ? TPlayer.Right.X : Main.spawnTileX * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's right X coordinate without mount influence.
+		/// </summary>
+		public float UnmountedRightX
+		{
+			get { return RealPlayer ? TPlayer.Center.X + 10 : Main.spawnTileX * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's Y coordinate. May be influenced by mounts.
 		/// </summary>
 		public float Y
 		{
@@ -1262,7 +1294,39 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Player X coordinate divided by 16. Supposed X world coordinate.
+		/// Gets the player's Y coordinate without mount influence.
+		/// </summary>
+		public float UnmountedY
+		{
+			get { return RealPlayer ? TPlayer.Bottom.Y - 42 : Main.spawnTileY * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's centered Y coordinate. May be influenced by mounts.
+		/// </summary>
+		public float CenterY
+		{
+			get { return RealPlayer ? TPlayer.Center.Y : Main.spawnTileY * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's centered Y coordinate without mount influence.
+		/// </summary>
+		public float UnmountedCenterY
+		{
+			get { return RealPlayer ? TPlayer.Bottom.Y - 24 : Main.spawnTileY * 16; }
+		}
+
+		/// <summary>
+		/// Gets the player's bottom Y coordinate. Not influenced by mounts.
+		/// </summary>
+		public float BottomY
+		{
+			get { return RealPlayer ? TPlayer.Bottom.Y : Main.spawnTileY * 16; }
+		}
+
+		/// <summary>
+		/// Player X coordinate divided by 16. Supposed X world coordinate. May be influenced by mounts.
 		/// </summary>
 		public int TileX
 		{
@@ -1270,11 +1334,75 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Player Y coordinate divided by 16. Supposed Y world coordinate.
+		/// Player X coordinate divided by 16. Supposed X world coordinate without mount influence.
+		/// </summary>
+		public int UnmountedTileX
+		{
+			get { return (int)(UnmountedX / 16); }
+		}
+
+		/// <summary>
+		/// Player center X coordinate divided by 16. Supposed X world coordinate. 
+		/// </summary>
+		public int CenterTileX
+		{
+			get { return (int)(CenterX / 16); }
+		}
+
+		/// <summary>
+		/// Player right X coordinate divided by 16. Supposed X world coordinate. May be influenced by mounts.
+		/// </summary>
+		public int RightTileX
+		{
+			get { return (int)(RightX / 16); }
+		}
+
+		/// <summary>
+		/// Player right X coordinate divided by 16. Supposed X world coordinate without mount influence.
+		/// </summary>
+		public int UnmountedRightTileX
+		{
+			get { return (int)(UnmountedRightX / 16); }
+		}
+
+		/// <summary>
+		/// Player Y coordinate divided by 16. Supposed Y world coordinate. May be influenced by mounts.
 		/// </summary>
 		public int TileY
 		{
 			get { return (int)(Y / 16); }
+		}
+
+		/// <summary>
+		/// Player Y coordinate divided by 16. Supposed Y world coordinate without mount influence.
+		/// </summary>
+		public int UnmountedTileY
+		{
+			get { return (int)(UnmountedY / 16); }
+		}
+
+		/// <summary>
+		/// Player center Y coordinate divided by 16. Supposed Y world coordinate. May be influenced by mounts.
+		/// </summary>
+		public int CenterTileY
+		{
+			get { return (int)(CenterY / 16); }
+		}
+
+		/// <summary>
+		/// Player center Y coordinate divided by 16. Supposed Y world coordinate without mount influence.
+		/// </summary>
+		public int UnmountedCenterTileY
+		{
+			get { return (int)(UnmountedCenterY / 16); }
+		}
+
+		/// <summary>
+		/// Player bottom Y coordinate divided by 16. Supposed Y world coordinate. Not influenced by mounts.
+		/// </summary>
+		public int BottomTileY
+		{
+			get { return (int)(BottomY / 16); }
 		}
 
 		/// <summary>
@@ -1445,6 +1573,50 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Teleports the player to the given position in the world.
+		/// </summary>
+		/// <param name="tilePos">The tile position to teleport to.</param>
+		/// <param name="style">The teleportation style.</param>
+		/// <param name="useBottom">If the bottom of the player should be modified instead.</param>
+		/// <returns>True or false.</returns>
+		public bool Teleport(Point tilePos, bool useBottom = false, byte style = 1)
+		{
+			// If we want to teleport the player via their bottom position, we set their bottom then get their position from that.
+			if (useBottom)
+				TPlayer.Bottom = tilePos.ToWorldCoordinates(8, 0);
+
+			return Teleport(X, Y, style);
+		}
+
+		/// <summary>
+		/// Teleports the player to the given position in the world.
+		/// </summary>
+		/// <param name="pos">The position to teleport to.</param>
+		/// <param name="style">The teleportation style.</param>
+		/// <param name="useBottom">If the bottom of the player should be modified instead.</param>
+		/// <returns>True or false.</returns>
+		public bool Teleport(Vector2 pos, bool useBottom = false, byte style = 1)
+		{
+			// If we want to teleport the player via their bottom position, we set their bottom then get their position from that.
+			if (useBottom)
+				TPlayer.Bottom = pos;
+
+			return Teleport(X, Y, style);
+		}
+
+		/// <summary>
+		/// Teleports the player to the given position in the world, centered
+		/// </summary>
+		/// <param name="pos">The position to teleport to.</param>
+		/// <param name="style">The teleportation style.</param>
+		/// <returns>True or false.</returns>
+		public bool TeleportCentered(Vector2 pos, byte style = 1)
+		{
+			TPlayer.Center = pos;
+			return Teleport(X, Y, style);
+		}
+
+		/// <summary>
 		/// Teleports the player to the given coordinates in the world.
 		/// </summary>
 		/// <param name="x">The X coordinate.</param>
@@ -1453,24 +1625,16 @@ namespace TShockAPI
 		/// <returns>True or false.</returns>
 		public bool Teleport(float x, float y, byte style = 1)
 		{
-			if (x > Main.rightWorld - 992)
-			{
-				x = Main.rightWorld - 992;
-			}
-			if (x < 992)
-			{
-				x = 992;
-			}
-			if (y > Main.bottomWorld - 992)
-			{
-				y = Main.bottomWorld - 992;
-			}
-			if (y < 992)
-			{
-				y = 992;
-			}
+			x = Math.Clamp(x,
+				640,
+				Main.rightWorld - 640 - TPlayer.width);
+
+			y = Math.Clamp(y,
+				640,
+				Main.bottomWorld - 640 - TPlayer.height);
 
 			SendTileSquareCentered((int)(x / 16), (int)(y / 16), 15);
+			RemoteClient.CheckSection(Index, new Vector2(x, y));
 			TPlayer.Teleport(new Vector2(x, y), style);
 			NetMessage.SendData((int)PacketTypes.Teleport, -1, -1, NetworkText.Empty, 0, TPlayer.whoAmI, x, y, style);
 			return true;
@@ -1500,7 +1664,22 @@ namespace TShockAPI
 					y = Main.spawnTileY;
 				}
 			}
-			return Teleport(x * 16, y * 16 - 48);
+			return Teleport(new Point(x, y), true);
+		}
+
+		/// <summary>
+		/// Teleports the player to the world spawn point, or the respective team-bsed spawnpoint if the world uses them.
+		/// </summary>
+		/// /// <param name="ignoreTeamBasedSpawns">If team-based spawnpoints should be ignored.</param>
+		/// <returns>True or false.</returns>
+		public bool TeleportToWorldSpawn(bool ignoreTeamBasedSpawns = false)
+		{
+			Point p = new Point(Main.spawnTileX, Main.spawnTileY);
+			if (!ignoreTeamBasedSpawns &&
+				Main.teamBasedSpawnsSeed && ExtraSpawnPointManager.TryGetExtraSpawnPointForTeam(Team, out var spawnPoint))
+				p = spawnPoint;
+			
+			return Teleport(p, true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- Most uses of ``TSPlayer.Teleport`` are now aligned to the player's bottom position, working around mounts changing player size
- ``TSPlayer.Teleport`` now uses ``RemoteClient.CheckSection`` when teleporting player to hopefully prevent cases where a player falls through blocks due to tiles not being loaded (because ``SendTileSquareCentered`` wasn't enough, apparantly)
- New overloads for ``TSPlayer.Teleport`` that take tile coordinates (Point) or world coordinates (Vector2), and can specify teleporting the player via their bottom position
- New position properties for TSPlayer, with some specifically working around mounts
- Spawn command now supports team-based spawns seed, added ``TeleportToWorldSpawn`` method to only teleport player to proper spawn point
- Adding a warp no longer places it incorrectly when using mounts that affect the player's hitbox size
- Teleporting to a region now teleports the player via their center position