### PR TITLE
[perf] Stagger stack-hack scans to smooth second-update load

### DIFF
--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -274,6 +274,11 @@ namespace TShockAPI
 		public DateTime LastPvPTeamChange;
 
 		/// <summary>
+		/// The last time stack-hack detection was run for this player.
+		/// </summary>
+		public DateTime LastStackDetectionCheck;
+
+		/// <summary>
 		/// Temp points for use in regions and other plugins.
 		/// </summary>
 		public Point[] TempPoints = new Point[2];

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1528,6 +1528,7 @@ namespace TShockAPI
 			Group = Group.DefaultGroup;
 			IceTiles = new List<Point>();
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow.AddSeconds(-(index % 5));
 		}
 
 		/// <summary>
@@ -1542,6 +1543,7 @@ namespace TShockAPI
 			FakePlayer = new Player { name = playerName, whoAmI = -1 };
 			Group = Group.DefaultGroup;
 			AwaitingResponse = new Dictionary<string, Action<object>>();
+			LastStackDetectionCheck = DateTime.UtcNow;
 
 			if (playerName == "All" || playerName == "Server")
 				FinishedHandshake = true; //Hot fix for the all player object not getting packets like TimeSet, etc because they have no state and finished handshake will always be false.

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1232,10 +1232,9 @@ namespace TShockAPI
 						}
 					}
 
-						if (player.IsBeingDisabled())
-						{
-							player.Disable(flags: flags);
-						}
+					if (player.IsBeingDisabled())
+					{
+						player.Disable(flags: flags);
 					}
 				}
 			}

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1221,10 +1221,16 @@ namespace TShockAPI
 
 					if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
 					{
-						if (!player.HasPermission(Permissions.ignorestackhackdetection))
+						var stackCheckDue = (DateTime.UtcNow - player.LastStackDetectionCheck).TotalSeconds >= 5;
+						if (stackCheckDue)
 						{
-							player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+							player.LastStackDetectionCheck = DateTime.UtcNow;
+							if (!player.HasPermission(Permissions.ignorestackhackdetection))
+							{
+								player.IsDisabledForStackDetection = player.HasHackedItemStacks(shouldWarnPlayer: true);
+							}
 						}
+					}
 
 						if (player.IsBeingDisabled())
 						{


### PR DESCRIPTION
## Summary
- add per-player stack-scan timestamp state
- schedule stack checks at 5s intervals instead of every second per player
- initialize timestamps with player-index offset to spread work

## Scope
- focused changes in TSPlayer and TShock.OnSecondUpdate`n- no unrelated file changes