### PR TITLE
[perf] Use TryGetValue for net module handler resolution

### DIFF
--- a/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
+++ b/TShockAPI/Handlers/NetModules/NetModulePacketHandler.cs
@@ -33,9 +33,9 @@ namespace TShockAPI.Handlers.NetModules
 		{
 			INetModuleHandler handler;
 
-			if (NetModulesToHandlersMap.ContainsKey(args.ModuleType))
+			if (NetModulesToHandlersMap.TryGetValue(args.ModuleType, out Type type))
 			{
-				handler = (INetModuleHandler)Activator.CreateInstance(NetModulesToHandlersMap[args.ModuleType]);
+				handler = (INetModuleHandler)Activator.CreateInstance(type);
 			}
 			else
 			{


### PR DESCRIPTION
This path runs for every net module packet.

This patch replaces a double dictionary lookup (`ContainsKey` + indexer) with a single `TryGetValue` lookup.

Behavior stays the same; it is only a small hot-path cleanup.