### PR TITLE
Fix issues with Torch God event

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1386,6 +1386,10 @@ namespace TShockAPI
 			// The server will assume ownership of this projectile, despite it being hostile, so it is the only hostile projectile clients are allowed to create.
 			if (type == ProjectileID.TorchGod && !args.Player.TPlayer.unlockedBiomeTorches)
 			{
+				if (CheckProjectileThreshold())
+					return;
+
+				ProjectileThresholdIncrement();
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile super accepted from (torch god) {0}", args.Player.Name));
 				args.Handled = false;
 				return;
@@ -1495,23 +1499,8 @@ namespace TShockAPI
 				// return;
 			}
 
-			if (args.Player.ProjectileThreshold >= TShock.Config.Settings.ProjectileThreshold)
-			{
-				if (TShock.Config.Settings.KickOnProjectileThresholdBroken)
-				{
-					args.Player.Kick(GetString("Projectile create threshold exceeded {0}.", TShock.Config.Settings.ProjectileThreshold));
-				}
-				else
-				{
-					args.Player.Disable(GetString("Reached projectile create threshold."), DisableFlags.WriteToLogAndConsole);
-					args.Player.RemoveProjectile(ident, owner);
-				}
-
-				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile create threshold from {0} {1}/{2}", args.Player.Name, args.Player.ProjectileThreshold, TShock.Config.Settings.ProjectileThreshold));
-				TShock.Log.ConsoleDebug(GetString("If this player wasn't hacking, please report the projectile create threshold they were disabled for to TShock so we can improve this!"));
-				args.Handled = true;
+			if (CheckProjectileThreshold())
 				return;
-			}
 
 			if (
 				(Projectile_MaxValuesAI.ContainsKey(type) &&
@@ -1542,17 +1531,7 @@ namespace TShockAPI
 				return;
 			}
 
-			if (!args.Player.HasPermission(Permissions.ignoreprojectiledetection))
-			{
-				if (type == ProjectileID.CrystalShard && TShock.Config.Settings.ProjIgnoreShrapnel) // Ignore crystal shards
-				{
-					TShock.Log.Debug(GetString("Ignoring shrapnel per config.."));
-				}
-				else if (!Main.projectile[index].active)
-				{
-					args.Player.ProjectileThreshold++; // Creating new projectile
-				}
-			}
+			ProjectileThresholdIncrement();
 
 			if ((type == ProjectileID.Bomb
 				|| type == ProjectileID.Dynamite
@@ -1564,6 +1543,45 @@ namespace TShockAPI
 			{
 				//  Denotes that the player has recently set a fuse - used for cheat detection.
 				args.Player.RecentFuse = 10;
+			}
+
+			// Checks if the player has exceeded the projectile creation threshold.
+			bool CheckProjectileThreshold()
+			{
+				if (args.Player.ProjectileThreshold >= TShock.Config.Settings.ProjectileThreshold)
+				{
+					if (TShock.Config.Settings.KickOnProjectileThresholdBroken)
+					{
+						args.Player.Kick(GetString("Projectile create threshold exceeded {0}.", TShock.Config.Settings.ProjectileThreshold));
+					}
+					else
+					{
+						args.Player.Disable(GetString("Reached projectile create threshold."), DisableFlags.WriteToLogAndConsole);
+						args.Player.RemoveProjectile(ident, owner);
+					}
+
+					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile create threshold from {0} {1}/{2}", args.Player.Name, args.Player.ProjectileThreshold, TShock.Config.Settings.ProjectileThreshold));
+					TShock.Log.ConsoleDebug(GetString("If this player wasn't hacking, please report the projectile create threshold they were disabled for to TShock so we can improve this!"));
+					args.Handled = true;
+					return true;
+				}
+				return false;
+			}
+
+			// Incremenets the player's projectile creation threshold, if necessary.
+			void ProjectileThresholdIncrement()
+			{
+				if (!args.Player.HasPermission(Permissions.ignoreprojectiledetection))
+				{
+					if (type == ProjectileID.CrystalShard && TShock.Config.Settings.ProjIgnoreShrapnel) // Ignore crystal shards
+					{
+						TShock.Log.Debug(GetString("Ignoring shrapnel per config.."));
+					}
+					else if (!Main.projectile[index].active)
+					{
+						args.Player.ProjectileThreshold++; // Creating new projectile
+					}
+				}
 			}
 		}
 

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1380,6 +1380,17 @@ namespace TShockAPI
 				return;
 			}
 
+
+			// Torch God attack is created only when player is experiencing the torch god event.
+			// However, checking for happyFunTorchTime doesn't work since due to a bug, clients don't sync it right away, so we check unlockedBiomeTorches instead.
+			// The server assumes ownership of this projectile usually, despite it being hostile
+			if (type == ProjectileID.TorchGod && !args.Player.TPlayer.unlockedBiomeTorches)
+			{
+				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile super accepted from (torch god) {0}", args.Player.Name));
+				args.Handled = false;
+				return;
+			}
+
 			/// If the projectile is a directional projectile, check if the player is holding their respected item to validate the projectile creation.
 			if (directionalProjectiles.ContainsKey(type))
 			{

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1380,10 +1380,10 @@ namespace TShockAPI
 				return;
 			}
 
-
-			// Torch God attack is created only when player is experiencing the torch god event.
-			// However, checking for happyFunTorchTime doesn't work since due to a bug, clients don't sync it right away, so we check unlockedBiomeTorches instead.
-			// The server assumes ownership of this projectile usually, despite it being hostile
+			// TorchGod projectile is created only when a player is experiencing the torch god event.
+			// However, checking for happyFunTorchTime being true doesn't work, since due to a bug or oversight,
+			// clients don't sync it when it's set to true, so we check for unlockedBiomeTorches being false instead.
+			// The server will assume ownership of this projectile, despite it being hostile, so it is the only hostile projectile clients are allowed to create.
 			if (type == ProjectileID.TorchGod && !args.Player.TPlayer.unlockedBiomeTorches)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile super accepted from (torch god) {0}", args.Player.Name));

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -591,6 +591,12 @@ namespace TShockAPI.Handlers
 		/// <returns><see langword="true"/>, if the rect at a valid distance, otherwise <see langword="false"/>.</returns>
 		private static bool IsRectDistanceValid(TSPlayer player, TileRect rect)
 		{
+			int range = 32;
+
+			// Torches can be modified from faw way through a water gun, or if the player is experiencing the torch god event.
+			if (IsRectATorch(player, rect))
+				range = 104; // Base value of 100 comes from Player.TorchAttack, bumped by 4 blocks to be safe.
+
 			for (int x = 0; x < rect.Width; x++)
 			{
 				for (int y = 0; y < rect.Height; y++)
@@ -598,7 +604,7 @@ namespace TShockAPI.Handlers
 					int realX = rect.X + x;
 					int realY = rect.Y + y;
 
-					if (!player.IsInRange(realX, realY))
+					if (!player.IsInRange(realX, realY, range))
 					{
 						return false;
 					}
@@ -608,6 +614,21 @@ namespace TShockAPI.Handlers
 			return true;
 		}
 
+		/// <summary>
+		/// Checks whether the tile rect is modifying a torch.
+		/// </summary>
+		/// <param name="player">The player the operation originates from.</param>
+		/// <param name="rect">The tile rectangle of the operation.</param>
+		/// <returns><see langword="true"/>, if the rect is modifying a torch, otherwise <see langword="false"/>.</returns>
+		private static bool IsRectATorch(TSPlayer player, TileRect rect)
+		{
+			// Rect is definitely not a torch...
+			if (rect.Width != 1 || rect.Height != 1)
+				return false;
+
+			// Is the rect actually a torch?
+			return rect[0, 0].Type == TileID.Torches;
+		}
 
 		/// <summary>
 		/// Checks whether the tile rect is a valid conversion spread (Clentaminator, Powders, etc.).

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -626,8 +626,8 @@ namespace TShockAPI.Handlers
 			if (rect.Width != 1 || rect.Height != 1)
 				return false;
 
-			// Is the rect actually a torch?
-			return rect[0, 0].Type == TileID.Torches;
+			// Is the rect actually modifying a torch?
+			return rect[0, 0].Type == TileID.Torches && Main.tile[rect.X, rect.Y].type == TileID.Torches;
 		}
 
 		/// <summary>

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -594,7 +594,7 @@ namespace TShockAPI.Handlers
 			int range = 32;
 
 			// Torches can be modified from far away through a water gun, or if the player is experiencing the torch god event.
-			if (IsRectATorch(player, rect))
+			if (IsRectATorch(rect))
 				range = 104; // Base value of 100 comes from Player.TorchAttack, bumped by 4 blocks to be safe.
 
 			for (int x = 0; x < rect.Width; x++)
@@ -617,10 +617,9 @@ namespace TShockAPI.Handlers
 		/// <summary>
 		/// Checks whether the tile rect is modifying a torch.
 		/// </summary>
-		/// <param name="player">The player the operation originates from.</param>
 		/// <param name="rect">The tile rectangle of the operation.</param>
 		/// <returns><see langword="true"/>, if the rect is modifying a torch, otherwise <see langword="false"/>.</returns>
-		private static bool IsRectATorch(TSPlayer player, TileRect rect)
+		private static bool IsRectATorch(TileRect rect)
 		{
 			// Rect is definitely not a torch...
 			if (rect.Width != 1 || rect.Height != 1)

--- a/TShockAPI/Handlers/SendTileRectHandler.cs
+++ b/TShockAPI/Handlers/SendTileRectHandler.cs
@@ -593,7 +593,7 @@ namespace TShockAPI.Handlers
 		{
 			int range = 32;
 
-			// Torches can be modified from faw way through a water gun, or if the player is experiencing the torch god event.
+			// Torches can be modified from far away through a water gun, or if the player is experiencing the torch god event.
 			if (IsRectATorch(player, rect))
 				range = 104; // Base value of 100 comes from Player.TorchAttack, bumped by 4 blocks to be safe.
 


### PR DESCRIPTION
Fixes two issues relating to the Torch God event:
- Other clients can't see torch attacks (they can on vanilla servers)
- Bump range check to 104 tiles for torches - ``Player.TorchAttack`` checks 100 blocks, but just in case.

Unsure if the range check should be completely removed for torches. The player can move extremely far away and then they won't be able to relight the torches extinguished by the event, as they'll get rejected by the range check.
Due to a bug or oversight, the client doesn't sync their ``happyFunTorchTime`` state when it's set to true, only when it's set to false, so there's no way to know for sure if the player is in the event to apply proper range checking (and projectile creation). Feedback appreciated.