### PR TITLE
Fix item drops sometimes being rejected

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1249,7 +1249,8 @@ namespace TShockAPI
 			}
 
 			// stop the client from changing the item type of a drop
-			if (Main.item[id].active && Main.item[id].type != type &&
+			// as long as it's not the last item
+			if (id < Main.maxItems && Main.item[id].active && Main.item[id].type != type &&
 			    !(Main.item[id].type == ItemID.EmptyBucket && type == ItemID.WaterBucket)) // Empty bucket turns into Water Bucket on rainy days
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnItemDrop rejected from item drop check from {0}", args.Player.Name));


### PR DESCRIPTION
Fixes player item drops being rejected when ``Main.item[Main.maxItems]`` is somehow active. I couldn't replicate this myself, but I have seen it can occur after a long play time without restarting the server. Appears to be a vanilla issue we now have to work around.

Clients always drop items in slot 400 (Main.maxItems) and then allow the server to assign it a slot, so this item slot being active caused the Bouncer to reject them when it shouldn't have.

I considered if I should also have the Bouncer reject new items being dropped outside of slot 400, but I worry this may have other unknown issues. Feedback appreciated on this decision.

Text for the changelog:
- Fixed item drops sometimes being incorrectly rejected after extended server uptime (lost-werewolf)