### PR TITLE
Fix pvp mode bugs

### DIFF
--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -113,9 +113,9 @@ namespace TShockAPI.Configuration
 		[Description("Enables never ending invasion events. You still need to start the event, such as with the /invade command.")]
 		public bool InfiniteInvasion;
 
-		/// <summary>Sets the PvP mode. Valid types are: "normal", "always", "pvpwithnoteam", "disabled".</summary>
-		[Description("Sets the PvP mode. Valid types are: \"normal\", \"always\", \"pvpwithnoteam\" and \"disabled\".")]
-		public string PvPMode = "normal";
+		/// <summary>Sets the PvP mode. Valid types are <see cref="TShockSettings.PvPMode"/>.</summary>
+		[Description($"Sets the PvP mode. Valid types are: \"{PvPModes.Normal}\", \"{PvPModes.Always}\", \"{PvPModes.PvPWithNoTeam}\" and \"{PvPModes.Disabled}\".")]
+		public string PvPMode = PvPModes.Normal;
 
 		/// <summary>Prevents tiles from being placed within SpawnProtectionRadius of the default spawn.</summary>
 		[Description("Prevents tiles from being placed within SpawnProtectionRadius of the default spawn.")]
@@ -716,5 +716,23 @@ namespace TShockAPI.Configuration
 
 			File.WriteAllText("docs/config-file-descriptions.md", sb.ToString());
 		}
+	}
+
+	/// <summary>
+	/// Constants for valid PvP mode strings used with <see cref="TShockSettings.PvPMode"/>.
+	/// </summary>
+	public static class PvPModes
+	{
+		/// <summary>Default mode – players choose whether to enable PvP.</summary>
+		public const string Normal = "normal";
+
+		/// <summary>PvP is permanently forced on for all players.</summary>
+		public const string Always = "always";
+
+		/// <summary>PvP is forced on, but only for players who are not on a team.</summary>
+		public const string PvPWithNoTeam = "pvpwithnoteam";
+
+		/// <summary>PvP is permanently disabled for all players.</summary>
+		public const string Disabled = "disabled";
 	}
 }

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2953,8 +2953,30 @@ namespace TShockAPI
 			byte team = args.Data.ReadInt8();
 			PlayerSpawnContext context = (PlayerSpawnContext)args.Data.ReadByte();
 
+			bool teamCorrectNeeded = false; // If we need to correct their team after handling
+			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
+
+			// To prevent clients from bypassing this pvp mode, we must correct their team
+			if (pvpMode == "pvpwithnoteam" && team != 0)
+			{
+				team = 0;
+				args.TPlayer.team = 0; // Make sure to set it to 0 (no team). This ensures it gets corrected.
+				teamCorrectNeeded = true;
+			}
+
+			// Malicious client likely trying to fast switch their team
+			if (team != args.Player.Team && args.Player.FinishedHandshake && (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+				teamCorrectNeeded = true;
+
 			if (args.Player.State >= (int)ConnectionState.RequestingWorldData && !args.Player.FinishedHandshake)
+			{
 				args.Player.FinishedHandshake = true; //If the player has requested world data before sending spawn player, they should be at the obvious ClientRequestedWorldData state. Also only set this once to remove redundant updates.
+				if (!Main.ServerSideCharacter && team != 0 && !teamCorrectNeeded) // Player will be requesting a team change later
+				{
+					args.Player.InitialTeamChangePending = true;
+					args.Player.LastPvPTeamChange = DateTime.UtcNow; // To prevent malicious clients from being able to get a free team change, we reset InitialTeamChangePending after 5 seconds
+				}
+			}
 
 			if (OnPlayerSpawn(args.Player, args.Data, player, spawnX, spawnY, respawnTimer, numberOfDeathsPVE, numberOfDeathsPVP, team, context))
 				return true;
@@ -3005,7 +3027,16 @@ namespace TShockAPI
 					return false;
 				}
 
-				args.TPlayer.team = team;
+				if (team != args.TPlayer.team)
+				{
+					if (teamCorrectNeeded)
+						team = (byte)args.TPlayer.team;
+					else
+						args.Player.LastPvPTeamChange = DateTime.UtcNow;
+
+					args.TPlayer.team = team;
+				}
+
 				args.TPlayer.Spawn(context);
 				// spawn the player before teleporting
 				NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)PlayerSpawnContext.ReviveFromDeath);
@@ -3018,9 +3049,55 @@ namespace TShockAPI
 				args.TPlayer.respawnTimer = respawnTimer;
 				args.TPlayer.numberOfDeathsPVE = numberOfDeathsPVE;
 				args.TPlayer.numberOfDeathsPVP = numberOfDeathsPVP;
+
+				// Correct their team after
+				if (teamCorrectNeeded)
+					args.Player.SendData(PacketTypes.PlayerTeam, "", args.Player.Index);
+
 				return true;
 			}
-			return false;
+
+			// Note: Because clients can change their team through this packet now, we have to always handle it ourselves to make sure we're syncing their team correctly.
+			if (teamCorrectNeeded) // Correction of malicious client's team change necessary, or we're enforcing the 'pvpwithnoteam' mode, where their team must be set to 0.
+				team = (byte)args.TPlayer.team; // This will always be 0 in 'pvpwithnoteam'
+
+			if (!args.Player.InitialTeamChangePending && args.TPlayer.team != team) // Client has changed team through this packet, track time since last team change
+				args.Player.LastPvPTeamChange = DateTime.UtcNow;
+
+			args.Player.TPlayer.team = team;
+			if (respawnTimer > 0)
+				args.Player.TPlayer.dead = true;
+
+			args.Player.TPlayer.Spawn(context);
+
+			// Handling of data from MessageBuffer, since we override this entirely now
+			if (args.Player.State == (int)ConnectionState.RequestingWorldData) // State 3
+			{
+				args.Player.State = (int)ConnectionState.Complete;
+				NetMessage.buffer[args.Player.Index].broadcast = true;
+				NetMessage.SyncConnectedPlayer(args.Player.Index);
+				bool flag11 = NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index);
+				Main.countsAsHostForGameplay[args.Player.Index] = flag11;
+				if (NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index))
+					NetMessage.TrySendData(139, args.Player.Index, -1, null, args.Player.Index, flag11.ToInt());
+
+				NetMessage.TrySendData(129, args.Player.Index);
+				NetMessage.greetPlayer(args.Player.Index);
+				if (args.Player.TPlayer.unlockedBiomeTorches)
+				{
+					NPC nPC = new NPC();
+					nPC.SetDefaults(664);
+					Main.BestiaryTracker.Kills.RegisterKill(nPC);
+				}
+			}
+
+			NetMessage.SendData((int)PacketTypes.PlayerSpawn, -1, args.Player.Index, null, args.Player.Index, (int)context);
+
+			if (teamCorrectNeeded)
+				args.Player.SendData(PacketTypes.PlayerTeam, "", args.Player.Index);
+
+			// We've handled it ourselves
+			return true;
 		}
 
 		private static bool HandlePlayerUpdate(GetDataHandlerArgs args)
@@ -3628,7 +3705,7 @@ namespace TShockAPI
 			if (id != args.Player.Index)
 				return true;
 
-			if (team == args.Player.Team) // No need to handle, interferes with SSC if we do.
+			if (!args.Player.InitialTeamChangePending && team == args.Player.Team) // No need to handle if initial change isn't pending, interferes with SSC if we do.
 				return true;
 
 			if (args.Player.IgnoreSSCPackets)
@@ -3639,7 +3716,23 @@ namespace TShockAPI
 			}
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "pvpwithnoteam" || (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+			if (pvpMode == "pvpwithnoteam")
+			{
+				args.Player.SendData(PacketTypes.PlayerTeam, "", id);
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam rejected from (pvp mode disallows teams) {0}", args.Player.Name));
+				return true;
+			}
+
+			// Player has pending team change
+			if (args.Player.InitialTeamChangePending)
+			{
+				args.Player.InitialTeamChangePending = false;
+				args.Player.LastPvPTeamChange = DateTime.MinValue; // Players can change teams or toggle pvp immediately after joining, so we have to allow such
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam super accepted from (initial team change) {0}", args.Player.Name));
+				return false;
+			}
+
+			if ((DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
 			{
 				args.Player.SendData(PacketTypes.PlayerTeam, "", id);
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam rejected team fastswitch {0}", args.Player.Name));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3065,7 +3065,11 @@ namespace TShockAPI
 				args.Player.LastPvPTeamChange = DateTime.UtcNow;
 
 			args.Player.TPlayer.team = team;
-			if (respawnTimer > 0)
+			args.TPlayer.respawnTimer = respawnTimer;
+			args.TPlayer.numberOfDeathsPVE = numberOfDeathsPVE;
+			args.TPlayer.numberOfDeathsPVP = numberOfDeathsPVP;
+
+			if (args.TPlayer.respawnTimer > 0)
 				args.Player.TPlayer.dead = true;
 
 			args.Player.TPlayer.Spawn(context);
@@ -3079,9 +3083,9 @@ namespace TShockAPI
 				bool flag11 = NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index);
 				Main.countsAsHostForGameplay[args.Player.Index] = flag11;
 				if (NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index))
-					NetMessage.TrySendData(139, args.Player.Index, -1, null, args.Player.Index, flag11.ToInt());
+					NetMessage.TrySendData((int)PacketTypes.SetCountsAsHostForGameplay, args.Player.Index, -1, null, args.Player.Index, flag11.ToInt());
 
-				NetMessage.TrySendData(129, args.Player.Index);
+				NetMessage.TrySendData((int)PacketTypes.FinishedConnectingToServer, args.Player.Index);
 				NetMessage.greetPlayer(args.Player.Index);
 				if (args.Player.TPlayer.unlockedBiomeTorches)
 				{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -29,6 +29,7 @@ using Terraria.GameContent.Tile_Entities;
 using Terraria.ID;
 using Terraria.Localization;
 using TShockAPI.Models.PlayerUpdate;
+using TShockAPI.Configuration;
 
 namespace TShockAPI
 {
@@ -2957,10 +2958,10 @@ namespace TShockAPI
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
 
 			// To prevent clients from bypassing this pvp mode, we must correct their team
-			if (pvpMode == "pvpwithnoteam" && team != 0)
+			if (pvpMode == PvPModes.PvPWithNoTeam && team != PlayerTeamID.None)
 			{
-				team = 0;
-				args.TPlayer.team = 0; // Make sure to set it to 0 (no team). This ensures it gets corrected.
+				team = (byte)PlayerTeamID.None;
+				args.TPlayer.team = PlayerTeamID.None; // Make sure to set it to 0 (no team). This ensures it gets corrected.
 				teamCorrectNeeded = true;
 			}
 
@@ -3080,18 +3081,18 @@ namespace TShockAPI
 				args.Player.State = (int)ConnectionState.Complete;
 				NetMessage.buffer[args.Player.Index].broadcast = true;
 				NetMessage.SyncConnectedPlayer(args.Player.Index);
-				bool flag11 = NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index);
-				Main.countsAsHostForGameplay[args.Player.Index] = flag11;
-				if (NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index))
-					NetMessage.TrySendData((int)PacketTypes.SetCountsAsHostForGameplay, args.Player.Index, -1, null, args.Player.Index, flag11.ToInt());
+				var isHost = NetMessage.DoesPlayerSlotCountAsAHost(args.Player.Index);
+				Main.countsAsHostForGameplay[args.Player.Index] = isHost;
+				if (isHost)
+					NetMessage.TrySendData((int)PacketTypes.SetCountsAsHostForGameplay, args.Player.Index, -1, null, args.Player.Index, true.ToInt());
 
 				NetMessage.TrySendData((int)PacketTypes.FinishedConnectingToServer, args.Player.Index);
 				NetMessage.greetPlayer(args.Player.Index);
 				if (args.Player.TPlayer.unlockedBiomeTorches)
 				{
-					NPC nPC = new NPC();
-					nPC.SetDefaults(664);
-					Main.BestiaryTracker.Kills.RegisterKill(nPC);
+					var npc = new NPC();
+					npc.SetDefaults(NPCID.TorchGod);
+					Main.BestiaryTracker.Kills.RegisterKill(npc);
 				}
 			}
 
@@ -3443,7 +3444,7 @@ namespace TShockAPI
 			}
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "disabled" || pvpMode == "always" || pvpMode == "pvpwithnoteam" || (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
+			if (pvpMode == PvPModes.Disabled || pvpMode == PvPModes.Always || pvpMode == PvPModes.PvPWithNoTeam || (DateTime.UtcNow - args.Player.LastPvPTeamChange).TotalSeconds < 5)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleTogglePvp rejected fastswitch {0}", args.Player.Name));
 				args.Player.SendData(PacketTypes.TogglePvp, "", id);
@@ -3720,7 +3721,7 @@ namespace TShockAPI
 			}
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "pvpwithnoteam")
+			if (pvpMode == PvPModes.PvPWithNoTeam)
 			{
 				args.Player.SendData(PacketTypes.PlayerTeam, "", id);
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandlePlayerTeam rejected from (pvp mode disallows teams) {0}", args.Player.Name));

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -24,6 +24,7 @@ using Terraria.GameContent.NetModules;
 using Terraria.Net;
 using Terraria.ID;
 using System;
+using TShockAPI.Configuration;
 
 namespace TShockAPI
 {
@@ -311,8 +312,8 @@ namespace TShockAPI
 			player.TPlayer.team = this.team;
 
 			string pvpMode = TShock.Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "pvpwithnoteam")
-				player.TPlayer.team = 0;
+			if (pvpMode == PvPModes.PvPWithNoTeam)
+				player.TPlayer.team = PlayerTeamID.None;
 
 			player.TPlayer.extraAccessory = extraSlot.HasValue && extraSlot.Value == 1 ? true : false;
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -402,6 +402,9 @@ namespace TShockAPI
 		/// <summary>Determines if the player has finished the handshake (Sent all necessary packets for connection, such as Request World Data, Spawn Player, etc). A normal client would do all of this no problem.</summary>
 		public bool FinishedHandshake = false;
 
+		/// <summary>Determines if the player will be sending a team change packet right after the initial spawn.</summary>
+		public bool InitialTeamChangePending = false;
+
 		/// <summary>Server-side character's recorded death count.</summary>
 		public int sscDeathsPVE = 0;
 
@@ -1670,7 +1673,7 @@ namespace TShockAPI
 		/// <summary>
 		/// Teleports the player to the world spawn point, or the respective team-bsed spawnpoint if the world uses them.
 		/// </summary>
-		/// /// <param name="ignoreTeamBasedSpawns">If team-based spawnpoints should be ignored.</param>
+		/// <param name="ignoreTeamBasedSpawns">If team-based spawnpoints should be ignored.</param>
 		/// <returns>True or false.</returns>
 		public bool TeleportToWorldSpawn(bool ignoreTeamBasedSpawns = false)
 		{

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1173,23 +1173,23 @@ namespace TShockAPI
 
 					// We need to make sure the pvp mode is enforced properly. Maybe this should be moved elsewhere?
 					string pvpMode = Config.Settings.PvPMode.ToLowerInvariant();
-					if (pvpMode != "normal")
+					if (pvpMode != PvPModes.Normal)
 					{
-						if (pvpMode == "disabled" && player.TPlayer.hostile) // player shouldn't be in pvp
+						if (pvpMode == PvPModes.Disabled && player.TPlayer.hostile) // player shouldn't be in pvp
 						{
 							player.TPlayer.hostile = false;
 							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
 						}
 
-						if ((pvpMode == "always" || pvpMode == "pvpwithnoteam") && !player.TPlayer.hostile) // player isn't in pvp when they should be
+						if ((pvpMode == PvPModes.Always || pvpMode == PvPModes.PvPWithNoTeam) && !player.TPlayer.hostile) // player isn't in pvp when they should be
 						{
 							player.TPlayer.hostile = true;
 							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
 						}
 
-						if (pvpMode == "pvpwithnoteam" && player.Team != 0) // player is on a team when they shouldn't be
+						if (pvpMode == PvPModes.PvPWithNoTeam && player.Team != PlayerTeamID.None) // player is on a team when they shouldn't be
 						{
-							player.TPlayer.team = 0;
+							player.TPlayer.team = PlayerTeamID.None;
 							NetMessage.SendData((int)PacketTypes.PlayerTeam, -1, -1, NetworkText.Empty, player.Index);
 						}
 					}
@@ -1690,7 +1690,7 @@ namespace TShockAPI
 			}
 			return chatMsg;
 		}
-    
+
 		private static readonly HashSet<PacketTypes> AllowedEarlyPackets =
 		[
 			PacketTypes.ConnectRequest,
@@ -1779,7 +1779,7 @@ namespace TShockAPI
 			player.SendFileTextAsMessage(FileTools.MotdPath);
 
 			string pvpMode = Config.Settings.PvPMode.ToLowerInvariant();
-			if (pvpMode == "always" || pvpMode == "pvpwithnoteam")
+			if (pvpMode is PvPModes.Always or PvPModes.PvPWithNoTeam)
 			{
 				player.TPlayer.hostile = true;
 				player.SendData(PacketTypes.TogglePvp, "", player.Index);

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1166,6 +1166,34 @@ namespace TShockAPI
 						TShock.Log.ConsoleDebug(GetString("OnSecondUpdate / initial ssc spawn for {0} at ({1}, {2})", player.Name, player.TPlayer.SpawnX, player.TPlayer.SpawnY));
 					}
 
+					// If a client didn't send a team change within 5 seconds of a pending team change from spawning, they're likely hacking.
+					// So we clear this flag to remove their one-time free team change.
+					if (player.InitialTeamChangePending && (DateTime.UtcNow - player.LastPvPTeamChange).TotalSeconds >= 5)
+						player.InitialTeamChangePending = false;
+
+					// We need to make sure the pvp mode is enforced properly. Maybe this should be moved elsewhere?
+					string pvpMode = Config.Settings.PvPMode.ToLowerInvariant();
+					if (pvpMode != "normal")
+					{
+						if (pvpMode == "disabled" && player.TPlayer.hostile) // player shouldn't be in pvp
+						{
+							player.TPlayer.hostile = false;
+							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
+						}
+
+						if ((pvpMode == "always" || pvpMode == "pvpwithnoteam") && !player.TPlayer.hostile) // player isn't in pvp when they should be
+						{
+							player.TPlayer.hostile = true;
+							NetMessage.SendData((int)PacketTypes.TogglePvp, -1, -1, null, player.Index);
+						}
+
+						if (pvpMode == "pvpwithnoteam" && player.Team != 0) // player is on a team when they shouldn't be
+						{
+							player.TPlayer.team = 0;
+							NetMessage.SendData((int)PacketTypes.PlayerTeam, -1, -1, NetworkText.Empty, player.Index);
+						}
+					}
+
 					if (player.RPPending > 0)
 					{
 						if (player.RPPending == 1)


### PR DESCRIPTION
This is a redo of #3237 without any conventional commits this time.
- fix players bypassing 'pvpwithnoteam' from spawn packet
- fix team fastswitch from player spawn packet
- fix initial team change message not being broadcast on player spawning in
- check player team and pvp status in ``OnSecondUpdate`` to enforce current pvp mode