### PR TITLE
Fix unsafe stone wall failing to match in conversions

### DIFF
--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -1231,9 +1231,9 @@ namespace TShockAPI.Handlers
 					}
 					break;
 				case 7:
-					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != 1)
+					if ((WallID.Sets.Conversion.Stone[wall] || WallID.Sets.Conversion.Ice[wall] || WallID.Sets.Conversion.Sandstone[wall]) && wall != WallID.StoneUnsafe)
 					{
-						tile.wall = 1;
+						tile.wall = WallID.StoneUnsafe;
 					}
 					else if ((WallID.Sets.Conversion.HardenedSand[wall] || WallID.Sets.Conversion.Snow[wall] || WallID.Sets.Conversion.Dirt[wall]) && wall != 2)
 					{
@@ -1290,9 +1290,9 @@ namespace TShockAPI.Handlers
 					tile.wall = 64;
 				}
 			}
-			else if (WallID.Sets.Conversion.Stone[wall] && wall != 1 && wall != 262 && wall != 274 && wall != 61 && wall != 185)
+			else if (WallID.Sets.Conversion.Stone[wall] && wall != WallID.StoneUnsafe && wall != 262 && wall != 274 && wall != 61 && wall != 185)
 			{
-				tile.wall = 1;
+				tile.wall = WallID.StoneUnsafe;
 			}
 			else if (WallID.Sets.Conversion.Stone[wall] && wall == 262)
 			{


### PR DESCRIPTION
Redo of #3251 to properly follow contributing guidelines.

``WorldGenMock`` now uses ``StoneWallUnsafe`` instead of ``Stone`` when simulating conversions, as 1.4.5 now uses this wall instead.