### PR TITLE
add handling for ChestSizeSync packet

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4986,7 +4986,7 @@ namespace TShockAPI
 			short id = args.Data.ReadInt16();
 			short newSize = args.Data.ReadInt16();
 
-			if (id < 0 || id > 8000) // chest is invalid
+			if (id < 0 || id >= 8000) // chest is invalid
 				return true;
 
 			Chest chest = Main.chest[id];
@@ -4994,6 +4994,20 @@ namespace TShockAPI
 			if (chest == null)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from null chest {0}", args.Player.Name));
+				return true;
+			}
+
+			if (args.Player.IsBeingDisabled())
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from disabled {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				return true;
+			}
+
+			if (args.Player.IsBouncerThrottled())
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from throttled {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
 				return true;
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -4986,7 +4986,7 @@ namespace TShockAPI
 			short id = args.Data.ReadInt16();
 			short newSize = args.Data.ReadInt16();
 
-			if (id < 0 || id >= 8000) // chest is invalid
+			if (id is < 0 or >= Main.maxChests) // chest is invalid
 				return true;
 
 			Chest chest = Main.chest[id];

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -5000,14 +5000,14 @@ namespace TShockAPI
 			if (args.Player.IsBeingDisabled())
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from disabled {0}", args.Player.Name));
-				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.maxItems);
 				return true;
 			}
 
 			if (args.Player.IsBouncerThrottled())
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from throttled {0}", args.Player.Name));
-				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.maxItems);
 				return true;
 			}
 
@@ -5021,14 +5021,14 @@ namespace TShockAPI
 			if (!args.Player.HasBuildPermission(chest.x, chest.y))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from build {0}", args.Player.Name));
-				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.maxItems);
 				return true;
 			}
 
 			if (newSize < 0) // size is invalid
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from invalid size {0}", args.Player.Name));
-				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.maxItems);
 				return true;
 			}
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -144,7 +144,8 @@ namespace TShockAPI
 					{ PacketTypes.SyncCavernMonsterType, HandleSyncCavernMonsterType },
 					{ PacketTypes.SyncLoadout, HandleSyncLoadout },
 					{ PacketTypes.TeamChangeFromUI, HandlePlayerTeam }, // Same packet as PlayerTeam
-					{ PacketTypes.TEDeadCellsDisplayJar, HandleDisplayJar }
+					{ PacketTypes.TEDeadCellsDisplayJar, HandleDisplayJar },
+					{ PacketTypes.SyncChestSize, HandleChestSizeSync }
 				};
 		}
 
@@ -4976,6 +4977,46 @@ namespace TShockAPI
 
 			if (OnDisplayJarTryPlacing(args.Player, args.Data, tileX, tileY, itemID, prefix, stack))
 				return true;
+
+			return false;
+		}
+
+		private static bool HandleChestSizeSync(GetDataHandlerArgs args)
+		{
+			short id = args.Data.ReadInt16();
+			short newSize = args.Data.ReadInt16();
+
+			if (id < 0 || id > 8000) // chest is invalid
+				return true;
+
+			Chest chest = Main.chest[id];
+
+			if (chest == null)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from null chest {0}", args.Player.Name));
+				return true;
+			}
+
+			if (!args.Player.HasPermission(Permissions.resizechests))
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from no permission {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				return true;
+			}
+
+			if (!args.Player.HasBuildPermission(chest.x, chest.y))
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from build {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				return true;
+			}
+
+			if (newSize < 0) // size is invalid
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from invalid size {0}", args.Player.Name));
+				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				return true;
+			}
 
 			return false;
 		}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -5014,7 +5014,7 @@ namespace TShockAPI
 			if (!args.Player.HasPermission(Permissions.resizechests))
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleChestSizeSync rejected from no permission {0}", args.Player.Name));
-				args.Player.SendData(PacketTypes.SyncChestSize, "", id, chest.item.Length);
+				args.Player.Kick(GetString("Exploit attempt detected!"), true);
 				return true;
 			}
 

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -515,6 +515,9 @@ namespace TShockAPI
 
 		[Description("Player can send emotes.")]
 		public static readonly string sendemoji = "tshock.sendemoji";
+
+		[Description("Player can resize chests. Warning: Dangerous permission to grant, very easy to abuse.")]
+		public static readonly string resizechests = "tshock.resizechests";
 		#endregion
 		/// <summary>
 		/// Lists all commands associated with a given permission

--- a/TShockAPI/Permissions.cs
+++ b/TShockAPI/Permissions.cs
@@ -172,6 +172,10 @@ namespace TShockAPI
 
 		[Description("Prevents you from being disabled by abnormal MP.")]
 		public static readonly string ignoremp = "tshock.ignore.mp";
+
+
+		[Description("Player can resize chests. Warning: Dangerous permission to grant, very easy to abuse.")]
+		public static readonly string resizechests = "tshock.ignore.resizechests";
 		#endregion
 
 		#region tshock.item nodes
@@ -515,9 +519,6 @@ namespace TShockAPI
 
 		[Description("Player can send emotes.")]
 		public static readonly string sendemoji = "tshock.sendemoji";
-
-		[Description("Player can resize chests. Warning: Dangerous permission to grant, very easy to abuse.")]
-		public static readonly string resizechests = "tshock.resizechests";
 		#endregion
 		/// <summary>
 		/// Lists all commands associated with a given permission


### PR DESCRIPTION
This adds handling and a permission for the chest size sync packet (155), due to a reported potential memory leak being caused by "chests and items" in the Pryaxis discord.

<img width="1148" height="200" alt="image" src="https://github.com/user-attachments/assets/f4201229-fb64-497c-ac1d-114b63fff706" />

~~ReLogic, why do you add these kinds of things and then don't make sure only the server can send them?~~