### PR TITLE
Update .NET 6 download link to .NET 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is the readme for TShock developers and hackers. We're building out new [TS
 
 If you want to contribute to TShock by sending a pull request or customize it to suit your own sparkly desires, this is the best starting point. By the end of this, you'll be able to build TShock from source, start to finish. More than that, though, you'll know how to start on the path of becoming an expert TShock developer.
 
-This guide works assuming that you have the [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) installed and that you're familiar with the command line. If that doesn't describe you, you should be able to accomplish the same thing using Visual Studio 2022 or Visual Studio Code.
+This guide works assuming that you have the [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) installed and that you're familiar with the command line. If that doesn't describe you, you should be able to accomplish the same thing using Visual Studio 2022 or Visual Studio Code.
 
 1. Clone the repository: `git clone https://github.com/Pryaxis/TShock.git --recurse-submodules`
 1. `cd TShock` to enter the repo.

--- a/README_cn.md
+++ b/README_cn.md
@@ -16,7 +16,7 @@ TShock是为泰拉瑞亚服务器和社区开发的一个工具箱。这个工�
 
 如果你想通过PR给TShock贡献代码或者想按照你美妙的想法定制它，这里是最好的出发点。看完之后你就能独立从源码编译出TShock。不止这样，你还能知道如何成为一名出色的TShock开发者。
 
-本指南假设你已经安装了[.NET 6 SDK](https://dotnet.microsoft.com/zh-cn/download/dotnet/6.0)并了解命令行。如果你不满足这些条件，你应该能通过Visual Studio 2022或者Visual Studio Code做到同样的事情。
+本指南假设你已经安装了[.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)并了解命令行。如果你不满足这些条件，你应该能通过Visual Studio 2022或者Visual Studio Code做到同样的事情。
 
 1. 克隆仓库：`git clone https://github.com/Pryaxis/TShock.git --recurse-submodules`
 1. 运行`cd TShock`来进入仓库文件夹

--- a/README_cn.md
+++ b/README_cn.md
@@ -16,7 +16,7 @@ TShock是为泰拉瑞亚服务器和社区开发的一个工具箱。这个工�
 
 如果你想通过PR给TShock贡献代码或者想按照你美妙的想法定制它，这里是最好的出发点。看完之后你就能独立从源码编译出TShock。不止这样，你还能知道如何成为一名出色的TShock开发者。
 
-本指南假设你已经安装了[.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)并了解命令行。如果你不满足这些条件，你应该能通过Visual Studio 2022或者Visual Studio Code做到同样的事情。
+本指南假设你已经安装了[.NET 9 SDK](https://dotnet.microsoft.com/zh-cn/download/dotnet/9.0)并了解命令行。如果你不满足这些条件，你应该能通过Visual Studio 2022或者Visual Studio Code做到同样的事情。
 
 1. 克隆仓库：`git clone https://github.com/Pryaxis/TShock.git --recurse-submodules`
 1. 运行`cd TShock`来进入仓库文件夹


### PR DESCRIPTION
As the title says, the link to download .NET is still set to 6 while the repository uses .NET 9.
This simply changes the link to use .NET 9 in both the EN and CN README.