### PR TITLE
add handler for DisplayDollPoseSync

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -41,6 +41,7 @@ namespace TShockAPI
 		internal Handlers.EmojiHandler EmojiHandler { get; private set; }
 		internal Handlers.IllegalPerSe.EmojiPlayerMismatch EmojiPlayerMismatch { get; private set; }
 		internal Handlers.DisplayDollItemSyncHandler DisplayDollItemSyncHandler { get; private set; }
+		internal Handlers.DisplayDollPoseSyncHandler DisplayDollPoseSyncHandler { get; private set; }
 		internal Handlers.RequestTileEntityInteractionHandler RequestTileEntityInteractionHandler { get; private set; }
 		internal Handlers.LandGolfBallInCupHandler LandGolfBallInCupHandler { get; private set; }
 		internal Handlers.SyncTilePickingHandler SyncTilePickingHandler { get; private set; }
@@ -98,6 +99,9 @@ namespace TShockAPI
 
 			DisplayDollItemSyncHandler = new Handlers.DisplayDollItemSyncHandler();
 			GetDataHandlers.DisplayDollItemSync += DisplayDollItemSyncHandler.OnReceive;
+
+			DisplayDollPoseSyncHandler = new Handlers.DisplayDollPoseSyncHandler();
+			GetDataHandlers.DisplayDollPoseSync += DisplayDollPoseSyncHandler.OnReceive;
 
 			RequestTileEntityInteractionHandler = new Handlers.RequestTileEntityInteractionHandler();
 			GetDataHandlers.RequestTileEntityInteraction += RequestTileEntityInteractionHandler.OnReceive;

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2169,9 +2169,14 @@ namespace TShockAPI
 			Dyes = 1,
 
 			/// <summary>
+			/// The ID of the pose. Not actually an item inventory.
+			/// </summary>
+			Pose = 2,
+
+			/// <summary>
 			/// The ID of the inventory holding the miscellaneous items (mounts, pets, etc.).
 			/// </summary>
-			Misc = 2,
+			Misc = 3
 		}
 		/// <summary>
 		/// For use in a TileEntityDisplayDollItemSync event.

--- a/TShockAPI/Handlers/DisplayDollPoseSyncHandler.cs
+++ b/TShockAPI/Handlers/DisplayDollPoseSyncHandler.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static TShockAPI.GetDataHandlers;
+
+namespace TShockAPI.Handlers
+{
+	/// <summary>
+	/// Handles the TileEntityDisplayDollPoseSync packets and checks for permissions.
+	/// </summary>
+	public class DisplayDollPoseSyncHandler : IPacketHandler<DisplayDollPoseSyncEventArgs>
+	{
+		public void OnReceive(object sender, DisplayDollPoseSyncEventArgs args)
+		{
+			if (!args.Player.HasBuildPermission(args.DisplayDollEntity.Position.X, args.DisplayDollEntity.Position.Y, false))
+			{
+				args.Player.SendErrorMessage(GetString("You do not have permission to modify a Mannequin in a protected area!"));
+				// Note - itemIndex is unused, so it remains 0 here.
+				args.Player.SendData(PacketTypes.TileEntityDisplayDollItemSync, "", 255, args.TileEntityID, 0, (int)DisplayDollInventoryID.Pose);
+				args.Handled = true;
+				return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds a handler for DisplayDollPoseSync to prevent players from posing protected mannequins. Also makes a correction to ``DisplayDollInventoryID`` - ``Misc`` is actually 3 according to the game (can be found in ``Terraria.GameConent.Tile_Entities.TEDisplayDoll.Read``), while ``Pose`` is 2. So Pose was added as 2 and Misc was moved to 3.

Please let me know if further changs should be made. Was reluctant to rename ``DisplayDollInventoryID``, if it would be appropriate to, I can do so.