### PR TITLE
Add "keep player appearance" option to SSC

### DIFF
--- a/TShockAPI/Configuration/ServerSideConfig.cs
+++ b/TShockAPI/Configuration/ServerSideConfig.cs
@@ -72,6 +72,12 @@ namespace TShockAPI.Configuration
 		/// </summary>
 		[Description("Warns players and the console if a player has the tshock.ignore.ssc permission with data in the SSC table.")]
 		public bool WarnPlayersAboutBypassPermission = true;
+
+		/// <summary>
+		/// If players should keep their local character appearance in SSC.
+		/// </summary>
+		[Description("If players should keep their local character appearance in SSC.")]
+		public bool KeepPlayerAppearance = false;
 	}
 
 	/// <summary>

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -316,28 +316,31 @@ namespace TShockAPI
 
 			player.TPlayer.extraAccessory = extraSlot.HasValue && extraSlot.Value == 1 ? true : false;
 
-			if (this.voiceVariant != null)
-				player.TPlayer.voiceVariant = this.voiceVariant.Value;
-			if (this.voicePitchOffset != null)
-				player.TPlayer.voicePitchOffset = this.voicePitchOffset.Value;
-			if (this.skinVariant != null)
-				player.TPlayer.skinVariant = this.skinVariant.Value;
-			if (this.hair != null)
-				player.TPlayer.hair = this.hair.Value;
-			if (this.hairColor != null)
-				player.TPlayer.hairColor = this.hairColor.Value;
-			if (this.pantsColor != null)
-				player.TPlayer.pantsColor = this.pantsColor.Value;
-			if (this.shirtColor != null)
-				player.TPlayer.shirtColor = this.shirtColor.Value;
-			if (this.underShirtColor != null)
-				player.TPlayer.underShirtColor = this.underShirtColor.Value;
-			if (this.shoeColor != null)
-				player.TPlayer.shoeColor = this.shoeColor.Value;
-			if (this.skinColor != null)
-				player.TPlayer.skinColor = this.skinColor.Value;
-			if (this.eyeColor != null)
-				player.TPlayer.eyeColor = this.eyeColor.Value;
+			if (!TShock.ServerSideCharacterConfig.Settings.KeepPlayerAppearance)
+			{
+				if (this.voiceVariant != null)
+					player.TPlayer.voiceVariant = this.voiceVariant.Value;
+				if (this.voicePitchOffset != null)
+					player.TPlayer.voicePitchOffset = this.voicePitchOffset.Value;
+				if (this.skinVariant != null)
+					player.TPlayer.skinVariant = this.skinVariant.Value;
+				if (this.hair != null)
+					player.TPlayer.hair = this.hair.Value;
+				if (this.hairColor != null)
+					player.TPlayer.hairColor = this.hairColor.Value;
+				if (this.pantsColor != null)
+					player.TPlayer.pantsColor = this.pantsColor.Value;
+				if (this.shirtColor != null)
+					player.TPlayer.shirtColor = this.shirtColor.Value;
+				if (this.underShirtColor != null)
+					player.TPlayer.underShirtColor = this.underShirtColor.Value;
+				if (this.shoeColor != null)
+					player.TPlayer.shoeColor = this.shoeColor.Value;
+				if (this.skinColor != null)
+					player.TPlayer.skinColor = this.skinColor.Value;
+				if (this.eyeColor != null)
+					player.TPlayer.eyeColor = this.eyeColor.Value;
+			}
 
 			if (this.hideVisuals != null)
 				player.TPlayer.hideVisibleAccessory = this.hideVisuals;

--- a/TShockAPI/PlayerData.cs
+++ b/TShockAPI/PlayerData.cs
@@ -291,7 +291,10 @@ namespace TShockAPI
 			player.TPlayer.statManaMax = this.maxMana;
 			player.TPlayer.SpawnX = this.spawnX;
 			player.TPlayer.SpawnY = this.spawnY;
-			player.TPlayer.hairDye = this.hairDye;
+
+			if (!TShock.ServerSideCharacterConfig.Settings.KeepPlayerAppearance)
+				player.TPlayer.hairDye = this.hairDye;
+
 			player.TPlayer.anglerQuestsFinished = this.questsCompleted;
 			player.TPlayer.UsingBiomeTorches = this.usingBiomeTorches == 1;
 			player.TPlayer.happyFunTorchTime = this.happyFunTorchTime == 1;


### PR DESCRIPTION
This PR adds an option to SSC that retains the player's offline character appearance.
This does **NOT** keep any local items, just character data such as hair, skin color, clothing style, etc.