### PR TITLE
Don't push attestations to the container registry

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -57,4 +57,3 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
While cool, those will spam the tag listing with unreadable and empty sha256 tags.

(This is a re-push of #3267 because GitHub apparently broke my PR.)

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. If you would like to not make particles add your changes to the changelog manually please consider saying you've already updated the changelog. Thanks! -->
