### PR TITLE
Fix stone wall conversion

### DIFF
--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -1231,9 +1231,9 @@ namespace TShockAPI.Handlers
 					}
 					break;
 				case 7:
-					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 349)
+					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != WallID.StoneUnsafe)
 					{
-						tile.wall = 349; // wall 349 (StoneUnsafe) found in WorldGen.Convert when looking for WallID.Sets.Conversion.Stone, replaces use of wall 1 (Stone)
+						tile.wall = WallID.StoneUnsafe;
 					}
 					else if ((WallID.Sets.Conversion.HardenedSand[wall] || WallID.Sets.Conversion.Snow[wall] || WallID.Sets.Conversion.Dirt[wall]) && wall != 2)
 					{
@@ -1290,9 +1290,9 @@ namespace TShockAPI.Handlers
 					tile.wall = 64;
 				}
 			}
-			else if (WallID.Sets.Conversion.Stone[wall] && wall != 349 && wall != 262 && wall != 274 && wall != 61 && wall != 185)
+			else if (WallID.Sets.Conversion.Stone[wall] && wall != WallID.StoneUnsafe && wall != 262 && wall != 274 && wall != 61 && wall != 185)
 			{
-				tile.wall = 349; // wall 349 (StoneUnsafe) found in WorldGen.Convert when looking for WallID.Sets.Conversion.Stone, replaces use of wall 1 (Stone)
+				tile.wall = WallID.StoneUnsafe;
 			}
 			else if (WallID.Sets.Conversion.Stone[wall] && wall == 262)
 			{

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -1231,9 +1231,9 @@ namespace TShockAPI.Handlers
 					}
 					break;
 				case 7:
-					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 1)
+					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 349)
 					{
-						tile.wall = 1;
+						tile.wall = 349;
 					}
 					else if ((WallID.Sets.Conversion.HardenedSand[wall] || WallID.Sets.Conversion.Snow[wall] || WallID.Sets.Conversion.Dirt[wall]) && wall != 2)
 					{
@@ -1290,9 +1290,9 @@ namespace TShockAPI.Handlers
 					tile.wall = 64;
 				}
 			}
-			else if (WallID.Sets.Conversion.Stone[wall] && wall != 1 && wall != 262 && wall != 274 && wall != 61 && wall != 185)
+			else if (WallID.Sets.Conversion.Stone[wall] && wall != 349 && wall != 262 && wall != 274 && wall != 61 && wall != 185)
 			{
-				tile.wall = 1;
+				tile.wall = 349;
 			}
 			else if (WallID.Sets.Conversion.Stone[wall] && wall == 262)
 			{

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -1233,7 +1233,7 @@ namespace TShockAPI.Handlers
 				case 7:
 					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 349)
 					{
-						tile.wall = 349;
+						tile.wall = 349; // wall 349 (StoneUnsafe) found in WorldGen.Convert when looking for WallID.Sets.Conversion.Stone, replaces use of wall 1 (Stone)
 					}
 					else if ((WallID.Sets.Conversion.HardenedSand[wall] || WallID.Sets.Conversion.Snow[wall] || WallID.Sets.Conversion.Dirt[wall]) && wall != 2)
 					{
@@ -1292,7 +1292,7 @@ namespace TShockAPI.Handlers
 			}
 			else if (WallID.Sets.Conversion.Stone[wall] && wall != 349 && wall != 262 && wall != 274 && wall != 61 && wall != 185)
 			{
-				tile.wall = 349;
+				tile.wall = 349; // wall 349 (StoneUnsafe) found in WorldGen.Convert when looking for WallID.Sets.Conversion.Stone, replaces use of wall 1 (Stone)
 			}
 			else if (WallID.Sets.Conversion.Stone[wall] && wall == 262)
 			{


### PR DESCRIPTION
Fixes the ``WorldGenMock`` conversion for walls to replace uses of ``Stone`` (1) with ``StoneUnsafe`` (349) as 1.4.5 no longer use safe stone walls in conversions, so purifying evils no longer gets incorrectly rejected