### PR TITLE
prevent dirt/liquid bombs and rockets from bypassing region protection

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3029,7 +3029,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Called when a player is trying to put an item into chest through Quick Stack.
+		/// Called when dirt/fluid projectiles (dirt bombs, liquid bombs, liquid rockets) are killed and attempt to place tiles or liquids.
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
@@ -3042,11 +3042,15 @@ namespace TShockAPI
 			if (player == null || !player.Active)
 				return;
 
-
 			var originalPlot = args.plot;
 			args.plot = (x, y) => player.HasBuildPermission(x, y) && originalPlot(x, y);
 		}
 
+		/// <summary>
+		/// Called when a player is trying to put an item into chest through Quick Stack.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="args"></param>
 		internal void OnQuickStack(object sender, OTAPI.Hooks.Chest.QuickStackEventArgs args)
 		{
 			var id = args.ChestIndex;

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -138,6 +138,7 @@ namespace TShockAPI
 			GetDataHandlers.FishOutNPC += OnFishOutNPC;
 			GetDataHandlers.FoodPlatterTryPlacing += OnFoodPlatterTryPlacing;
 			OTAPI.Hooks.Chest.QuickStack += OnQuickStack;
+			HookEvents.Terraria.Projectile.Kill_DirtAndFluidProjectiles_RunDelegateMethodPushUpForHalfBricks += OnProjectileDirtFluidKill;
 
 
 			// The following section is based off Player.PlaceThing_Tiles_PlaceIt and Player.PlaceThing_Tiles_PlaceIt_GetLegacyTileStyle.
@@ -3032,6 +3033,20 @@ namespace TShockAPI
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="args"></param>
+		internal void OnProjectileDirtFluidKill(Terraria.Projectile sender, HookEvents.Terraria.Projectile.Kill_DirtAndFluidProjectiles_RunDelegateMethodPushUpForHalfBricksEventArgs args)
+		{
+			if (sender.owner < 0 || sender.owner >= Main.maxPlayers)
+				return;
+
+			var player = TShock.Players[sender.owner];
+			if (player == null || !player.Active)
+				return;
+
+
+			var originalPlot = args.plot;
+			args.plot = (x, y) => player.HasBuildPermission(x, y) && originalPlot(x, y);
+		}
+
 		internal void OnQuickStack(object sender, OTAPI.Hooks.Chest.QuickStackEventArgs args)
 		{
 			var id = args.ChestIndex;


### PR DESCRIPTION
Hook `Kill_DirtAndFluidProjectiles_RunDelegateMethodPushUpForHalfBricks` via OTAPI to wrap the plot delegate with a `HasBuildPermission` check
Prevents dirt bombs, liquid bombs, and liquid rockets from placing tiles/liquids in protected regions

Limitation: Liquid or sand placed outside a region boundary may still flow/fall into protected regions via vanilla liquid physics/gravity simulation

Partially addresses #3158