### PR TITLE
fix: team change message isn't broadcast on spawn

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2907,6 +2907,7 @@ namespace TShockAPI
 			if (pvpMode == "pvpwithnoteam" && team != 0)
 			{
 				team = 0;
+				args.TPlayer.team = 0; // make sure to set it to 0 (no team)
 				teamCorrectNeeded = true;
 			}
 			// Malicious client likely trying to fast switch
@@ -2972,12 +2973,13 @@ namespace TShockAPI
 					return false;
 				}
 
-				if (teamCorrectNeeded)
+				if (team != args.TPlayer.team)
 				{
-					team = (byte)args.Player.Team;
-				}
+					if (teamCorrectNeeded)
+						team = (byte)args.TPlayer.team;
 
-				args.TPlayer.team = team;
+					args.TPlayer.team = team;
+				}
 
 				args.TPlayer.Spawn(context);
 				// spawn the player before teleporting
@@ -3001,9 +3003,9 @@ namespace TShockAPI
 
 			// Note: Because clients can change their team through this packet now, we have to always handle it ourselves.
 			if (teamCorrectNeeded) // correction of malicious client's team change necessary
-				team = (byte)args.Player.Team;
+				team = (byte)args.TPlayer.team;
 
-			if (!args.Player.InitialTeamChangePending && args.Player.Team != team) // client changed team through this packet, track time since last team change
+			if (!args.Player.InitialTeamChangePending && args.TPlayer.team != team) // client changed team through this packet, track time since last team change
 				args.Player.LastPvPTeamChange = DateTime.UtcNow;
 
 			args.Player.TPlayer.team = team;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2901,7 +2901,7 @@ namespace TShockAPI
 			byte team = args.Data.ReadInt8();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
 
-			bool teamCorrectNeeded = false; // Only used if malicious client attempts to change team this way
+			bool teamCorrectNeeded = false; // If we need to correct their team after handling
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
 			// To prevent clients from bypassing this pvp mode, we must correct their team
 			if (pvpMode == "pvpwithnoteam" && team != 0)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2977,6 +2977,8 @@ namespace TShockAPI
 				{
 					if (teamCorrectNeeded)
 						team = (byte)args.TPlayer.team;
+					else
+						args.Player.LastPvPTeamChange = DateTime.UtcNow;
 
 					args.TPlayer.team = team;
 				}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3385,7 +3385,14 @@ namespace TShockAPI
 			}
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "disabled" || pvpMode == "always" || pvpMode == "pvpwithnoteam" || (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+			if (pvpMode == "disabled" || pvpMode == "always" || pvpMode == "pvpwithnoteam")
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleTogglePvp rejected from (pvp mode disallows toggling) {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.TogglePvp, "", id);
+				return true;
+			}
+
+			if ((DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleTogglePvp rejected fastswitch {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.TogglePvp, "", id);

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2901,8 +2901,27 @@ namespace TShockAPI
 			byte team = args.Data.ReadInt8();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
 
+			bool teamCorrectNeeded = false; // Only used if malicious client attempts to change team this way
+			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
+			// To prevent clients from bypassing this pvp mode, we must correct their team
+			if (pvpMode == "pvpwithnoteam" && team != 0)
+			{
+				team = 0;
+				teamCorrectNeeded = true;
+			}
+			// MMalicious client likely trying to fast switch
+			if (team != args.Player.Team && args.Player.FinishedHandshake && (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+				teamCorrectNeeded = true;
+
 			if (args.Player.State >= (int)ConnectionState.RequestingWorldData && !args.Player.FinishedHandshake)
+			{
 				args.Player.FinishedHandshake = true; //If the player has requested world data before sending spawn player, they should be at the obvious ClientRequestedWorldData state. Also only set this once to remove redundant updates.
+				if (!Main.ServerSideCharacter && team != 0 && !teamCorrectNeeded) // Player will be requesting a team change later
+				{
+					args.Player.InitialTeamChangePending = true;
+					args.Player.LastPvPTeamChange = DateTime.UtcNow; // To prevent malicious clients from being able to get a free team change, we reset InitialTeamChangePending after 5 seconds
+				}
+			}
 
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnX, spawnY, respawnTimer, numberOfDeathsPVE, numberOfDeathsPVP, team, context))
 				return true;
@@ -2953,7 +2972,13 @@ namespace TShockAPI
 					return false;
 				}
 
+				if (teamCorrectNeeded)
+				{
+					team = (byte)args.Player.Team;
+				}
+
 				args.TPlayer.team = team;
+
 				args.TPlayer.Spawn(context);
 				// spawn the player before teleporting
 				NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)PlayerSpawnContext.ReviveFromDeath);
@@ -2966,9 +2991,55 @@ namespace TShockAPI
 				args.TPlayer.respawnTimer = respawnTimer;
 				args.TPlayer.numberOfDeathsPVE = numberOfDeathsPVE;
 				args.TPlayer.numberOfDeathsPVP = numberOfDeathsPVP;
+
+				// Correct their team after
+				if (teamCorrectNeeded)
+					args.Player.SendData(PacketTypes.PlayerTeam, "", args.Player.Index);
+
 				return true;
 			}
-			return false;
+
+			// Note: Because clients can change their team through this packet now, we have to always handle it ourselves.
+			if (teamCorrectNeeded) // correction of malicious client's team change necessary
+				team = (byte)args.Player.Team;
+
+			if (!args.Player.InitialTeamChangePending && args.Player.Team != team) // client changed team through this packet, track time since last team change
+				args.Player.LastPvPTeamChange = DateTime.UtcNow;
+
+			args.Player.TPlayer.team = team;
+			if (respawnTimer > 0)
+				args.Player.TPlayer.dead = true;
+
+			args.Player.TPlayer.Spawn(context);
+
+			// Handling of data from MessageBuffer...
+			if (args.Player.State == (int)ConnectionState.RequestingWorldData)
+			{
+				args.Player.State = 10;
+				NetMessage.buffer[args.Player.Index].broadcast = true;
+				NetMessage.SyncConnectedPlayer(args.Player.Index);
+				bool flag11 = NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index);
+				Main.countsAsHostForGameplay[args.Player.Index] = flag11;
+				if (NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index))
+					NetMessage.TrySendData(139, args.Player.Index, -1, null, args.Player.Index, flag11.ToInt());
+
+				NetMessage.TrySendData(129, args.Player.Index);
+				NetMessage.greetPlayer(args.Player.Index);
+				if (args.Player.TPlayer.unlockedBiomeTorches)
+				{
+					NPC nPC = new NPC();
+					nPC.SetDefaults(664);
+					Main.BestiaryTracker.Kills.RegisterKill(nPC);
+				}
+			}
+
+			NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)context);
+
+			if (teamCorrectNeeded)
+				args.Player.SendData(PacketTypes.PlayerTeam, "", args.Player.Index);
+
+			// We've handled it ourselves
+			return true;
 		}
 
 		private static bool HandlePlayerUpdate(GetDataHandlerArgs args)
@@ -3571,7 +3642,7 @@ namespace TShockAPI
 			if (id != args.Player.Index)
 				return true;
 
-			if (team == args.Player.Team) // No need to handle, interferes with SSC if we do.
+			if (!args.Player.InitialTeamChangePending && team == args.Player.Team) // No need to handle if initial change isn't pending, interferes with SSC if we do.
 				return true;
 
 			if (args.Player.IgnoreSSCPackets)
@@ -3582,7 +3653,23 @@ namespace TShockAPI
 			}
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "pvpwithnoteam" || (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+			if (pvpMode == "pvpwithnoteam")
+			{
+				args.Player.SendData(PacketTypes.PlayerTeam, "", id);
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam rejected from (pvp mode disallows teams) {0}", args.Player.Name));
+				return true;
+			}
+
+			// Player has pending team change
+			if (args.Player.InitialTeamChangePending)
+			{
+				args.Player.InitialTeamChangePending = false;
+				args.Player.LastPvPTeamChange = DateTime.MinValue; // Players can change teams or toggle pvp immediately after joining, so we have to allow such
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam super accepted from (initial team change) {0}", args.Player.Name));
+				return false;
+			}
+
+			if ((DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
 			{
 				args.Player.SendData(PacketTypes.PlayerTeam, "", id);
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam rejected team fastswitch {0}", args.Player.Name));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2909,7 +2909,7 @@ namespace TShockAPI
 				team = 0;
 				teamCorrectNeeded = true;
 			}
-			// MMalicious client likely trying to fast switch
+			// Malicious client likely trying to fast switch
 			if (team != args.Player.Team && args.Player.FinishedHandshake && (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
 				teamCorrectNeeded = true;
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -402,6 +402,9 @@ namespace TShockAPI
 		/// <summary>Determines if the player has finished the handshake (Sent all necessary packets for connection, such as Request World Data, Spawn Player, etc). A normal client would do all of this no problem.</summary>
 		public bool FinishedHandshake = false;
 
+		/// <summary>Determines if the player will be sending a team change packet right after the initial spawn. </summary>
+		public bool InitialTeamChangePending = false;
+
 		/// <summary>Server-side character's recorded death count.</summary>
 		public int sscDeathsPVE = 0;
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1164,6 +1164,10 @@ namespace TShockAPI
 						TShock.Log.ConsoleDebug(GetString("OnSecondUpdate / initial ssc spawn for {0} at ({1}, {2})", player.Name, player.TPlayer.SpawnX, player.TPlayer.SpawnY));
 					}
 
+					// If a client didn't set a team change within 5 seconds, they're likely hacking, so clear this flag to remove their one-time free team change
+					if (player.InitialTeamChangePending && (DateTime.UtcNow - player.LastPvPTeamChange).TotalSeconds >= 5)
+						player.InitialTeamChangePending = false;
+
 					if (player.RPPending > 0)
 					{
 						if (player.RPPending == 1)

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1168,6 +1168,29 @@ namespace TShockAPI
 					if (player.InitialTeamChangePending && (DateTime.UtcNow - player.LastPvPTeamChange).TotalSeconds >= 5)
 						player.InitialTeamChangePending = false;
 
+					// Enforce the pvp mode.
+					string pvpMode = Config.Settings.PvPMode.ToLowerInvariant();
+					if (pvpMode != "normal")
+					{
+						if (pvpMode == "disabled" && player.TPlayer.hostile)
+						{
+							player.TPlayer.hostile = false;
+							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
+						}
+
+						if ((pvpMode == "always" || pvpMode == "pvpwithnoteam") && !player.TPlayer.hostile)
+						{
+							player.TPlayer.hostile = true;
+							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
+						}
+
+						if (pvpMode == "pvpwithnoteam" && player.Team != 0)
+						{
+							player.TPlayer.team = 0;
+							NetMessage.SendData((int)PacketTypes.PlayerTeam, -1, -1, NetworkText.Empty, player.Index);
+						}
+					}
+
 					if (player.RPPending > 0)
 					{
 						if (player.RPPending == 1)


### PR DESCRIPTION
- Fix player spawn bypassing pvp with no team setting
- Prevent malicious client from fast-switching team with spawn packet
- Split up a check in HandlePlayerTeam to accomodate for team changes

As a side effect of the change to handling of team in the ``PlayerSpawn`` packet, it now must handle the vanilla logic on its own, to prevent malicious clients from changing their team too fast, and to also prevent this from bypassing the "pvpwithnoteam" pvp mode.