### PR TITLE
Fix boss summon bypass

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1266,6 +1266,15 @@ namespace TShockAPI
 				args.Handled = true;
 				return;
 			}
+
+			if (type == ItemID.GuideVoodooDoll && !args.Player.HasPermission(Permissions.summonboss))
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected Guide Voodoo Doll drop from {0}", args.Player.Name));
+				args.Player.SendErrorMessage(GetString("You do not have permission to summon the Wall of Flesh."));
+				args.Player.SendData(PacketTypes.SyncItemDespawn, "", id);
+				args.Handled = true;
+				return;
+			}
 		}
 
 		/// <summary>Bouncer's projectile trigger hook stops world damaging projectiles from destroying the world.</summary>

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1267,7 +1267,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (type == ItemID.GuideVoodooDoll && !args.Player.HasPermission(Permissions.summonboss))
+			if (type == ItemID.GuideVoodooDoll && pos.Y / 16f >= Main.maxTilesY - 205 && !args.Player.HasPermission(Permissions.summonboss))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected Guide Voodoo Doll drop from {0}", args.Player.Name));
 				args.Player.SendErrorMessage(GetString("You do not have permission to summon the Wall of Flesh."));

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1267,7 +1267,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (type == ItemID.GuideVoodooDoll && pos.Y / 16f >= Main.maxTilesY - 205 && !args.Player.HasPermission(Permissions.summonboss))
+			if (type == ItemID.GuideVoodooDoll && args.Player.TPlayer.ZoneUnderworldHeight && !args.Player.HasPermission(Permissions.summonboss))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected Guide Voodoo Doll drop from {0}", args.Player.Name));
 				args.Player.SendErrorMessage(GetString("You do not have permission to summon the Wall of Flesh."));

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -672,15 +672,22 @@ namespace TShockAPI
 					return;
 				}
 
-				if (action == EditAction.KillTile && Main.tile[tileX, tileY].type == TileID.PlanteraBulb)
 				{
-					if (!args.Player.HasPermission(Permissions.summonboss))
+					// Check if this tile is a Plantera Bulb or a support tile beneath one
+					bool isPlanteraBulb = Main.tile[tileX, tileY].active() && Main.tile[tileX, tileY].type == TileID.PlanteraBulb;
+					bool isSupportTile = tileY - 1 >= 0
+						&& Main.tile[tileX, tileY - 1].active() && Main.tile[tileX, tileY - 1].type == TileID.PlanteraBulb;
+
+					if (isPlanteraBulb || isSupportTile)
 					{
-						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected Plantera bulb destroy from {0}", args.Player.Name));
-						args.Player.SendErrorMessage(GetString("You do not have permission to summon Plantera."));
-						args.Player.SendTileSquareCentered(tileX, tileY, 4);
-						args.Handled = true;
-						return;
+						if (!args.Player.HasPermission(Permissions.summonboss))
+						{
+							TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected Plantera bulb destroy from {0}", args.Player.Name));
+							args.Player.SendErrorMessage(GetString("You do not have permission to summon Plantera."));
+							args.Player.SendTileSquareCentered(tileX, tileY, 4);
+							args.Handled = true;
+							return;
+						}
 					}
 				}
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -672,6 +672,18 @@ namespace TShockAPI
 					return;
 				}
 
+				if (action == EditAction.KillTile && Main.tile[tileX, tileY].type == TileID.PlanteraBulb)
+				{
+					if (!args.Player.HasPermission(Permissions.summonboss))
+					{
+						TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected Plantera bulb destroy from {0}", args.Player.Name));
+						args.Player.SendErrorMessage(GetString("You do not have permission to summon Plantera."));
+						args.Player.SendTileSquareCentered(tileX, tileY, 4);
+						args.Handled = true;
+						return;
+					}
+				}
+
 				if (args.Player.Dead && TShock.Config.Settings.PreventDeadModification)
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnTileEdit rejected from (pdm) {0} {1} {2}", args.Player.Name, action, editData));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3825,7 +3825,7 @@ namespace TShockAPI
 			var plr = args.Data.ReadInt16();
 			var thingType = args.Data.ReadInt16();
 
-			var isKnownBoss = (thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType]) || thingType == -16 || thingType == 113;
+			var isKnownBoss = (thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType]) || thingType == -16;
 			if (isKnownBoss && !args.Player.HasPermission(Permissions.summonboss))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawnBoss rejected boss {0} {1}", args.Player.Name, thingType));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3694,6 +3694,7 @@ namespace TShockAPI
 				if (!args.Player.HasPermission(Permissions.summonboss))
 				{
 					args.Player.SendErrorMessage(GetString("You do not have permission to summon the Skeletron."));
+					args.Player.SendData(PacketTypes.NpcUpdate, "", id);
 					TShock.Log.ConsoleDebug(GetString($"GetDataHandlers / HandleNpcStrike rejected Skeletron summon from {args.Player.Name}"));
 					return true;
 				}
@@ -3824,7 +3825,7 @@ namespace TShockAPI
 			var plr = args.Data.ReadInt16();
 			var thingType = args.Data.ReadInt16();
 
-			var isKnownBoss = (thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType]) || thingType == -16;
+			var isKnownBoss = (thingType > 0 && thingType < Terraria.ID.NPCID.Count && NPCID.Sets.MPAllowedEnemies[thingType]) || thingType == -16 || thingType == 113;
 			if (isKnownBoss && !args.Player.HasPermission(Permissions.summonboss))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawnBoss rejected boss {0} {1}", args.Player.Name, thingType));


### PR DESCRIPTION
Block Plantera summon by preventing Plantera Bulb destruction without `summonboss` permission
Sync Old Man NPC state back to client when Skeletron summon is rejected
Block Wall of Flesh summon by intercepting Guide Voodoo Doll item drop without `summonboss` permission

Note: 
For wof:
when blocked, the Guide Voodoo Doll is already consumed and will not be returned to the player; wof summon via Guide NPC dying in lava and voodoo doll dropped by voodoo demons naturally are not covered by this fix. If you have an alternative feel free to present

For Plantera:
From wiki:
<img width="2006" height="612" alt="image" src="https://github.com/user-attachments/assets/badc02fd-c124-4418-a46b-e6f8af34586e" />
The protection behaves like a region — all methods except lava contact are covered, as lava-triggered destruction is server-side and cannot be intercepted(flowing lava can also destroy protected region)
Fixes #3243 

btw I can't summon cultist or skeletron without permission