### PR TITLE
fix wrongfully kicking players when releasing a critter

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -2361,12 +2361,8 @@ namespace TShockAPI
 
 			// if released npc not from its item (from crafted packet)
 			// e.g. using bunny item to release golden bunny
-			if (args.Player.TPlayer.lastVisualizedSelectedItem.makeNPC != type || args.Player.TPlayer.lastVisualizedSelectedItem.placeStyle != style)
+			if (args.Player.SelectedItem.makeNPC != type || args.Player.SelectedItem.placeStyle != style)
 			{
-				// If the critter is an Explosive Bunny, check if we've recently created an Explosive Bunny projectile.
-				// If we have, check if the critter we are trying to create is within range of the projectile
-				// If we have at least one of those, then this wasn't a crafted packet, but simply a delayed critter release from an
-				// Explosive Bunny projectile.
 				if (type == NPCID.ExplosiveBunny)
 				{
 					if (args.Player.TPlayer.ownedProjectileCounts[ProjectileID.ExplosiveBunny] == 0)


### PR DESCRIPTION
<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. If you would like to not make particles add your changes to the changelog manually please consider saying you've already updated the changelog. Thanks! -->

**Fix critter release kicking issue**

since `lastVisualizedSelectedItem` is not synced between server and client, it stays as default Item value. this causes `makeNPC` to always be `0`, failing the check and making Bouncer interpret every critter release as an invalid action, resulting in a player kick