### PR TITLE
[perf] Make projectile cleanup deterministic in OnSecondUpdate

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3056,20 +3056,17 @@ namespace TShockAPI
 
 		internal void OnSecondUpdate()
 		{
-			Task.Run(() =>
+			var threshold = DateTime.UtcNow.AddSeconds(-5);
+			foreach (var player in TShock.Players)
 			{
-				foreach (var player in TShock.Players)
+				if (player != null && player.TPlayer.whoAmI >= 0)
 				{
-					if (player != null && player.TPlayer.whoAmI >= 0)
+					lock (player.RecentlyCreatedProjectiles)
 					{
-						var threshold = DateTime.Now.AddSeconds(-5);
-						lock (player.RecentlyCreatedProjectiles)
-						{
-							player.RecentlyCreatedProjectiles = player.RecentlyCreatedProjectiles.Where(s => s.CreatedAt > threshold).ToList();
-						}
+						player.RecentlyCreatedProjectiles.RemoveAll(s => s.CreatedAt <= threshold);
 					}
 				}
-			});
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary
- run recent projectile cleanup directly in second-update path
- remove stale entries in place with RemoveAll under lock

## Scope
- focused change in Bouncer.OnSecondUpdate only
- no unrelated file changes