### PR TITLE
[perf] Clear per-second placement rollback cache

### DIFF
--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1147,6 +1147,8 @@ namespace TShockAPI
 					if (player.TilePlaceThreshold > 0)
 					{
 						player.TilePlaceThreshold = 0;
+						lock (player.TilesCreated)
+							player.TilesCreated.Clear();
 					}
 
 					if (player.RecentFuse > 0)


### PR DESCRIPTION
## Summary
- clear TilesCreated when TilePlaceThreshold is reset each second
- keep placement rollback tracking bounded to active threshold window

## Scope
- focused change in TShock.OnSecondUpdate only
- no unrelated file changes