### PR TITLE
misc: Don't check item/projectile bans for non-logged in players

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1312,7 +1312,7 @@ namespace TShockAPI
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from bouncer throttle from {0}", args.Player.Name));
 
 				// Client will fight the server if we remove pets, silently reject instead
-				if (!Main.projPet[type] || !ProjectileID.Sets.LightPet[type])
+				if (!Main.projPet[type] && !ProjectileID.Sets.LightPet[type])
 					args.Player.RemoveProjectile(ident, owner);
 
 				args.Handled = true;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -572,11 +572,7 @@ namespace TShockAPI
 						{
 							args.Player.SendErrorMessage(GetString("Disabled. You went too far with banned armor."));
 						}
-						else if (args.Player.IsDisabledForSSC)
-						{
-							args.Player.SendErrorMessage(GetString("Disabled. You need to {0}login to load your saved data.", TShock.Config.Settings.CommandSpecifier));
-						}
-						else if (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn)
+						else if (args.Player.IsDisabledForSSC || (TShock.Config.Settings.RequireLogin && !args.Player.IsLoggedIn))
 						{
 							args.Player.SendErrorMessage(GetString("Account needed! Please {0}register or {0}login to play!", TShock.Config.Settings.CommandSpecifier));
 						}
@@ -1299,6 +1295,30 @@ namespace TShockAPI
 				return;
 			}
 
+			if (args.Player.IsBeingDisabled())
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from disabled from {0}", args.Player.Name));
+
+				// Client will fight the server if we remove pets, silently reject instead
+				if (!Main.projPet[type] && !ProjectileID.Sets.LightPet[type])
+					args.Player.RemoveProjectile(ident, owner);
+
+				args.Handled = true;
+				return;
+			}
+
+			if (args.Player.IsBouncerThrottled())
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from bouncer throttle from {0}", args.Player.Name));
+
+				// Client will fight the server if we remove pets, silently reject instead
+				if (!Main.projPet[type] || !ProjectileID.Sets.LightPet[type])
+					args.Player.RemoveProjectile(ident, owner);
+
+				args.Handled = true;
+				return;
+			}
+
 			if (TShock.ProjectileBans.ProjectileIsBanned(type, args.Player))
 			{
 				args.Player.Disable(GetString("Player does not have permission to create projectile {0}.", type), DisableFlags.WriteToLogAndConsole);
@@ -1313,14 +1333,6 @@ namespace TShockAPI
 			{
 				args.Player.Disable(GetString("Projectile damage is higher than {0}.", TShock.Config.Settings.MaxProjDamage), DisableFlags.WriteToLogAndConsole);
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile damage limit from {0} {1}/{2}", args.Player.Name, damage, TShock.Config.Settings.MaxProjDamage));
-				args.Player.RemoveProjectile(ident, owner);
-				args.Handled = true;
-				return;
-			}
-
-			if (args.Player.IsBeingDisabled())
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from disabled from {0}", args.Player.Name));
 				args.Player.RemoveProjectile(ident, owner);
 				args.Handled = true;
 				return;
@@ -1444,14 +1456,6 @@ namespace TShockAPI
 
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile create threshold from {0} {1}/{2}", args.Player.Name, args.Player.ProjectileThreshold, TShock.Config.Settings.ProjectileThreshold));
 				TShock.Log.ConsoleDebug(GetString("If this player wasn't hacking, please report the projectile create threshold they were disabled for to TShock so we can improve this!"));
-				args.Handled = true;
-				return;
-			}
-
-			if (args.Player.IsBouncerThrottled())
-			{
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from bouncer throttle from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/ItemBans.cs
+++ b/TShockAPI/ItemBans.cs
@@ -87,18 +87,18 @@ namespace TShockAPI
 				// Untaint now, re-taint if they fail the check.
 				UnTaint(player);
 
-				// No matter the player type, we do a check when a player is holding an item that's banned.
-				if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[player.TPlayer.selectedItem].type), player))
+				// If player isn't disabled for not being logged in, check for any banned items in use.
+				if ((TShock.Config.Settings.RequireLogin || Main.ServerSideCharacter) && player.IsLoggedIn ||
+					(!TShock.Config.Settings.RequireLogin && !Main.ServerSideCharacter))
 				{
-					string itemName = player.TPlayer.inventory[player.TPlayer.selectedItem].Name;
-					player.Disable(GetString($"holding banned item: {itemName}"), disableFlags);
-					SendCorrectiveMessage(player, itemName);
-				}
-
-				// If SSC isn't enabled OR if SSC is enabled and the player is logged in
-				// In a case like this, we do the full check too.
-				if (!Main.ServerSideCharacter || (Main.ServerSideCharacter && player.IsLoggedIn))
-				{
+					// No matter the player type, we do a check when a player is holding an item that's banned.
+					if (DataModel.ItemIsBanned(EnglishLanguage.GetItemNameById(player.TPlayer.inventory[player.TPlayer.selectedItem].type), player))
+					{
+						string itemName = player.TPlayer.inventory[player.TPlayer.selectedItem].Name;
+						player.Disable(GetString($"holding banned item: {itemName}"), disableFlags);
+						SendCorrectiveMessage(player, itemName);
+					}
+					
 					// The Terraria inventory is composed of a multicultural set of arrays
 					// with various different contents and beliefs
 


### PR DESCRIPTION
- Item bans are no longer checked for players who are not yet logged in when they are required to login
- Moved ``IsBouncerThrottled``/``IsBeingDisabled`` checks in ``OnNewProjectile`` to before projectile ban checks
- Silently reject pet projectiles from disabled/bouncer throttled players
- Use same message when required to login for both SSC and RequireLogin setting

Note: Will still CC for hacked stacks, and when login is required (SSC disabled)

Tests of this PR would be greatly appreciated! Hope it didn't break any existing behavior.