### PR TITLE
Packet hot-path optimizations and deterministic projectile cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ Thumbs.db
 *.user
 .vs/*
 
+# VS Code (keep shared debug/task configs tracked) #
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
+
 #Template Bat file#
 ###################
 postbuild.bat

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3057,7 +3057,7 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			var threshold = DateTime.Now.AddSeconds(-5);
+			var threshold = DateTime.UtcNow.AddSeconds(-5);
 			foreach (var player in TShock.Players)
 			{
 				if (player != null && player.TPlayer.whoAmI >= 0)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3056,20 +3056,17 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			Task.Run(() =>
+			var threshold = DateTime.Now.AddSeconds(-5);
+			foreach (var player in TShock.Players)
 			{
-				foreach (var player in TShock.Players)
+				if (player != null && player.TPlayer.whoAmI >= 0)
 				{
-					if (player != null && player.TPlayer.whoAmI >= 0)
+					lock (player.RecentlyCreatedProjectiles)
 					{
-						var threshold = DateTime.Now.AddSeconds(-5);
-						lock (player.RecentlyCreatedProjectiles)
-						{
-							player.RecentlyCreatedProjectiles = player.RecentlyCreatedProjectiles.Where(s => s.CreatedAt > threshold).ToList();
-						}
+						player.RecentlyCreatedProjectiles.RemoveAll(s => s.CreatedAt <= threshold);
 					}
 				}
-			});
+			}
 		}
 
 		/// <summary>

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3188,7 +3188,7 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			var threshold = DateTime.UtcNow.AddSeconds(-5);
+				var threshold = DateTime.UtcNow.AddSeconds(-5);
 			foreach (var player in TShock.Players)
 			{
 				if (player != null && player.TPlayer.whoAmI >= 0)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -553,60 +553,62 @@ namespace TShockAPI
 				return;
 			}
 
-			if (!pos.Equals(args.Player.LastNetPosition))
-			{
-				float distance = Vector2.Distance(new Vector2(pos.X / 16f, pos.Y / 16f),
-					new Vector2(args.Player.LastNetPosition.X / 16f, args.Player.LastNetPosition.Y / 16f));
-
-				if (args.Player.IsBeingDisabled())
+				if (!pos.Equals(args.Player.LastNetPosition))
 				{
-					// If the player has moved outside the disabled zone...
-					if (distance > TShock.Config.Settings.MaxRangeForDisabled)
+					if (args.Player.IsBeingDisabled())
 					{
-						// We need to tell them they were disabled and why, then revert the change.
-						if (args.Player.IsDisabledForStackDetection)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You went too far with hacked item stacks."));
-						}
-						else if (args.Player.IsDisabledForBannedWearable)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You went too far with banned armor."));
-						}
-						else if (args.Player.IsDisabledForSSC)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You need to {0}login to load your saved data.", TShock.Config.Settings.CommandSpecifier));
-						}
-						else if (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn)
-						{
-							args.Player.SendErrorMessage(GetString("Account needed! Please {0}register or {0}login to play!", TShock.Config.Settings.CommandSpecifier));
-						}
-						else if (args.Player.IsDisabledPendingTrashRemoval)
-						{
-							args.Player.SendErrorMessage(GetString("You need to rejoin to ensure your trash can is cleared!"));
-						}
+						var maxRange = TShock.Config.Settings.MaxRangeForDisabled;
+						var maxRangeSquared = maxRange * maxRange;
+						var dx = (pos.X - args.Player.LastNetPosition.X) / 16f;
+						var dy = (pos.Y - args.Player.LastNetPosition.Y) / 16f;
 
-						// ??
-						if (!args.Player.Teleport(args.Player.LastNetPosition))
+						// If the player has moved outside the disabled zone...
+						if ((dx * dx) + (dy * dy) > maxRangeSquared)
 						{
-							args.Player.Spawn(PlayerSpawnContext.RecallFromItem);
+							// We need to tell them they were disabled and why, then revert the change.
+							if (args.Player.IsDisabledForStackDetection)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You went too far with hacked item stacks."));
+							}
+							else if (args.Player.IsDisabledForBannedWearable)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You went too far with banned armor."));
+							}
+							else if (args.Player.IsDisabledForSSC)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You need to {0}login to load your saved data.", TShock.Config.Settings.CommandSpecifier));
+							}
+							else if (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn)
+							{
+								args.Player.SendErrorMessage(GetString("Account needed! Please {0}register or {0}login to play!", TShock.Config.Settings.CommandSpecifier));
+							}
+							else if (args.Player.IsDisabledPendingTrashRemoval)
+							{
+								args.Player.SendErrorMessage(GetString("You need to rejoin to ensure your trash can is cleared!"));
+							}
+
+							// ??
+							if (!args.Player.Teleport(args.Player.LastNetPosition))
+							{
+								args.Player.Spawn(PlayerSpawnContext.RecallFromItem);
+							}
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (??) {0}", args.Player.Name));
+							args.Handled = true;
+							return;
 						}
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (??) {0}", args.Player.Name));
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (below ??) {0}", args.Player.Name));
 						args.Handled = true;
 						return;
 					}
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (below ??) {0}", args.Player.Name));
-					args.Handled = true;
-					return;
-				}
 
-				// Corpses don't move, but ghost
-				if (args.Player.Dead && !args.Player.TPlayer.ghost)
-				{
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
-					args.Handled = true;
-					return;
+					// Corpses don't move, but ghost
+					if (args.Player.Dead && !args.Player.TPlayer.ghost)
+					{
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
+						args.Handled = true;
+						return;
+					}
 				}
-			}
 
 			args.Player.LastNetPosition = pos;
 			return;
@@ -804,14 +806,37 @@ namespace TShockAPI
 					// Handle placement if the user is placing rope that comes from a ropecoil,
 					// but have not created the ropecoil projectile recently or the projectile was not at the correct coordinate, or the tile that the projectile places does not match the rope it is suposed to place
 					// projectile should be the same X coordinate as all tile places (Note by @Olink)
-					if (ropeCoilPlacements.ContainsKey(selectedItem.type) &&
-						!args.Player.RecentlyCreatedProjectiles.Any(p => GetDataHandlers.projectileCreatesTile.ContainsKey(p.Type) && GetDataHandlers.projectileCreatesTile[p.Type] == editData &&
-						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)))
+					if (ropeCoilPlacements.ContainsKey(selectedItem.type))
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
-						args.Player.SendTileSquareCentered(tileX, tileY, 1);
-						args.Handled = true;
-						return;
+						bool hasMatchingRopeProjectile = false;
+						lock (args.Player.RecentlyCreatedProjectiles)
+						{
+							for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+							{
+								var tracked = args.Player.RecentlyCreatedProjectiles[i];
+								if (tracked.Killed)
+									continue;
+								if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+									continue;
+								if (!GetDataHandlers.projectileCreatesTile.TryGetValue(tracked.Type, out var createdTile) || createdTile != editData)
+									continue;
+
+								var projectile = Main.projectile[tracked.Index];
+								if (Math.Abs((int)(projectile.position.X / 16f) - tileX) <= Math.Abs(projectile.velocity.X))
+								{
+									hasMatchingRopeProjectile = true;
+									break;
+								}
+							}
+						}
+
+						if (!hasMatchingRopeProjectile)
+						{
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
+							args.Player.SendTileSquareCentered(tileX, tileY, 1);
+							args.Handled = true;
+							return;
+						}
 					}
 				}
 				else if (action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall)
@@ -860,31 +885,45 @@ namespace TShockAPI
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
 						args.Handled = true;
 					}
-					// If they aren't selecting the item which creates the tile, they're hacking.
-					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
-					{
-						// These would get caught up in the below check because Terraria does not set their createTile field.
-						if (selectedItem.type != ItemID.IceRod &&
-						    selectedItem.type != ItemID.DirtBomb &&
-						    selectedItem.type != ItemID.StickyBomb &&
-						    selectedItem.type != ItemID.MudBallPlayer &&
-						    selectedItem.type != ItemID.AcornAxe &&
-						    selectedItem.type != ItemID.StaffofRegrowth &&
-						    !(args.Player.RecentlyCreatedProjectiles.Any(x =>
-							      x.Type == ProjectileID.AcornSlingshotAcorn) &&
-						      editData == TileID.Saplings) &&
-						    !(args.Player.TPlayer.mount.Type == MountID.DiggingMoleMinecart &&
-						      editData == TileID.MinecartTrack)
-						   )
+						// If they aren't selecting the item which creates the tile, they're hacking.
+						if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
 						{
-							TShock.Log.ConsoleDebug(GetString(
-								"Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}",
-								args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
-							args.Player.SendTileSquareCentered(tileX, tileY, 4);
-							args.Handled = true;
-							return;
+							bool hasRecentAcornProjectile = false;
+							if (editData == TileID.Saplings)
+							{
+								lock (args.Player.RecentlyCreatedProjectiles)
+								{
+									for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+									{
+										if (args.Player.RecentlyCreatedProjectiles[i].Type == ProjectileID.AcornSlingshotAcorn)
+										{
+											hasRecentAcornProjectile = true;
+											break;
+										}
+									}
+								}
+							}
+
+							// These would get caught up in the below check because Terraria does not set their createTile field.
+							if (selectedItem.type != ItemID.IceRod &&
+							    selectedItem.type != ItemID.DirtBomb &&
+							    selectedItem.type != ItemID.StickyBomb &&
+							    selectedItem.type != ItemID.MudBallPlayer &&
+							    selectedItem.type != ItemID.AcornAxe &&
+							    selectedItem.type != ItemID.StaffofRegrowth &&
+							    !(hasRecentAcornProjectile && editData == TileID.Saplings) &&
+							    !(args.Player.TPlayer.mount.Type == MountID.DiggingMoleMinecart &&
+							      editData == TileID.MinecartTrack)
+							   )
+							{
+								TShock.Log.ConsoleDebug(GetString(
+									"Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}",
+									args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
+								args.Player.SendTileSquareCentered(tileX, tileY, 4);
+								args.Handled = true;
+								return;
+							}
 						}
-					}
 					// If they aren't selecting the item which creates the wall, they're hacking.
 					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
 					{
@@ -1343,14 +1382,27 @@ namespace TShockAPI
 				return;
 			}
 
-			/// If the created projectile is a golf ball and the player is not holding a golf club item and neither a golf ball item and neither they have had a golf club projectile created recently.
-			if (Handlers.LandGolfBallInCupHandler.GolfBallProjectileIDs.Contains(type) &&
-				!Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
-				!Handlers.LandGolfBallInCupHandler.GolfBallItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
-				!args.Player.RecentlyCreatedProjectiles.Any(p => p.Type == ProjectileID.GolfClubHelper))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1} (golf)", args.Player.Name, type));
-			}
+				/// If the created projectile is a golf ball and the player is not holding a golf club item and neither a golf ball item and neither they have had a golf club projectile created recently.
+				bool hasRecentGolfClubProjectile = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
+				{
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						if (args.Player.RecentlyCreatedProjectiles[i].Type == ProjectileID.GolfClubHelper)
+						{
+							hasRecentGolfClubProjectile = true;
+							break;
+						}
+					}
+				}
+
+				if (Handlers.LandGolfBallInCupHandler.GolfBallProjectileIDs.Contains(type) &&
+					!Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+					!Handlers.LandGolfBallInCupHandler.GolfBallItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+					!hasRecentGolfClubProjectile)
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1} (golf)", args.Player.Name, type));
+				}
 
 			// Main.projHostile contains projectiles that can harm players
 			// without PvP enabled and belong to enemy mobs, so they shouldn't be
@@ -1390,18 +1442,43 @@ namespace TShockAPI
 			        return;
 			    }
 
-			    // Validate we found an active bolt projectile
-			    var boltProjectileData = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].type == ProjectileID.PortalGunBolt);
-			    if (boltProjectileData.Type == 0 || boltProjectileData.Killed)
-			    {
-				    TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));
-			        args.Player.RemoveProjectile(ident, owner);
-			        args.Handled = true;
-			        return;
-			    }
+					// Validate we found an active bolt projectile.
+					int boltProjectileDataIndex = -1;
+					lock (args.Player.RecentlyCreatedProjectiles)
+					{
+						for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+						{
+							var tracked = args.Player.RecentlyCreatedProjectiles[i];
+							if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+								continue;
+							if (tracked.Killed)
+								continue;
+							if (Main.projectile[tracked.Index].type != ProjectileID.PortalGunBolt)
+								continue;
 
-			    boltProjectileData.Killed = true;
-			}
+							boltProjectileDataIndex = i;
+							break;
+						}
+					}
+
+					if (boltProjectileDataIndex < 0)
+					{
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));
+						args.Player.RemoveProjectile(ident, owner);
+						args.Handled = true;
+						return;
+					}
+
+					lock (args.Player.RecentlyCreatedProjectiles)
+					{
+						if (boltProjectileDataIndex >= 0 && boltProjectileDataIndex < args.Player.RecentlyCreatedProjectiles.Count)
+						{
+							var tracked = args.Player.RecentlyCreatedProjectiles[boltProjectileDataIndex];
+							tracked.Killed = true;
+							args.Player.RecentlyCreatedProjectiles[boltProjectileDataIndex] = tracked;
+						}
+					}
+				}
 
 			if (!TShock.Config.Settings.IgnoreProjUpdate && !args.Player.HasPermission(Permissions.ignoreprojectiledetection))
 			{
@@ -1853,23 +1930,29 @@ namespace TShockAPI
 				args.Player.TileLiquidThreshold++;
 			}
 
-			bool wasThereABombNearby = false;
-			lock (args.Player.RecentlyCreatedProjectiles)
-			{
-				IEnumerable<int> projectileTypesThatPerformThisOperation;
-				if (amount > 0) //handle the projectiles that create fluid.
+				bool wasThereABombNearby = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
 				{
-					projectileTypesThatPerformThisOperation = projectileCreatesLiquid.Where(k => k.Value == type).Select(k => k.Key);
-				}
-				else //handle the scenario where we are removing liquid
-				{
-					projectileTypesThatPerformThisOperation = projectileCreatesLiquid.Where(k => k.Value == LiquidType.Removal).Select(k => k.Key);
-				}
+					var expectedLiquidOperation = amount > 0 ? type : LiquidType.Removal;
+					var bombRadius = TShock.Config.Settings.BombExplosionRadius;
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						var tracked = args.Player.RecentlyCreatedProjectiles[i];
+						if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+							continue;
 
-				var recentBombs = args.Player.RecentlyCreatedProjectiles.Where(p => projectileTypesThatPerformThisOperation.Contains(Main.projectile[p.Index].type));
-				wasThereABombNearby = recentBombs.Any(r => Math.Abs(args.TileX - (Main.projectile[r.Index].position.X / 16.0f)) < TShock.Config.Settings.BombExplosionRadius
-														&& Math.Abs(args.TileY - (Main.projectile[r.Index].position.Y / 16.0f)) < TShock.Config.Settings.BombExplosionRadius);
-			}
+						var projectileInstance = Main.projectile[tracked.Index];
+						if (!projectileCreatesLiquid.TryGetValue(projectileInstance.type, out var operation) || operation != expectedLiquidOperation)
+							continue;
+
+						if (Math.Abs(args.TileX - (projectileInstance.position.X / 16.0f)) < bombRadius
+							&& Math.Abs(args.TileY - (projectileInstance.position.Y / 16.0f)) < bombRadius)
+						{
+							wasThereABombNearby = true;
+							break;
+						}
+					}
+				}
 
 			// Liquid anti-cheat
 			// Arguably the banned buckets bit should be in the item bans system
@@ -2325,17 +2408,25 @@ namespace TShockAPI
 				{
 					bool areAnyBunnyProjectilesInRange;
 
-					lock (args.Player.RecentlyCreatedProjectiles)
-					{
-						areAnyBunnyProjectilesInRange = args.Player.RecentlyCreatedProjectiles.Any(projectile =>
+						lock (args.Player.RecentlyCreatedProjectiles)
 						{
-							if (projectile.Type != ProjectileID.ExplosiveBunny)
-								return false;
+							areAnyBunnyProjectilesInRange = false;
+							for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+							{
+								var projectile = args.Player.RecentlyCreatedProjectiles[i];
+								if (projectile.Type != ProjectileID.ExplosiveBunny)
+									continue;
+								if (projectile.Index < 0 || projectile.Index >= Main.projectile.Length)
+									continue;
 
-							var projectileInstance = Main.projectile[projectile.Index];
-							return projectileInstance.active && projectileInstance.WithinRange(new Vector2(args.X, args.Y), 32.0f);
-						});
-					}
+								var projectileInstance = Main.projectile[projectile.Index];
+								if (projectileInstance.active && projectileInstance.WithinRange(new Vector2(args.X, args.Y), 32.0f))
+								{
+									areAnyBunnyProjectilesInRange = true;
+									break;
+								}
+							}
+						}
 
 					if (!areAnyBunnyProjectilesInRange)
 					{
@@ -2931,31 +3022,49 @@ namespace TShockAPI
 			}
 		}
 
-		/// <summary>
-		/// Called when the player fishes out an NPC.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="args"></param>
-		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
-		{
-			/// Getting recent projectiles of the player and selecting the first that is a bobber.
-			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].bobber);
+			/// <summary>
+			/// Called when the player fishes out an NPC.
+			/// </summary>
+			/// <param name="sender"></param>
+			/// <param name="args"></param>
+			internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
+			{
+				// Find a recent bobber projectile for fish-out validation.
+				GetDataHandlers.ProjectileStruct projectile = default;
+				bool hasRecentBobber = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
+				{
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						var tracked = args.Player.RecentlyCreatedProjectiles[i];
+						if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+							continue;
+						if (!Main.projectile[tracked.Index].bobber)
+							continue;
 
-			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not using a fishing rod! - From {0}", args.Player.Name));
-				args.Handled = true;
-				return;
-			}
-			if (projectile.Type == 0 || projectile.Killed) /// The bobber projectile is never killed when the NPC spawns. Type can only be 0 if no recent projectile is found that is named Bobber.
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not finding active bobber projectile! - From {0}", args.Player.Name));
-				args.Handled = true;
-				return;
-			}
-			if (!FishableNpcIDs.Contains(args.NpcID))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for the NPC not being on the fishable NPCs list! - From {0}", args.Player.Name));
+						projectile = tracked;
+						hasRecentBobber = true;
+						break;
+					}
+				}
+
+				if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not using a fishing rod! - From {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				if (!hasRecentBobber || projectile.Killed) // Bobber type is validated by the bobber flag above.
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not finding active bobber projectile! - From {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				if (!FishableNpcIDs.Contains(args.NpcID))
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for the NPC not being on the fishable NPCs list! - From {0}", args.Player.Name));
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2883,14 +2883,15 @@ namespace TShockAPI
 		internal void OnKillMe(object sender, GetDataHandlers.KillMeEventArgs args)
 		{
 			short damage = args.Damage;
+			ushort normalizedDamage = (ushort)damage;
 			short id = args.PlayerId;
 			PlayerDeathReason playerDeathReason = args.PlayerDeathReason;
 
-			if (damage > 42000) //Abnormal values have the potential to cause infinite loops in the server.
+			if (normalizedDamage > 42000) //Abnormal values have the potential to cause infinite loops in the server.
 			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected high damage from {0} {1}", args.Player.Name, damage));
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected high damage from {0} {1}", args.Player.Name, normalizedDamage));
 				args.Player.Kick(GetString("Failed to shade polygon normals."), true, true);
-				TShock.Log.ConsoleError(GetString("Death Exploit Attempt: Damage {0}", damage));
+				TShock.Log.ConsoleError(GetString("Death Exploit Attempt: Damage {0}", normalizedDamage));
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -548,9 +548,9 @@ namespace TShockAPI
 
 			if (args.Player.LastNetPosition == Vector2.Zero)
 			{
-				TShock.Log.ConsoleInfo(GetString("Bouncer / OnPlayerUpdate *would have rejected* from (last network position zero) {0}", args.Player.Name));
-				// args.Handled = true;
-				// return;
+				// Initialize movement baseline on the first valid update packet.
+				args.Player.LastNetPosition = pos;
+				return;
 			}
 
 			if (!pos.Equals(args.Player.LastNetPosition))

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -988,7 +988,7 @@ namespace TShockAPI
 						return;
 					}
 
-					if (action == EditAction.KillTile || action == EditAction.KillWall && ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0)
+					if ((action == EditAction.KillTile || action == EditAction.KillWall) && ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0)
 					{
 						args.Handled = false;
 						return;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2557,10 +2557,10 @@ namespace TShockAPI
 
 			// Ignore rope placement range
 			if ((type != TileID.Rope
-					|| type != TileID.SilkRope
-					|| type != TileID.VineRope
-					|| type != TileID.WebRope
-					|| type != TileID.MysticSnakeRope)
+					&& type != TileID.SilkRope
+					&& type != TileID.VineRope
+					&& type != TileID.WebRope
+					&& type != TileID.MysticSnakeRope)
 					&& !args.Player.IsInRange(x, y))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected range checks from {0}", args.Player.Name));

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1237,10 +1237,32 @@ namespace TShockAPI
 
 			if (type == 0)
 			{
-				if (!args.Player.IsInRange((int)(Main.item[id].position.X / 16f), (int)(Main.item[id].position.Y / 16f)))
+				if (id < 0 || id >= Main.item.Length)
 				{
-					// Causes item duplications. Will be re added if necessary
-					//args.Player.SendData(PacketTypes.ItemDrop, "", id);
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from invalid item slot check from {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				bool IsWithinPickupRange(Vector2 worldPosition, int range)
+				{
+					if (!TShock.Config.Settings.RangeChecks)
+						return true;
+
+					var itemTileX = (int)(worldPosition.X / 16f);
+					var itemTileY = (int)(worldPosition.Y / 16f);
+
+					return Math.Abs(args.Player.TileX - itemTileX) <= range &&
+					       Math.Abs(args.Player.TileY - itemTileY) <= range;
+				}
+
+				// Vanilla uses Player.defaultItemGrabRange (currently 42 tiles) when attracting/picking up drops.
+				// Use both packet and server item positions to avoid false rejections from minor desync.
+				var pickupRange = Math.Max(Player.defaultItemGrabRange + 8, 50);
+				var inRangeByPacketPosition = IsWithinPickupRange(pos, pickupRange);
+				var inRangeByServerPosition = IsWithinPickupRange(Main.item[id].position, pickupRange);
+				if (!inRangeByPacketPosition && !inRangeByServerPosition)
+				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from dupe range check from {0}", args.Player.Name));
 					args.Handled = true;
 					return;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4784,7 +4784,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (args.Player.IsBeingDisabled())
+			if (args.Player.IsBeingDisabled() && args.Player.State == (int)ConnectionState.Complete)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSyncLoadout rejected loadout index sync {0}", args.Player.Name));
 				NetMessage.SendData((int)PacketTypes.SyncLoadout, number: args.Player.Index, number2: args.TPlayer.CurrentLoadoutIndex);

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -99,6 +99,7 @@ namespace TShockAPI
 					{ PacketTypes.PlayerAnimation, HandlePlayerAnimation },
 					{ PacketTypes.PlayerMana, HandlePlayerMana },
 					{ PacketTypes.PlayerTeam, HandlePlayerTeam },
+					{ PacketTypes.TeamChangeFromUI, HandlePlayerTeam },
 					{ PacketTypes.SignRead, HandleSignRead },
 					{ PacketTypes.SignNew, HandleSign },
 					{ PacketTypes.LiquidSet, HandleLiquidSet },
@@ -141,7 +142,10 @@ namespace TShockAPI
 					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
 					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
 					{ PacketTypes.SyncCavernMonsterType, HandleSyncCavernMonsterType },
-					{ PacketTypes.SyncLoadout, HandleSyncLoadout }
+					{ PacketTypes.SyncLoadout, HandleSyncLoadout },
+					{ PacketTypes.SyncItemCannotBeTakenByEnemies, HandleItemDrop },
+					{ PacketTypes.SyncItemsWithShimmer, HandleItemDrop },
+					{ PacketTypes.SpectatePlayer, HandleSyncPlayerSpectating }
 				};
 		}
 
@@ -4788,6 +4792,11 @@ namespace TShockAPI
 				Terraria.Utils.Swap(ref args.Player.PlayerData.inventory[switchedLoadoutDyeSlotStartIndex + i],
 					ref args.Player.PlayerData.inventory[NetItem.DyeIndex.Item1 + i]);
 
+			return false;
+		}
+
+		private static bool HandleSyncPlayerSpectating(GetDataHandlerArgs args)
+		{
 			return false;
 		}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4770,23 +4770,25 @@ namespace TShockAPI
 			// and the server will replicate the changes the client did. This means that PlayerData.StoreSlot is never called, so we need to
 			// swap around the PlayerData items ourself.
 
-			Tuple<int, int> GetArmorSlotsForLoadoutIndex(int index)
+			(int, int) GetArmorSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
 					0 => NetItem.Loadout1Armor,
 					1 => NetItem.Loadout2Armor,
-					2 => NetItem.Loadout3Armor
+					2 => NetItem.Loadout3Armor,
+					_ => throw new NotImplementedException($"invalid loadout index {index}")
 				};
 			}
 
-			Tuple<int, int> GetDyeSlotsForLoadoutIndex(int index)
+			(int, int) GetDyeSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
 					0 => NetItem.Loadout1Dye,
 					1 => NetItem.Loadout2Dye,
-					2 => NetItem.Loadout3Dye
+					2 => NetItem.Loadout3Dye,
+					_ => throw new NotImplementedException($"invalid loadout index {index}")
 				};
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4770,7 +4770,7 @@ namespace TShockAPI
 			// and the server will replicate the changes the client did. This means that PlayerData.StoreSlot is never called, so we need to
 			// swap around the PlayerData items ourself.
 
-			(int, int) GetArmorSlotsForLoadoutIndex(int index)
+			Tuple<int, int> GetArmorSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
@@ -4781,7 +4781,7 @@ namespace TShockAPI
 				};
 			}
 
-			(int, int) GetDyeSlotsForLoadoutIndex(int index)
+			Tuple<int, int> GetDyeSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
@@ -4792,11 +4792,11 @@ namespace TShockAPI
 				};
 			}
 
-			var (currentLoadoutArmorSlotStartIndex, _) = GetArmorSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex);
-			var (currentLoadoutDyeSlotStartIndex, _) = GetDyeSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex);
+			var currentLoadoutArmorSlotStartIndex = GetArmorSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex).Item1;
+			var currentLoadoutDyeSlotStartIndex = GetDyeSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex).Item1;
 
-			var (switchedLoadoutArmorSlotStartIndex, _) = GetArmorSlotsForLoadoutIndex(loadoutIndex);
-			var (switchedLoadoutDyeSlotStartIndex, _) = GetDyeSlotsForLoadoutIndex(loadoutIndex);
+			var switchedLoadoutArmorSlotStartIndex = GetArmorSlotsForLoadoutIndex(loadoutIndex).Item1;
+			var switchedLoadoutDyeSlotStartIndex = GetDyeSlotsForLoadoutIndex(loadoutIndex).Item1;
 
 			// Emulate what is seen in Player.TrySwitchingLoadout:
 			// - Swap the current loadout items with the player's equipment

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3197,13 +3197,23 @@ namespace TShockAPI
 
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
+				bool alreadyTracked = false;
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					if (args.Player.RecentlyCreatedProjectiles[i].Index == index)
+					{
+						alreadyTracked = true;
+						break;
+					}
+				}
+
+				if (!alreadyTracked)
 				{
 					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 					{
 						Index = index,
 						Type = type,
-						CreatedAt = DateTime.Now
+						CreatedAt = DateTime.UtcNow
 					});
 				}
 			}
@@ -3314,7 +3324,15 @@ namespace TShockAPI
 			args.Player.LastKilledProjectile = type;
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				args.Player.RecentlyCreatedProjectiles.ForEach(s => { if (s.Index == index) { s.Killed = true; } });
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					if (args.Player.RecentlyCreatedProjectiles[i].Index != index)
+						continue;
+
+					var trackedProjectile = args.Player.RecentlyCreatedProjectiles[i];
+					trackedProjectile.Killed = true;
+					args.Player.RecentlyCreatedProjectiles[i] = trackedProjectile;
+				}
 			}
 
 			return false;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3218,6 +3218,13 @@ namespace TShockAPI
 			var direction = (byte)(args.Data.ReadInt8() - 1);
 			var crit = args.Data.ReadInt8();
 
+			if (id < 0 || id >= Main.npc.Length)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleNpcStrike rejected out of bounds NPC index {0} for {1}",
+					id, args.Player.Name));
+				return true;
+			}
+
 			if (OnNPCStrike(args.Player, args.Data, id, direction, dmg, knockback, crit))
 				return true;
 
@@ -4306,7 +4313,13 @@ namespace TShockAPI
 			var itemID = args.Data.ReadInt16();
 			var prefix = args.Data.ReadInt8();
 			var stack = args.Data.ReadInt16();
-			var itemFrame = (TEItemFrame)TileEntity.ByID[TEItemFrame.Find(x, y)];
+			var tileEntityId = TEItemFrame.Find(x, y);
+			if (tileEntityId < 0 || !TileEntity.ByID.TryGetValue(tileEntityId, out var tileEntity) || tileEntity is not TEItemFrame itemFrame)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlaceItemFrame rejected missing item frame at ({0}, {1}) from {2}",
+					x, y, args.Player.Name));
+				return true;
+			}
 
 			if (OnPlaceItemFrame(args.Player, args.Data, x, y, itemID, prefix, stack, itemFrame))
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3188,6 +3188,13 @@ namespace TShockAPI
 			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player, ai))
 				return true;
 
+			if (index < 0 || index >= Main.maxProjectiles)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected out of bounds projectile index {0} for {1}",
+					index, args.Player.Name));
+				return true;
+			}
+
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
 				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
@@ -3261,6 +3268,13 @@ namespace TShockAPI
 
 			if (OnProjectileKill(args.Player, args.Data, ident, owner, index))
 			{
+				return true;
+			}
+
+			if (index < 0 || index >= Main.maxProjectiles)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected out of bounds projectile index {0} for {1}",
+					index, args.Player.Name));
 				return true;
 			}
 

--- a/TShockAPI/HandlerList.cs
+++ b/TShockAPI/HandlerList.cs
@@ -37,6 +37,7 @@ namespace TShockAPI
 
 		protected object HandlerLock = new object();
 		protected List<HandlerItem> Handlers { get; set; }
+		private HandlerItem[] HandlerSnapshot { get; set; } = Array.Empty<HandlerItem>();
 		public HandlerList()
 		{
 			Handlers = new List<HandlerItem>();
@@ -59,6 +60,7 @@ namespace TShockAPI
 			{
 				Handlers.Add(obj);
 				Handlers = Handlers.OrderBy(h => (int)h.Priority).ToList();
+				HandlerSnapshot = Handlers.ToArray();
 			}
 		}
 
@@ -66,21 +68,21 @@ namespace TShockAPI
 		{
 			lock (HandlerLock)
 			{
-				Handlers.RemoveAll(h => h.Handler.Equals(handler));
+				if (Handlers.RemoveAll(h => h.Handler.Equals(handler)) > 0)
+				{
+					HandlerSnapshot = Handlers.ToArray();
+				}
 			}
 		}
 
 		public void Invoke(object sender, T e)
 		{
-			List<HandlerItem> handlers;
-			lock (HandlerLock)
-			{
-				//Copy the list for invoking as to not keep it locked during the invokes
-				handlers = new List<HandlerItem>(Handlers);
-			}
+			var handlers = HandlerSnapshot;
+			if (handlers.Length == 0)
+				return;
 
 			var hargs = e as HandledEventArgs;
-			for (int i = 0; i < handlers.Count; i++)
+			for (int i = 0; i < handlers.Length; i++)
 			{
 				if (hargs == null || !hargs.Handled || (hargs.Handled && handlers[i].GetHandled))
 				{

--- a/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
+++ b/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
@@ -102,7 +102,7 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			if (!Main.tile[args.TileX, args.TileY].active() && Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
+			if (!Main.tile[args.TileX, args.TileY].active() || Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
 			{
 				TShock.Log.ConsoleDebug(GetString($"LandGolfBallInCupHandler: Tile at packet position X:{args.TileX} Y:{args.TileY} is not a golf hole! - From {args.Player.Name}"));
 				args.Handled = true;
@@ -116,8 +116,22 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			var usedGolfBall = args.Player.RecentlyCreatedProjectiles.Any(e => GolfBallProjectileIDs.Contains(e.Type));
-			var usedGolfClub = args.Player.RecentlyCreatedProjectiles.Any(e => e.Type == ProjectileID.GolfClubHelper);
+			var usedGolfBall = false;
+			var usedGolfClub = false;
+			lock (args.Player.RecentlyCreatedProjectiles)
+			{
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					var tracked = args.Player.RecentlyCreatedProjectiles[i];
+					if (!usedGolfBall && GolfBallProjectileIDs.Contains(tracked.Type))
+						usedGolfBall = true;
+					if (!usedGolfClub && tracked.Type == ProjectileID.GolfClubHelper)
+						usedGolfClub = true;
+					if (usedGolfBall && usedGolfClub)
+						break;
+				}
+			}
+
 			if (!usedGolfClub && !usedGolfBall)
 			{
 				TShock.Log.ConsoleDebug(GetString($"GolfPacketHandler: Player did not have create a golf club projectile the last 5 seconds! - From {args.Player.Name}"));

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -33,9 +33,9 @@ namespace TShockAPI.Handlers.NetModules
 		{
 			INetModuleHandler handler;
 
-			if (NetModulesToHandlersMap.ContainsKey(args.ModuleType))
+			if (NetModulesToHandlersMap.TryGetValue(args.ModuleType, out Type type))
 			{
-				handler = (INetModuleHandler)Activator.CreateInstance(NetModulesToHandlersMap[args.ModuleType]);
+				handler = (INetModuleHandler)Activator.CreateInstance(type);
 			}
 			else
 			{

--- a/TShockAPI/SqlLog.cs
+++ b/TShockAPI/SqlLog.cs
@@ -276,10 +276,10 @@ namespace TShockAPI
 
 			var caller = "TShock";
 
-			var frame = new StackTrace().GetFrame(2);
-			if (frame != null)
-			{
-				var meth = frame.GetMethod();
+				var frame = new StackFrame(2, false);
+				if (frame != null)
+				{
+					var meth = frame.GetMethod();
 				if (meth != null && meth.DeclaringType != null)
 					caller = meth.DeclaringType.Name;
 			}

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1533,6 +1533,7 @@ namespace TShockAPI
 			Group = Group.DefaultGroup;
 			IceTiles = new List<Point>();
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow.AddSeconds(-(index % 5));
 		}
 
 		/// <summary>
@@ -1547,6 +1548,7 @@ namespace TShockAPI
 			FakePlayer = new Player { name = playerName, whoAmI = -1 };
 			Group = Group.DefaultGroup;
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow;
 
 			if (playerName == "All" || playerName == "Server")
 				FinishedHandshake = true; //Hot fix for the all player object not getting packets like TimeSet, etc because they have no state and finished handshake will always be false.

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -298,6 +298,11 @@ namespace TShockAPI
 		public DateTime LastThreat { get; set; }
 
 		/// <summary>
+		/// The last time stack hack detection was executed for this player.
+		/// </summary>
+		public DateTime LastStackDetectionCheck { get; set; }
+
+		/// <summary>
 		/// Whether the player should see logs.
 		/// </summary>
 		public bool DisplayLogs = true;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1146,6 +1146,8 @@ namespace TShockAPI
 					if (player.TilePlaceThreshold > 0)
 					{
 						player.TilePlaceThreshold = 0;
+						lock (player.TilesCreated)
+							player.TilesCreated.Clear();
 					}
 
 					if (player.RecentFuse > 0)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1496,19 +1496,19 @@ namespace TShockAPI
 			// Terraria now has chat commands on the client side.
 			// These commands remove the commands prefix (e.g. /me /playing) and send the command id instead
 			// In order for us to keep legacy code we must reverse this and get the prefix using the command id
-			foreach (var item in Terraria.UI.Chat.ChatManager.Commands._localizedCommands)
+			if (!string.IsNullOrEmpty(args.CommandId._name))
 			{
-				if (item.Value._name == args.CommandId._name)
+				var commandPrefix = EnglishLanguage.GetCommandPrefixByName(args.CommandId._name);
+				if (!string.IsNullOrEmpty(commandPrefix))
 				{
 					if (!String.IsNullOrEmpty(text))
 					{
-						text = EnglishLanguage.GetCommandPrefixByName(item.Value._name) + ' ' + text;
+						text = commandPrefix + ' ' + text;
 					}
 					else
 					{
-						text = EnglishLanguage.GetCommandPrefixByName(item.Value._name);
+						text = commandPrefix;
 					}
-					break;
 				}
 			}
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1834,19 +1834,33 @@ namespace TShockAPI
 						var player = Players[projectile.owner];
 						if (player != null)
 						{
-							if (player.RecentlyCreatedProjectiles.Any(p => p.Index == e.number && p.Killed))
+							lock (player.RecentlyCreatedProjectiles)
 							{
-								player.RecentlyCreatedProjectiles.RemoveAll(p => p.Index == e.number && p.Killed);
-							}
-
-							if (!player.RecentlyCreatedProjectiles.Any(p => p.Index == e.number))
-							{
-								player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
+								bool foundActiveEntry = false;
+								for (int i = player.RecentlyCreatedProjectiles.Count - 1; i >= 0; i--)
 								{
-									Index = e.number,
-									Type = (short)projectile.type,
-									CreatedAt = DateTime.Now
-								});
+									var tracked = player.RecentlyCreatedProjectiles[i];
+									if (tracked.Index != e.number)
+										continue;
+
+									if (tracked.Killed)
+									{
+										player.RecentlyCreatedProjectiles.RemoveAt(i);
+										continue;
+									}
+
+									foundActiveEntry = true;
+								}
+
+								if (!foundActiveEntry)
+								{
+									player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
+									{
+										Index = e.number,
+										Type = (short)projectile.type,
+										CreatedAt = DateTime.UtcNow
+									});
+								}
 							}
 						}
 					}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1220,16 +1220,17 @@ namespace TShockAPI
 						player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 					}
 
-					if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
-					{
-						if (!player.HasPermission(Permissions.ignorestackhackdetection))
+						if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
 						{
-							if ((DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5)
+							var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
+							if (stackCheckDue)
 							{
-								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
 								player.LastStackDetectionCheck = DateTime.UtcNow;
+								if (!player.HasPermission(Permissions.ignorestackhackdetection))
+								{
+									player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+								}
 							}
-						}
 
 						if (player.IsBeingDisabled())
 						{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -45,6 +45,7 @@ using TShockAPI.Localization;
 using TShockAPI.Configuration;
 using Terraria.GameContent.Creative;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using MonoMod.Cil;
 using Terraria.Achievements;
 using Terraria.Initializers;
@@ -1492,6 +1493,10 @@ namespace TShockAPI
 			string text = TruncateChatMessageIfNecessary(args);
 			// We should now use the truncated message instead of the original, we don't want anything to fire off on text that has been "removed"...
 			// Yes, double assignment like this looks bad...
+
+			text = Regex.Replace(text, @"\[ct:[^\]]*\]", "");
+			// Filter out [ct:xxx] tags because they may crash the PE client
+
 			var chatText = text;
 
 			// Terraria now has chat commands on the client side.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1224,7 +1224,11 @@ namespace TShockAPI
 					{
 						if (!player.HasPermission(Permissions.ignorestackhackdetection))
 						{
-							player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+							if ((DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5)
+							{
+								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+								player.LastStackDetectionCheck = DateTime.UtcNow;
+							}
 						}
 
 						if (player.IsBeingDisabled())

--- a/TShockAPI/TextLog.cs
+++ b/TShockAPI/TextLog.cs
@@ -255,10 +255,10 @@ namespace TShockAPI
 
 			var caller = "TShock";
 
-			var frame = new StackTrace().GetFrame(2);
-			if (frame != null)
-			{
-				var meth = frame.GetMethod();
+				var frame = new StackFrame(2, false);
+				if (frame != null)
+				{
+					var meth = frame.GetMethod();
 				if (meth != null && meth.DeclaringType != null)
 					caller = meth.DeclaringType.Name;
 			}

--- a/scripts/capture_dotnet_trace.ps1
+++ b/scripts/capture_dotnet_trace.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$ProcessName = "TerrariaServer",
+    [int]$DurationSeconds = 120,
+    [string]$OutputDirectory = "profiles"
+)
+
+$traceTool = Get-Command dotnet-trace -ErrorAction SilentlyContinue
+if ($null -eq $traceTool)
+{
+    Write-Error "dotnet-trace is not installed. Install with: dotnet tool install -g dotnet-trace"
+    exit 1
+}
+
+if ($DurationSeconds -le 0)
+{
+    Write-Error "DurationSeconds must be greater than zero."
+    exit 1
+}
+
+$targetProcess = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue |
+    Sort-Object CPU -Descending |
+    Select-Object -First 1
+
+if ($null -eq $targetProcess)
+{
+    Write-Error "No running process found with name '$ProcessName'."
+    exit 1
+}
+
+$duration = [TimeSpan]::FromSeconds($DurationSeconds)
+$durationArg = "{0:00}:{1:00}:{2:00}:{3:00}" -f $duration.Days, $duration.Hours, $duration.Minutes, $duration.Seconds
+
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+
+$stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$baseName = "{0}_{1}" -f $ProcessName, $stamp
+$outputPath = Join-Path $OutputDirectory ("{0}.nettrace" -f $baseName)
+$speedscopePath = Join-Path $OutputDirectory ("{0}.speedscope.json" -f $baseName)
+
+Write-Host ("Collecting CPU trace for PID {0} ({1}) for {2} seconds..." -f $targetProcess.Id, $targetProcess.ProcessName, $DurationSeconds)
+
+dotnet-trace collect --process-id $targetProcess.Id --duration $durationArg --profile cpu-sampling --output $outputPath --format Speedscope
+if ($LASTEXITCODE -ne 0)
+{
+    exit $LASTEXITCODE
+}
+
+Write-Host ("NetTrace: {0}" -f $outputPath)
+if (Test-Path $speedscopePath)
+{
+    Write-Host ("Speedscope: {0}" -f $speedscopePath)
+}


### PR DESCRIPTION
## Summary
- optimize handler dispatch using copy-on-write snapshots
- make projectile cleanup deterministic in second-update path

## Why
Reduces lock/iteration overhead in packet/handler paths while preserving plugin compatibility.