### PR TITLE
Revamp the Nuget publish workflow

### DIFF
--- a/.github/workflows/ci-otapi3-nuget.yml
+++ b/.github/workflows/ci-otapi3-nuget.yml
@@ -1,12 +1,11 @@
-name: Deploy NuGet(OTAPI3)
+name: Publish NuGet
 
 on:
-  push:
-    branches: [ nuget-release ]
+  release:
+    types: [published]
 
 jobs:
-  build:
-
+  publish:
     runs-on: ubuntu-latest
     environment: release
 
@@ -14,17 +13,28 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
+
+    - name: Check csproj version matches release tag
+      run: |
+        CSPROJ_VERSION=$(grep -oP '(?<=<Version>)[^<]+' TShockAPI/TShockAPI.csproj)
+        TAG_VERSION=${GITHUB_REF_NAME#v}
+        if [ "$CSPROJ_VERSION" != "$TAG_VERSION" ]; then
+          echo "::warning::<Version> in TShockAPI.csproj is $CSPROJ_VERSION but the release tag is $TAG_VERSION. The NuGet package will use $TAG_VERSION. Consider updating the csproj to match."
+        fi
+
     - name: Restore dependencies
       run: dotnet restore
+
     - name: Build
-      run: dotnet build TShock.sln --configuration Release --no-restore
+      run: dotnet build TShock.sln --configuration Release --no-restore -p:PackageVersion=${GITHUB_REF_NAME#v}
+
     - name: Test
       run: dotnet test --no-build --verbosity normal --configuration Release
 
-    # Publish to nuget
-    - name: Push TShockAPI
-      run: dotnet nuget push TShockAPI/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+    - name: Push to NuGet
+      run: dotnet nuget push TShockAPI/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/TShockAPI/TShockAPI.csproj
+++ b/TShockAPI/TShockAPI.csproj
@@ -16,7 +16,9 @@
           location, which previously held the date and time.
 
       Also, be sure to release on github with the exact assembly version tag as below
-      so that the update manager works correctly (via the Github releases api and mimic)
+      so that the update manager works correctly (via the Github releases api and mimic).
+      Otherwise the Nuget package will have a version mismatch with the version here.
+      Prerelease upgrades should not update this version—only do so for the full release.
     -->
     <Version>5.9.9</Version>
     <AssemblyTitle>TShock for Terraria</AssemblyTitle>


### PR DESCRIPTION
- The workflow now runs every time a release is created, rather than when a commit is pushed into the nuget-release branch.
- If there's a mismatch between the release tag and the project tag, the release tag will take precedence. If such a version override happens, there will be a workflow warning.
- It is recommended that for pre-releases, you don't update the version number in the csproj file. This will ensure that UpdateManager.cs continues to work as expected (it does not currently handle version numbers with a prerelease suffix, and otherwise we'd have to add logic to not alert for prerelease updates). But once you have a mainline release, the version number should be updated.

The goal here is to eliminate all human error that would cause the Nuget package to ever not be updated. If there is a GitHub release, the Nuget release will always be there, including for pre-releases.

The utility of the Nuget package is greatly diminished if it isn't consistently up-to-date. I was planning soon to update a bunch of plugins to the latest pre-release, many of which currently reference TShock using the Nuget package. Having the benefits of a package reference at one point, and then being forced to go back to a binary reference later on, and then just continuing to switch back and forth, makes for a less ergonomic updating experience.

Changelog updates: N/A