### PR TITLE
Fix first SSC login appearance reset for new players

### DIFF
--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -913,6 +913,11 @@ namespace TShockAPI
 					}
 
 					args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					if (Main.ServerSideCharacter && TShock.CharacterDB.IsSeededAppearanceMissing(args.Player.PlayerData))
+					{
+						TShock.CharacterDB.SyncSeededAppearance(account, args.Player);
+						args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					}
 
 					args.Player.Group = group;
 					args.Player.tempGroup = null;

--- a/TShockAPI/DB/CharacterManager.cs
+++ b/TShockAPI/DB/CharacterManager.cs
@@ -185,6 +185,69 @@ namespace TShockAPI.DB
 		}
 
 		/// <summary>
+		/// Checks whether an SSC row appears to be seeded without appearance fields.
+		/// </summary>
+		/// <param name="playerData">Loaded SSC data for an account.</param>
+		/// <returns>true when appearance fields are still missing.</returns>
+		public bool IsSeededAppearanceMissing(PlayerData playerData)
+		{
+			if (playerData == null || !playerData.exists)
+				return false;
+
+			return playerData.skinVariant == null
+				&& playerData.hair == null
+				&& playerData.hairColor == null
+				&& playerData.pantsColor == null
+				&& playerData.shirtColor == null
+				&& playerData.underShirtColor == null
+				&& playerData.shoeColor == null
+				&& playerData.skinColor == null
+				&& playerData.eyeColor == null
+				&& playerData.hideVisuals == null
+				&& playerData.voiceVariant == null
+				&& playerData.voicePitchOffset == null;
+		}
+
+		/// <summary>
+		/// Updates appearance-related SSC fields for accounts with seeded rows missing appearance data.
+		/// </summary>
+		/// <param name="account">The account owning the SSC row.</param>
+		/// <param name="player">The currently connected player source.</param>
+		/// <returns>true if update succeeded.</returns>
+		public bool SyncSeededAppearance(UserAccount account, TSPlayer player)
+		{
+			if (account == null || player == null)
+				return false;
+
+			try
+			{
+				return database.Query(
+					"UPDATE tsCharacter SET skinVariant = @0, hair = @1, hairDye = @2, hairColor = @3, pantsColor = @4, shirtColor = @5, underShirtColor = @6, shoeColor = @7, hideVisuals = @8, skinColor = @9, eyeColor = @10, voiceVariant = @11, voicePitchOffset = @12, team = @13 WHERE Account = @14;",
+					player.TPlayer.skinVariant,
+					player.TPlayer.hair,
+					player.TPlayer.hairDye,
+					TShock.Utils.EncodeColor(player.TPlayer.hairColor),
+					TShock.Utils.EncodeColor(player.TPlayer.pantsColor),
+					TShock.Utils.EncodeColor(player.TPlayer.shirtColor),
+					TShock.Utils.EncodeColor(player.TPlayer.underShirtColor),
+					TShock.Utils.EncodeColor(player.TPlayer.shoeColor),
+					TShock.Utils.EncodeBoolArray(player.TPlayer.hideVisibleAccessory),
+					TShock.Utils.EncodeColor(player.TPlayer.skinColor),
+					TShock.Utils.EncodeColor(player.TPlayer.eyeColor),
+					player.TPlayer.voiceVariant,
+					player.TPlayer.voicePitchOffset,
+					player.TPlayer.team,
+					account.ID) > 0;
+			}
+			catch (Exception ex)
+			{
+				TShock.Log.Error(ex.ToString());
+			}
+
+			return false;
+		}
+
+		/// <summary>
 		/// Inserts player data to the tsCharacter database table
 		/// </summary>
 		/// <param name="player">player to take data from</param>

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2807,6 +2807,11 @@ namespace TShockAPI
 						return true;
 
 					args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					if (Main.ServerSideCharacter && TShock.CharacterDB.IsSeededAppearanceMissing(args.Player.PlayerData))
+					{
+						TShock.CharacterDB.SyncSeededAppearance(account, args.Player);
+						args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					}
 
 					args.Player.Group = group;
 					args.Player.tempGroup = null;
@@ -3432,6 +3437,11 @@ namespace TShockAPI
 				{
 					args.Player.RequiresPassword = false;
 					args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					if (Main.ServerSideCharacter && TShock.CharacterDB.IsSeededAppearanceMissing(args.Player.PlayerData))
+					{
+						TShock.CharacterDB.SyncSeededAppearance(account, args.Player);
+						args.Player.PlayerData = TShock.CharacterDB.GetPlayerData(args.Player, account.ID);
+					}
 
 					if (args.Player.State == (int)ConnectionState.AssigningPlayerSlot)
 						args.Player.State = (int)ConnectionState.AwaitingPlayerInfo;


### PR DESCRIPTION
Players reported that with SSC enabled, first-time players can get default appearance values after they log in.

This patch keeps SSC behavior the same, but if the seeded tsCharacter row has missing appearance fields, it fills them from the current player data at login and reloads PlayerData.

It is applied in all login paths (UUID login, password login, and /login).