### PR TITLE
Revert "Filter out [ct:xxx] tags to prevent PE client crashes"

### DIFF
--- a/TShockAPI/Configuration/TShockConfig.cs
+++ b/TShockAPI/Configuration/TShockConfig.cs
@@ -464,10 +464,6 @@ namespace TShockAPI.Configuration
 		/// <summary>Allows you to disable or enable protection against creating custom messages with death. Created for developers who came up with a more original solution to this problem.</summary>
 		[Description("Allows you to disable or enable protection against creating custom messages with death. Created for developers who came up with a more original solution to this problem.")]
 		public bool DisableCustomDeathMessages = true;
-
-		/// <summary>Allows players to use [ct:] tags in chat.</summary>
-		[Description("Allows players to use [ct:] tags in chat. Note: invalid [ct:] tags can crash mobile clients.")]
-		public bool AllowCtTag = false;
 		#endregion
 
 

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -45,7 +45,6 @@ using TShockAPI.Localization;
 using TShockAPI.Configuration;
 using Terraria.GameContent.Creative;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using MonoMod.Cil;
 using Terraria.Achievements;
 using Terraria.Initializers;
@@ -1516,14 +1515,6 @@ namespace TShockAPI
 			string text = TruncateChatMessageIfNecessary(args);
 			// We should now use the truncated message instead of the original, we don't want anything to fire off on text that has been "removed"...
 			// Yes, double assignment like this looks bad...
-
-
-			// Filter out [ct:xxx] tags because they may crash the PE client
-			if (!Config.Settings.AllowCtTag)
-			{
-				text = Regex.Replace(text, @"\[ct:[^\]]*\]", "");
-			}
-
 			var chatText = text;
 
 			// Terraria now has chat commands on the client side.


### PR DESCRIPTION
Reverts Pryaxis/TShock#3193

Terraria PE v1.4.5.6 totally resolves the CT tag crash bug