### PR TITLE
feat/terraria 1.4.5.7/.8 port

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 TShock, a server mod for Terraria
 Copyright (C) 2011-2019 Pryaxis & TShock Contributors
 
@@ -2676,7 +2676,7 @@ namespace TShockAPI
 
 			if (!args.Player.HasBuildPermission(args.X, args.Y))
 			{
-				int num = Item.NewItem(null, (args.X * 16) + 8, (args.Y * 16) + 8, args.Player.TPlayer.width, args.Player.TPlayer.height, args.ItemID, args.Stack, noBroadcast: true, args.Prefix, noGrabDelay: true);
+				int num = Item.NewItem(null, (args.X * 16) + 8, (args.Y * 16) + 8, args.Player.TPlayer.width, args.Player.TPlayer.height, args.ItemID, args.Stack, noBroadcast: true, args.Prefix, Terraria.NewItemOwnership.None);
 				Main.item[num].playerIndexTheItemIsReservedFor = args.Player.Index;
 				NetMessage.SendData((int)PacketTypes.ItemDrop, args.Player.Index, -1, NetworkText.Empty, num, 1f);
 				NetMessage.SendData((int)PacketTypes.ItemOwner, args.Player.Index, -1, NetworkText.Empty, num);

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1312,8 +1312,6 @@ namespace TShockAPI
 			short type = args.Type;
 			int index = args.Index;
 			float[] ai = args.Ai;
-			// The projectile is rejected before vanilla creates it, so the server can't look its
-			// generation up afterwards - it has to come from the packet.
 			int generation = args.Generation;
 
 			// Clients do send NaN values so we can't just kick them

--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1312,6 +1312,9 @@ namespace TShockAPI
 			short type = args.Type;
 			int index = args.Index;
 			float[] ai = args.Ai;
+			// The projectile is rejected before vanilla creates it, so the server can't look its
+			// generation up afterwards - it has to come from the packet.
+			int generation = args.Generation;
 
 			// Clients do send NaN values so we can't just kick them
 			// See https://github.com/Pryaxis/TShock/issues/3076
@@ -1332,7 +1335,7 @@ namespace TShockAPI
 			if (index > Main.maxProjectiles)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from above projectile limit from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1343,7 +1346,7 @@ namespace TShockAPI
 
 				// Client will fight the server if we remove pets, silently reject instead
 				if (!Main.projPet[type] && !ProjectileID.Sets.LightPet[type])
-					args.Player.RemoveProjectile(ident, owner);
+					args.Player.RemoveProjectile(ident, owner, generation);
 
 				args.Handled = true;
 				return;
@@ -1355,7 +1358,7 @@ namespace TShockAPI
 
 				// Client will fight the server if we remove pets, silently reject instead
 				if (!Main.projPet[type] && !ProjectileID.Sets.LightPet[type])
-					args.Player.RemoveProjectile(ident, owner);
+					args.Player.RemoveProjectile(ident, owner, generation);
 
 				args.Handled = true;
 				return;
@@ -1366,7 +1369,7 @@ namespace TShockAPI
 				args.Player.Disable(GetString("Player does not have permission to create projectile {0}.", type), DisableFlags.WriteToLogAndConsole);
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from permission check from {0} {1}", args.Player.Name, type));
 				args.Player.SendErrorMessage(GetString("You do not have permission to create that projectile."));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1375,7 +1378,7 @@ namespace TShockAPI
 			{
 				args.Player.Disable(GetString("Projectile damage is higher than {0}.", TShock.Config.Settings.MaxProjDamage), DisableFlags.WriteToLogAndConsole);
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile damage limit from {0} {1}/{2}", args.Player.Name, damage, TShock.Config.Settings.MaxProjDamage));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1412,7 +1415,7 @@ namespace TShockAPI
 			if (Main.projHostile[type])
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from hostile projectile from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1423,7 +1426,7 @@ namespace TShockAPI
 			if (type == ProjectileID.Tombstone)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from tombstones from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1439,7 +1442,7 @@ namespace TShockAPI
 			    if (discreteDirection is < -3 or > 4)
 			    {
 				    TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (invalid angle: {1})", args.Player.Name, discreteDirection));
-			        args.Player.RemoveProjectile(ident, owner);
+			        args.Player.RemoveProjectile(ident, owner, generation);
 			        args.Handled = true;
 			        return;
 			    }
@@ -1449,7 +1452,7 @@ namespace TShockAPI
 			    if (boltProjectileData.Type == 0 || boltProjectileData.Killed)
 			    {
 				    TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));
-			        args.Player.RemoveProjectile(ident, owner);
+			        args.Player.RemoveProjectile(ident, owner, generation);
 			        args.Handled = true;
 			        return;
 			    }
@@ -1478,7 +1481,7 @@ namespace TShockAPI
 				{
 					TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile please report to tshock about this! normally this is a reject from {0} {1}", args.Player.Name, type));
 					// args.Player.Disable(String.Format("Does not have projectile permission to update projectile. ({0})", type), DisableFlags.WriteToLogAndConsole);
-					// args.Player.RemoveProjectile(ident, owner);
+					// args.Player.RemoveProjectile(ident, owner, generation);
 				}
 				// args.Handled = false;
 				// return;
@@ -1493,7 +1496,7 @@ namespace TShockAPI
 				else
 				{
 					args.Player.Disable(GetString("Reached projectile create threshold."), DisableFlags.WriteToLogAndConsole);
-					args.Player.RemoveProjectile(ident, owner);
+					args.Player.RemoveProjectile(ident, owner, generation);
 				}
 
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from projectile create threshold from {0} {1}/{2}", args.Player.Name, args.Player.ProjectileThreshold, TShock.Config.Settings.ProjectileThreshold));
@@ -1510,7 +1513,7 @@ namespace TShockAPI
 			)
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from bouncer modified AI from {0}.", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1526,7 +1529,7 @@ namespace TShockAPI
 			if (TShock.Config.Settings.DisableModifiedZenith && type == ProjectileID.FinalFractal && (ai[0] < -100 || ai[0] > 101) && !Terraria.Graphics.FinalFractalHelper._fractalProfiles.ContainsKey((int)ai[1]))
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from bouncer modified Zenith projectile from {0}.", args.Player.Name));
-				args.Player.RemoveProjectile(ident, owner);
+				args.Player.RemoveProjectile(ident, owner, generation);
 				args.Handled = true;
 				return;
 			}
@@ -1632,7 +1635,7 @@ namespace TShockAPI
 			if (args.Player.IsBeingDisabled())
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnProjectileKill rejected from disabled from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(args.ProjectileIdentity, args.ProjectileOwner);
+				args.Player.RemoveProjectile(args.ProjectileIdentity, args.ProjectileOwner, args.ProjectileGeneration);
 				args.Handled = true;
 				return;
 			}
@@ -1640,7 +1643,7 @@ namespace TShockAPI
 			if (args.Player.IsBouncerThrottled())
 			{
 				TShock.Log.ConsoleDebug(GetString("Bouncer / OnProjectileKill rejected from bouncer throttle from {0}", args.Player.Name));
-				args.Player.RemoveProjectile(args.ProjectileIdentity, args.ProjectileOwner);
+				args.Player.RemoveProjectile(args.ProjectileIdentity, args.ProjectileOwner, args.ProjectileGeneration);
 				args.Handled = true;
 				return;
 			}

--- a/TShockAPI/Commands.cs
+++ b/TShockAPI/Commands.cs
@@ -2537,7 +2537,7 @@ namespace TShockAPI
 					}
 					else
 					{
-						Main.StartRain(garenteeCoinRain: true);
+						Main.StartRain(guaranteeCoinRain: true);
 						TSPlayer.All.SendData(PacketTypes.WorldInfo);
 						TSPlayer.All.SendInfoMessage(GetString("{0} caused it to coin rain.", args.Player.Name));
 					}

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3260,8 +3260,21 @@ namespace TShockAPI
 			var vel = new Vector2(args.Data.ReadSingle(), args.Data.ReadSingle());
 			var stacks = args.Data.ReadInt16();
 			var prefix = args.Data.ReadInt8();
-			var noDelay = args.Data.ReadInt8() == 1;
+			BitsByte flags = args.Data.ReadInt8();
+			// Bits 0-1: Terraria.NewItemOwnership (0 None, 1 ReserveForLocalPlayer,
+			// 2 GrabDelayForLocalPlayer, 3 GrabDelayForAllPlayers)
+			var ownership = (byte)((flags[0] ? 1 : 0) | (flags[1] ? 2 : 0));
+			var noDelay = ownership <= 1;
 			var type = args.Data.ReadInt16();
+			if (flags[2])
+			{
+				args.Data.ReadBoolean(); // shimmered
+				args.Data.ReadSingle(); // shimmerTime
+			}
+			if (flags[3])
+			{
+				args.Data.ReadInt8(); // enemyGrabDelayTime
+			}
 
 			if (OnItemDrop(args.Player, args.Data, id, pos, vel, stacks, prefix, noDelay, type))
 				return true;
@@ -3271,6 +3284,8 @@ namespace TShockAPI
 
 		private static bool HandleItemOwner(GetDataHandlerArgs args)
 		{
+			// As of 1.4.5.7 this packet is server->client only and vanilla ignores it inbound;
+			// clients no longer send it (including the old slot-400 SSC echo).
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 
@@ -3295,10 +3310,14 @@ namespace TShockAPI
 
 		private static bool HandleProjectileNew(GetDataHandlerArgs args)
 		{
-			short ident = args.Data.ReadInt16();
+			// 1.4.5.7: a packed ProjectileKey (spawner:8 | index:10 | generation:14) replaces
+			// the old identity short + owner byte; the trailing bit7 UUID short is gone.
+			uint key = (uint)args.Data.ReadInt32();
+			byte owner = (byte)(key & 255u);
+			short ident = (short)(key >> 8 & 1023u);
+			int generation = (int)(key >> 18 & 16383u);
 			Vector2 pos = args.Data.ReadVector2();
 			Vector2 vel = args.Data.ReadVector2();
-			byte owner = args.Data.ReadInt8();
 			short type = args.Data.ReadInt16();
 			BitsByte bitsByte = (BitsByte)args.Data.ReadByte();
 			BitsByte bitsByte2 = (BitsByte)(bitsByte[2] ? args.Data.ReadByte() : 0);
@@ -3310,11 +3329,17 @@ namespace TShockAPI
 			short dmg = (short)(bitsByte[4] ? args.Data.ReadInt16() : 0);
 			float knockback = bitsByte[5] ? args.Data.ReadSingle() : 0f;
 			short origDmg = (short)(bitsByte[6] ? args.Data.ReadInt16() : 0);
-			short projUUID = (short)(bitsByte[7] ? args.Data.ReadInt16() : -1);
-			if (projUUID >= 1000) projUUID = -1;
 			ai[2] = (bitsByte2[0] ? args.Data.ReadSingle() : 0f);
 
-			var index = TShock.Utils.SearchProjectile(ident, owner);
+			// Vanilla rejects keys whose spawner isn't the sending client; mirror that here.
+			if (owner != args.Player.Index)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected key spawner mismatch {0}", args.Player.Name));
+				return true;
+			}
+
+			// The key's index is the projectile slot; the old identity scan no longer applies.
+			var index = (int)ident;
 
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
 			// Block ai[0] == 3 (dig state)
@@ -3344,11 +3369,18 @@ namespace TShockAPI
 
 		private static bool HandleNpcStrike(GetDataHandlerArgs args)
 		{
-			var id = args.Data.ReadInt16();
+			// 1.4.5.7: slot shrank to a byte and gained a generation byte (slot-reuse guard).
+			// Vanilla drops strikes whose generation doesn't match and acks each one with
+			// packet 162 (DamageNPCAck).
+			short id = args.Data.ReadInt8();
+			var generation = args.Data.ReadInt8();
 			var dmg = args.Data.ReadInt16();
 			var knockback = args.Data.ReadSingle();
 			var direction = (byte)(args.Data.ReadInt8() - 1);
 			var crit = args.Data.ReadInt8();
+
+			if (id >= Main.npc.Length)
+				return true;
 
 			if (OnNPCStrike(args.Player, args.Data, id, direction, dmg, knockback, crit))
 				return true;
@@ -3393,10 +3425,15 @@ namespace TShockAPI
 
 		private static bool HandleProjectileKill(GetDataHandlerArgs args)
 		{
-			var ident = args.Data.ReadInt16();
-			var owner = args.Data.ReadInt8();
-			owner = (byte)args.Player.Index;
-			var index = TShock.Utils.SearchProjectile(ident, owner);
+			// 1.4.5.7: i32 ProjectileKey + kill-effect position replace the old identity/owner pair.
+			uint key = (uint)args.Data.ReadInt32();
+			var killPos = args.Data.ReadVector2();
+			var ident = (short)(key >> 8 & 1023u);
+			var owner = (byte)args.Player.Index;
+			var index = (int)ident;
+
+			if (index >= Main.projectile.Length)
+				return true;
 
 			if (OnProjectileKill(args.Player, args.Data, ident, owner, index))
 			{
@@ -4280,8 +4317,8 @@ namespace TShockAPI
 
 		private static bool HandleCatchNpc(GetDataHandlerArgs args)
 		{
+			// 1.4.5.7 removed the trailing "who" byte; the server uses the sender's index.
 			var npcID = args.Data.ReadInt16();
-			var who = args.Data.ReadByte();
 
 			if (Main.npc[npcID]?.catchItem == 0)
 			{
@@ -5193,6 +5230,7 @@ namespace TShockAPI
 			Ping,
 			Ambience,
 			Bestiary,
+			CreativeUnlocks,
 			CreativePowers,
 			CreativeUnlocksPlayerReport,
 			TeleportPylon,
@@ -5200,11 +5238,8 @@ namespace TShockAPI
 			CreativePowerPermissions,
 			Banners,
 			CraftingRequests,
-			TagEffectState,
 			LeashedEntity,
-			UnbreakableWallScan,
-			[Obsolete("Removed in 1.4.5")]
-			CreativeUnlocks
+			UnbreakableWallScan
 		}
 
 		public enum CreativePowerTypes

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3294,8 +3294,11 @@ namespace TShockAPI
 
 		private static bool HandleItemOwner(GetDataHandlerArgs args)
 		{
-			// As of 1.4.5.7 this packet is server->client only and vanilla ignores it inbound;
-			// clients no longer send it (including the old slot-400 SSC echo).
+			// As of 1.4.5.7 vanilla's case 22 is guarded by `Main.netMode != 2`, so a server
+			// ignores this packet entirely and its payload changed shape (7-bit encoded ints,
+			// trailing position). The slot-400 branch below is therefore dead - SSC no longer
+			// depends on it, since RestoreCharacter clears IgnoreSSCPackets in a finally block.
+			// Kept only so an old client echoing the packet still behaves.
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 
@@ -4357,6 +4360,14 @@ namespace TShockAPI
 		{
 			// 1.4.5.7 removed the trailing "who" byte; the server uses the sender's index.
 			var npcID = args.Data.ReadInt16();
+
+			// Vanilla range-checks this before touching Main.npc. Without it a crafted id
+			// indexes out of bounds.
+			if (npcID < 0 || npcID >= Main.maxNPCs)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleCatchNpc rejected out of range npc {0}", args.Player.Name));
+				return true;
+			}
 
 			if (Main.npc[npcID]?.catchItem == 0)
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3310,12 +3310,11 @@ namespace TShockAPI
 
 		private static bool HandleProjectileNew(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: a packed ProjectileKey (spawner:8 | index:10 | generation:14) replaces
-			// the old identity short + owner byte; the trailing bit7 UUID short is gone.
-			uint key = (uint)args.Data.ReadInt32();
-			byte owner = (byte)(key & 255u);
-			short ident = (short)(key >> 8 & 1023u);
-			int generation = (int)(key >> 18 & 16383u);
+			// 1.4.5.7: a packed ProjectileKey replaces the old identity short + owner byte;
+			// the trailing bit7 UUID short is gone.
+			var key = (ProjectileKey)args.Data.ReadInt32();
+			byte owner = (byte)key.Spawner;
+			short ident = (short)key.Index;
 			Vector2 pos = args.Data.ReadVector2();
 			Vector2 vel = args.Data.ReadVector2();
 			short type = args.Data.ReadInt16();
@@ -3331,15 +3330,23 @@ namespace TShockAPI
 			short origDmg = (short)(bitsByte[6] ? args.Data.ReadInt16() : 0);
 			ai[2] = (bitsByte2[0] ? args.Data.ReadSingle() : 0f);
 
-			// Vanilla rejects keys whose spawner isn't the sending client; mirror that here.
+			// Vanilla drops hostile projectile types and keys whose spawner isn't the sending
+			// client before touching any state; mirror both here.
+			if (type < 0 || type >= Main.projHostile.Length || Main.projHostile[type])
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected hostile projectile type {0}", args.Player.Name));
+				return true;
+			}
+
 			if (owner != args.Player.Index)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected key spawner mismatch {0}", args.Player.Name));
 				return true;
 			}
 
-			// The key's index is the projectile slot; the old identity scan no longer applies.
-			var index = (int)ident;
+			// Resolves to 1000 for a projectile the server has not created yet, matching what
+			// the pre-1.4.5.7 identity scan returned in the same situation.
+			var index = TShock.Utils.SearchProjectile(ident, owner);
 
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
 			// Block ai[0] == 3 (dig state)
@@ -3381,6 +3388,14 @@ namespace TShockAPI
 
 			if (id >= Main.npc.Length)
 				return true;
+
+			// Vanilla drops the strike outright when the generation counter doesn't match the
+			// NPC currently in that slot, which is what stops a recycled slot from being hit.
+			if (Main.npc[id].generation != generation)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleNpcStrike rejected npc generation mismatch {0}", args.Player.Name));
+				return true;
+			}
 
 			if (OnNPCStrike(args.Player, args.Data, id, direction, dmg, knockback, crit))
 				return true;
@@ -3426,14 +3441,27 @@ namespace TShockAPI
 		private static bool HandleProjectileKill(GetDataHandlerArgs args)
 		{
 			// 1.4.5.7: i32 ProjectileKey + kill-effect position replace the old identity/owner pair.
-			uint key = (uint)args.Data.ReadInt32();
+			var key = (ProjectileKey)args.Data.ReadInt32();
 			var killPos = args.Data.ReadVector2();
-			var ident = (short)(key >> 8 & 1023u);
+			var ident = (short)key.Index;
 			var owner = (byte)args.Player.Index;
-			var index = (int)ident;
 
-			if (index >= Main.projectile.Length)
+			// Vanilla resolves the key through Projectile.TryLookup, which compares the whole
+			// key including its generation counter, so a stale key kills nothing. Drop those
+			// rather than acting on whatever currently occupies the slot.
+			if (!key.TryGet(out var killed) || !killed.active)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected stale projectile key {0}", args.Player.Name));
 				return true;
+			}
+
+			var index = killed.whoAmI;
+
+			if (killed.owner != args.Player.Index)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected owner mismatch {0}", args.Player.Name));
+				return true;
+			}
 
 			if (OnProjectileKill(args.Player, args.Data, ident, owner, index))
 			{

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3270,7 +3270,6 @@ namespace TShockAPI
 			var stacks = args.Data.ReadInt16();
 			var prefix = args.Data.ReadInt8();
 			BitsByte flags = args.Data.ReadInt8();
-			// bits 0-1: NewItemOwnership (0 none, 1 reserveLocal, 2 grabDelayLocal, 3 grabDelayAll)
 			var ownership = (byte)((flags[0] ? 1 : 0) | (flags[1] ? 2 : 0));
 			var noDelay = ownership <= 1;
 			var type = args.Data.ReadInt16();
@@ -3292,7 +3291,7 @@ namespace TShockAPI
 
 		private static bool HandleItemOwner(GetDataHandlerArgs args)
 		{
-			// dead since 1.4.5.7 (vanilla guards case 22 with netMode != 2); kept for old clients
+			// vanilla never runs case 22 on a server; kept for old clients
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 
@@ -3317,7 +3316,6 @@ namespace TShockAPI
 
 		private static bool HandleProjectileNew(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: packed ProjectileKey replaces identity+owner, no trailing UUID short
 			var key = (ProjectileKey)args.Data.ReadInt32();
 			byte owner = (byte)key.Spawner;
 			short ident = (short)key.Index;
@@ -3378,7 +3376,6 @@ namespace TShockAPI
 
 		private static bool HandleNpcStrike(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: byte slot + generation byte; ack is packet 162 (DamageNPCAck)
 			short id = args.Data.ReadInt8();
 			var generation = args.Data.ReadInt8();
 			var dmg = args.Data.ReadInt16();
@@ -3438,20 +3435,18 @@ namespace TShockAPI
 
 		private static bool HandleProjectileKill(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: i32 ProjectileKey + kill position replace identity/owner
 			var key = (ProjectileKey)args.Data.ReadInt32();
 			var killPos = args.Data.ReadVector2();
 			var ident = (short)key.Index;
 			var owner = (byte)args.Player.Index;
 
-			// Index is 10 bits (0-1023), keyToIndex only maxProjectiles+1 wide, TryGet does not bounds check
+			// TryGet does not bounds check, and Index is wider than keyToIndex
 			if (key.Index > Main.maxProjectiles)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected out of range projectile index {0}", args.Player.Name));
 				return true;
 			}
 
-			// vanilla compares the generation too, so a stale key kills nothing
 			if (!key.TryGet(out var killed) || !killed.active)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected stale projectile key {0}", args.Player.Name));
@@ -4348,10 +4343,8 @@ namespace TShockAPI
 
 		private static bool HandleCatchNpc(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: no trailing "who" byte, server uses the sender's index
 			var npcID = args.Data.ReadInt16();
 
-			// a crafted id would index out of bounds
 			if (npcID < 0 || npcID >= Main.maxNPCs)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleCatchNpc rejected out of range npc {0}", args.Player.Name));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3291,7 +3291,6 @@ namespace TShockAPI
 
 		private static bool HandleItemOwner(GetDataHandlerArgs args)
 		{
-			// vanilla never runs case 22 on a server; kept for old clients
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -701,8 +701,7 @@ namespace TShockAPI
 			public int Index { get; set; }
 
 			/// <summary>
-			/// Slot-reuse counter from the sender's ProjectileKey. The server has not created
-			/// the projectile yet at this point, so this is the only way to address it back.
+			/// Slot-reuse counter from the sender's ProjectileKey.
 			/// </summary>
 			public int Generation { get; set; }
 
@@ -3271,8 +3270,7 @@ namespace TShockAPI
 			var stacks = args.Data.ReadInt16();
 			var prefix = args.Data.ReadInt8();
 			BitsByte flags = args.Data.ReadInt8();
-			// Bits 0-1: Terraria.NewItemOwnership (0 None, 1 ReserveForLocalPlayer,
-			// 2 GrabDelayForLocalPlayer, 3 GrabDelayForAllPlayers)
+			// bits 0-1: NewItemOwnership (0 none, 1 reserveLocal, 2 grabDelayLocal, 3 grabDelayAll)
 			var ownership = (byte)((flags[0] ? 1 : 0) | (flags[1] ? 2 : 0));
 			var noDelay = ownership <= 1;
 			var type = args.Data.ReadInt16();
@@ -3294,11 +3292,7 @@ namespace TShockAPI
 
 		private static bool HandleItemOwner(GetDataHandlerArgs args)
 		{
-			// As of 1.4.5.7 vanilla's case 22 is guarded by `Main.netMode != 2`, so a server
-			// ignores this packet entirely and its payload changed shape (7-bit encoded ints,
-			// trailing position). The slot-400 branch below is therefore dead - SSC no longer
-			// depends on it, since RestoreCharacter clears IgnoreSSCPackets in a finally block.
-			// Kept only so an old client echoing the packet still behaves.
+			// dead since 1.4.5.7 (vanilla guards case 22 with netMode != 2); kept for old clients
 			var id = args.Data.ReadInt16();
 			var owner = args.Data.ReadInt8();
 
@@ -3323,8 +3317,7 @@ namespace TShockAPI
 
 		private static bool HandleProjectileNew(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: a packed ProjectileKey replaces the old identity short + owner byte;
-			// the trailing bit7 UUID short is gone.
+			// 1.4.5.7: packed ProjectileKey replaces identity+owner, no trailing UUID short
 			var key = (ProjectileKey)args.Data.ReadInt32();
 			byte owner = (byte)key.Spawner;
 			short ident = (short)key.Index;
@@ -3343,8 +3336,6 @@ namespace TShockAPI
 			short origDmg = (short)(bitsByte[6] ? args.Data.ReadInt16() : 0);
 			ai[2] = (bitsByte2[0] ? args.Data.ReadSingle() : 0f);
 
-			// Vanilla drops hostile projectile types and keys whose spawner isn't the sending
-			// client before touching any state; mirror both here.
 			if (type < 0 || type >= Main.projHostile.Length || Main.projHostile[type])
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected hostile projectile type {0}", args.Player.Name));
@@ -3357,9 +3348,6 @@ namespace TShockAPI
 				return true;
 			}
 
-			// Resolves to 1000 for a projectile the server has not created yet, matching what
-			// the pre-1.4.5.7 identity scan returned in the same situation. The generation keeps a
-			// reused identity from resolving onto the projectile that previously held it.
 			var index = TShock.Utils.SearchProjectile(ident, owner, key.Generation);
 
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
@@ -3390,9 +3378,7 @@ namespace TShockAPI
 
 		private static bool HandleNpcStrike(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: slot shrank to a byte and gained a generation byte (slot-reuse guard).
-			// Vanilla drops strikes whose generation doesn't match and acks each one with
-			// packet 162 (DamageNPCAck).
+			// 1.4.5.7: byte slot + generation byte; ack is packet 162 (DamageNPCAck)
 			short id = args.Data.ReadInt8();
 			var generation = args.Data.ReadInt8();
 			var dmg = args.Data.ReadInt16();
@@ -3403,8 +3389,6 @@ namespace TShockAPI
 			if (id >= Main.npc.Length)
 				return true;
 
-			// Vanilla drops the strike outright when the generation counter doesn't match the
-			// NPC currently in that slot, which is what stops a recycled slot from being hit.
 			if (Main.npc[id].generation != generation)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleNpcStrike rejected npc generation mismatch {0}", args.Player.Name));
@@ -3454,24 +3438,20 @@ namespace TShockAPI
 
 		private static bool HandleProjectileKill(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7: i32 ProjectileKey + kill-effect position replace the old identity/owner pair.
+			// 1.4.5.7: i32 ProjectileKey + kill position replace identity/owner
 			var key = (ProjectileKey)args.Data.ReadInt32();
 			var killPos = args.Data.ReadVector2();
 			var ident = (short)key.Index;
 			var owner = (byte)args.Player.Index;
 
-			// ProjectileKey.Index is a 10 bit field (0-1023) but Projectile.keyToIndex only has
-			// Main.maxProjectiles + 1 columns, and TryGet does not bounds check the lookup, so an
-			// out of range index throws rather than simply missing.
+			// Index is 10 bits (0-1023), keyToIndex only maxProjectiles+1 wide, TryGet does not bounds check
 			if (key.Index > Main.maxProjectiles)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected out of range projectile index {0}", args.Player.Name));
 				return true;
 			}
 
-			// Vanilla resolves the key through Projectile.TryLookup, which compares the whole
-			// key including its generation counter, so a stale key kills nothing. Drop those
-			// rather than acting on whatever currently occupies the slot.
+			// vanilla compares the generation too, so a stale key kills nothing
 			if (!key.TryGet(out var killed) || !killed.active)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected stale projectile key {0}", args.Player.Name));
@@ -4368,11 +4348,10 @@ namespace TShockAPI
 
 		private static bool HandleCatchNpc(GetDataHandlerArgs args)
 		{
-			// 1.4.5.7 removed the trailing "who" byte; the server uses the sender's index.
+			// 1.4.5.7: no trailing "who" byte, server uses the sender's index
 			var npcID = args.Data.ReadInt16();
 
-			// Vanilla range-checks this before touching Main.npc. Without it a crafted id
-			// indexes out of bounds.
+			// a crafted id would index out of bounds
 			if (npcID < 0 || npcID >= Main.maxNPCs)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleCatchNpc rejected out of range npc {0}", args.Player.Name));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3459,6 +3459,15 @@ namespace TShockAPI
 			var ident = (short)key.Index;
 			var owner = (byte)args.Player.Index;
 
+			// ProjectileKey.Index is a 10 bit field (0-1023) but Projectile.keyToIndex only has
+			// Main.maxProjectiles + 1 columns, and TryGet does not bounds check the lookup, so an
+			// out of range index throws rather than simply missing.
+			if (key.Index > Main.maxProjectiles)
+			{
+				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileKill rejected out of range projectile index {0}", args.Player.Name));
+				return true;
+			}
+
 			// Vanilla resolves the key through Projectile.TryLookup, which compares the whole
 			// key including its generation counter, so a stale key kills nothing. Drop those
 			// rather than acting on whatever currently occupies the slot.

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3358,8 +3358,9 @@ namespace TShockAPI
 			}
 
 			// Resolves to 1000 for a projectile the server has not created yet, matching what
-			// the pre-1.4.5.7 identity scan returned in the same situation.
-			var index = TShock.Utils.SearchProjectile(ident, owner);
+			// the pre-1.4.5.7 identity scan returned in the same situation. The generation keeps a
+			// reused identity from resolving onto the projectile that previously held it.
+			var index = TShock.Utils.SearchProjectile(ident, owner, key.Generation);
 
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
 			// Block ai[0] == 3 (dig state)

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -701,6 +701,12 @@ namespace TShockAPI
 			public int Index { get; set; }
 
 			/// <summary>
+			/// Slot-reuse counter from the sender's ProjectileKey. The server has not created
+			/// the projectile yet at this point, so this is the only way to address it back.
+			/// </summary>
+			public int Generation { get; set; }
+
+			/// <summary>
 			/// The special meaning of the projectile.
 			/// </summary>
 			public float[] Ai { get; set; }
@@ -709,7 +715,7 @@ namespace TShockAPI
 		/// NewProjectile - Called when a client creates a new projectile
 		/// </summary>
 		public static HandlerList<NewProjectileEventArgs> NewProjectile = new HandlerList<NewProjectileEventArgs>();
-		private static bool OnNewProjectile(MemoryStream data, short ident, Vector2 pos, Vector2 vel, float knockback, short dmg, byte owner, short type, int index, TSPlayer player, float[] ai)
+		private static bool OnNewProjectile(MemoryStream data, short ident, Vector2 pos, Vector2 vel, float knockback, short dmg, byte owner, short type, int index, TSPlayer player, float[] ai, int generation)
 		{
 			if (NewProjectile == null)
 				return false;
@@ -726,7 +732,8 @@ namespace TShockAPI
 				Type = type,
 				Index = index,
 				Player = player,
-				Ai = ai
+				Ai = ai,
+				Generation = generation
 			};
 			NewProjectile.Invoke(null, args);
 			return args.Handled;
@@ -790,6 +797,8 @@ namespace TShockAPI
 			public byte ProjectileOwner;
 			/// <summary>The index of the projectile in Main.projectile.</summary>
 			public int ProjectileIndex;
+			/// <summary>Slot-reuse counter from the sender's ProjectileKey.</summary>
+			public int ProjectileGeneration;
 		}
 		/// <summary>The event fired when a projectile kill packet is received.</summary>
 		public static HandlerList<ProjectileKillEventArgs> ProjectileKill = new HandlerList<ProjectileKillEventArgs>();
@@ -800,7 +809,7 @@ namespace TShockAPI
 		/// <param name="owner">The projectile's owner (from the packet).</param>
 		/// <param name="index">The projectile's index (from Main.projectiles).</param>
 		/// <returns>bool</returns>
-		private static bool OnProjectileKill(TSPlayer player, MemoryStream data, int identity, byte owner, int index)
+		private static bool OnProjectileKill(TSPlayer player, MemoryStream data, int identity, byte owner, int index, int generation)
 		{
 			if (ProjectileKill == null)
 				return false;
@@ -812,6 +821,7 @@ namespace TShockAPI
 				ProjectileIdentity = identity,
 				ProjectileOwner = owner,
 				ProjectileIndex = index,
+				ProjectileGeneration = generation,
 			};
 
 			ProjectileKill.Invoke(null, args);
@@ -3356,7 +3366,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player, ai))
+			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player, ai, key.Generation))
 				return true;
 
 			lock (args.Player.RecentlyCreatedProjectiles)
@@ -3463,7 +3473,7 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (OnProjectileKill(args.Player, args.Data, ident, owner, index))
+			if (OnProjectileKill(args.Player, args.Data, ident, owner, index, key.Generation))
 			{
 				return true;
 			}

--- a/TShockAPI/Net/ProjectileRemoveMsg.cs
+++ b/TShockAPI/Net/ProjectileRemoveMsg.cs
@@ -30,20 +30,21 @@ namespace TShockAPI.Net
 
 		public short Index { get; set; }
 		public byte Owner { get; set; }
+		/// <summary>Slot-reuse counter of the projectile being removed. A stale generation makes
+		/// clients treat the key as a fresh (type 0) projectile, which still clears the slot.</summary>
+		public int Generation { get; set; }
 
 		public override void Pack(Stream stream)
 		{
-			stream.WriteInt16(Index);
+			// ProjectileKey: spawner:8 | index:10 | generation:14
+			int key = (Owner & 255) | (Index & 1023) << 8 | (Generation & 16383) << 18;
+			stream.WriteInt32(key);
 			stream.WriteSingle(-1);
 			stream.WriteSingle(-1);
 			stream.WriteSingle(0);
 			stream.WriteSingle(0);
-			stream.WriteSingle(0);
 			stream.WriteInt16(0);
-			stream.WriteByte(Owner);
-			stream.WriteInt16(0);
-			stream.WriteSingle(0);
-			stream.WriteSingle(0);
+			stream.WriteByte(0);
 		}
 	}
 }

--- a/TShockAPI/Net/ProjectileRemoveMsg.cs
+++ b/TShockAPI/Net/ProjectileRemoveMsg.cs
@@ -30,7 +30,7 @@ namespace TShockAPI.Net
 
 		public short Index { get; set; }
 		public byte Owner { get; set; }
-		/// <summary>Slot-reuse counter. Must match the live projectile, or the client clears the wrong slot.</summary>
+		/// <summary>Slot-reuse counter from the sender's ProjectileKey.</summary>
 		public int Generation { get; set; }
 
 		public override void Pack(Stream stream)

--- a/TShockAPI/Net/ProjectileRemoveMsg.cs
+++ b/TShockAPI/Net/ProjectileRemoveMsg.cs
@@ -30,8 +30,9 @@ namespace TShockAPI.Net
 
 		public short Index { get; set; }
 		public byte Owner { get; set; }
-		/// <summary>Slot-reuse counter of the projectile being removed. A stale generation makes
-		/// clients treat the key as a fresh (type 0) projectile, which still clears the slot.</summary>
+		/// <summary>Slot-reuse counter of the projectile being removed. This MUST match the live
+		/// projectile's generation: the client resolves the key through Projectile.TryLookup, and
+		/// on a mismatch it allocates a brand new slot instead of clearing the offending one.</summary>
 		public int Generation { get; set; }
 
 		public override void Pack(Stream stream)

--- a/TShockAPI/Net/ProjectileRemoveMsg.cs
+++ b/TShockAPI/Net/ProjectileRemoveMsg.cs
@@ -30,9 +30,7 @@ namespace TShockAPI.Net
 
 		public short Index { get; set; }
 		public byte Owner { get; set; }
-		/// <summary>Slot-reuse counter of the projectile being removed. This MUST match the live
-		/// projectile's generation: the client resolves the key through Projectile.TryLookup, and
-		/// on a mismatch it allocates a brand new slot instead of clearing the offending one.</summary>
+		/// <summary>Slot-reuse counter. Must match the live projectile, or the client clears the wrong slot.</summary>
 		public int Generation { get; set; }
 
 		public override void Pack(Stream stream)

--- a/TShockAPI/Rest/RestManager.cs
+++ b/TShockAPI/Rest/RestManager.cs
@@ -976,9 +976,9 @@ namespace TShockAPI
 				return ret;
 
 			TSPlayer player = (TSPlayer)ret;
-			var inventory = player.TPlayer.inventory.Where(p => p.active).ToList();
-			var equipment = player.TPlayer.armor.Where(p => p.active).ToList();
-			var dyes = player.TPlayer.dye.Where(p => p.active).ToList();
+			var inventory = player.TPlayer.inventory.Where(p => !p.IsAir).ToList();
+			var equipment = player.TPlayer.armor.Where(p => !p.IsAir).ToList();
+			var dyes = player.TPlayer.dye.Where(p => !p.IsAir).ToList();
 			return new RestObject()
 			{
 				{"nickname", player.Name},
@@ -1012,12 +1012,12 @@ namespace TShockAPI
 
 			object items = new
 			{
-				inventory = player.TPlayer.inventory.Where(i => i.active).Select(item => (NetItem)item),
-				equipment = player.TPlayer.armor.Where(i => i.active).Select(item => (NetItem)item),
-				dyes = player.TPlayer.dye.Where(i => i.active).Select(item => (NetItem)item),
-				piggy = player.TPlayer.bank.item.Where(i => i.active).Select(item => (NetItem)item),
-				safe = player.TPlayer.bank2.item.Where(i => i.active).Select(item => (NetItem)item),
-				forge = player.TPlayer.bank3.item.Where(i => i.active).Select(item => (NetItem)item)
+				inventory = player.TPlayer.inventory.Where(i => !i.IsAir).Select(item => (NetItem)item),
+				equipment = player.TPlayer.armor.Where(i => !i.IsAir).Select(item => (NetItem)item),
+				dyes = player.TPlayer.dye.Where(i => !i.IsAir).Select(item => (NetItem)item),
+				piggy = player.TPlayer.bank.item.Where(i => !i.IsAir).Select(item => (NetItem)item),
+				safe = player.TPlayer.bank2.item.Where(i => !i.IsAir).Select(item => (NetItem)item),
+				forge = player.TPlayer.bank3.item.Where(i => !i.IsAir).Select(item => (NetItem)item)
 			};
 
 			return new RestObject

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1420,7 +1420,7 @@ namespace TShockAPI
 				{
 					for (int i = 0; i < 50; i++) //51 is trash can, 52-55 is coins, 56-59 is ammo
 					{
-						if (TPlayer.inventory[i] == null || !TPlayer.inventory[i].active || TPlayer.inventory[i].Name == "")
+						if (TPlayer.inventory[i] == null || TPlayer.inventory[i].IsAir || TPlayer.inventory[i].Name == "")
 						{
 							flag = true;
 							break;
@@ -1984,7 +1984,7 @@ namespace TShockAPI
 
 		private void GiveItemByDrop(int type, int stack, int prefix)
 		{
-			int itemIndex = Item.NewItem(new EntitySource_DebugCommand(), (int)X, (int)Y, TPlayer.width, TPlayer.height, type, stack, true, prefix, true);
+			int itemIndex = Item.NewItem(new EntitySource_DebugCommand(), (int)X, (int)Y, TPlayer.width, TPlayer.height, type, stack, true, prefix, Terraria.NewItemOwnership.None);
 			Main.item[itemIndex].playerIndexTheItemIsReservedFor = this.Index;
 			SendData(PacketTypes.ItemDrop, "", itemIndex, 1);
 			SendData(PacketTypes.ItemOwner, null, itemIndex);

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1740,7 +1740,7 @@ namespace TShockAPI
 		/// <param name="owner">The projectile's owner.</param>
 		public void RemoveProjectile(int index, int owner)
 		{
-			// index is the identity, not the slot; a stale generation makes the client spawn a blank one
+			// index is the identity, not the slot
 			int generation = 0;
 			int slot = TShock.Utils.SearchProjectile((short)index, owner);
 			if (slot >= 0 && slot < Main.maxProjectiles)
@@ -1750,7 +1750,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Removes a projectile whose generation is already known, e.g. straight from the packet.
+		/// Removes a projectile whose generation is already known, typically taken from the packet.
 		/// </summary>
 		/// <param name="index">The projectile's identity.</param>
 		/// <param name="owner">The player index of the projectile's owner.</param>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1740,10 +1740,7 @@ namespace TShockAPI
 		/// <param name="owner">The projectile's owner.</param>
 		public void RemoveProjectile(int index, int owner)
 		{
-			// `index` is the projectile's identity, not its slot. Since 1.4.5.7 the client keys
-			// projectiles on (spawner, identity, generation), so resolve the live projectile and
-			// reuse its generation - a stale one makes the client spawn a new blank projectile
-			// and leave the one we're trying to remove untouched.
+			// index is the identity, not the slot; a stale generation makes the client spawn a blank one
 			int generation = 0;
 			int slot = TShock.Utils.SearchProjectile((short)index, owner);
 			if (slot >= 0 && slot < Main.maxProjectiles)
@@ -1753,9 +1750,7 @@ namespace TShockAPI
 		}
 
 		/// <summary>
-		/// Removes a projectile whose generation is already known - typically straight from the
-		/// packet that asked for it. Prefer this when rejecting a projectile the server has not
-		/// created yet, because the server-side lookup cannot resolve one that doesn't exist.
+		/// Removes a projectile whose generation is already known, e.g. straight from the packet.
 		/// </summary>
 		/// <param name="index">The projectile's identity.</param>
 		/// <param name="owner">The player index of the projectile's owner.</param>

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1740,7 +1740,6 @@ namespace TShockAPI
 		/// <param name="owner">The projectile's owner.</param>
 		public void RemoveProjectile(int index, int owner)
 		{
-			// index is the identity, not the slot
 			int generation = 0;
 			int slot = TShock.Utils.SearchProjectile((short)index, owner);
 			if (slot >= 0 && slot < Main.maxProjectiles)

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1749,6 +1749,19 @@ namespace TShockAPI
 			if (slot >= 0 && slot < Main.maxProjectiles)
 				generation = Main.projectile[slot].key.Generation;
 
+			RemoveProjectile(index, owner, generation);
+		}
+
+		/// <summary>
+		/// Removes a projectile whose generation is already known - typically straight from the
+		/// packet that asked for it. Prefer this when rejecting a projectile the server has not
+		/// created yet, because the server-side lookup cannot resolve one that doesn't exist.
+		/// </summary>
+		/// <param name="index">The projectile's identity.</param>
+		/// <param name="owner">The player index of the projectile's owner.</param>
+		/// <param name="generation">Slot-reuse counter from the sender's ProjectileKey.</param>
+		public void RemoveProjectile(int index, int owner, int generation)
+		{
 			using (var ms = new MemoryStream())
 			{
 				var msg = new ProjectileRemoveMsg

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1740,12 +1740,22 @@ namespace TShockAPI
 		/// <param name="owner">The projectile's owner.</param>
 		public void RemoveProjectile(int index, int owner)
 		{
+			// `index` is the projectile's identity, not its slot. Since 1.4.5.7 the client keys
+			// projectiles on (spawner, identity, generation), so resolve the live projectile and
+			// reuse its generation - a stale one makes the client spawn a new blank projectile
+			// and leave the one we're trying to remove untouched.
+			int generation = 0;
+			int slot = TShock.Utils.SearchProjectile((short)index, owner);
+			if (slot >= 0 && slot < Main.maxProjectiles)
+				generation = Main.projectile[slot].key.Generation;
+
 			using (var ms = new MemoryStream())
 			{
 				var msg = new ProjectileRemoveMsg
 				{
 					Index = (short)index,
-					Owner = (byte)owner
+					Owner = (byte)owner,
+					Generation = generation
 				};
 				msg.PackFull(ms);
 				SendRawData(ms.ToArray());

--- a/TShockAPI/TShock.cs
+++ b/TShockAPI/TShock.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 TShock, a server mod for Terraria
 Copyright (C) 2011-2019 Pryaxis & TShock Contributors
 
@@ -1066,7 +1066,7 @@ namespace TShockAPI
 			// even if there are no clients connected
 			if (ServerApi.ForceUpdate)
 			{
-				Netplay.HasClients = true;
+				Netplay.HasFullyConnectedClients = true;
 			}
 
 			if (Backups.IsBackupTime)

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -779,11 +779,10 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner)
 		{
-			for (int i = 0; i < Main.maxProjectiles; i++)
-			{
-				if (Main.projectile[i].identity == identity && Main.projectile[i].owner == owner)
-					return i;
-			}
+			// 1.4.5.7 replaced Projectile.identity with ProjectileKey, whose index component
+			// is the slot in Main.projectile, so the lookup is direct.
+			if (identity >= 0 && identity < Main.maxProjectiles && Main.projectile[identity].owner == owner)
+				return identity;
 			return 1000;
 		}
 

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -798,6 +798,28 @@ namespace TShockAPI
 		}
 
 		/// <summary>
+		/// Searches for a projectile by identity, owner and generation.
+		/// </summary>
+		/// <param name="identity">identity</param>
+		/// <param name="owner">owner</param>
+		/// <param name="generation">slot-reuse counter from the sender's ProjectileKey</param>
+		/// <returns>projectile ID</returns>
+		public int SearchProjectile(short identity, int owner, int generation)
+		{
+			// An identity is reused as soon as the client retires it, so matching only spawner and
+			// identity resolves a new projectile onto the slot its predecessor still occupies.
+			// Vanilla compares the whole key; the generation is what separates the two.
+			int index = SearchProjectile(identity, owner);
+			if (index < 0 || index >= Main.maxProjectiles)
+				return 1000;
+
+			if (Main.projectile[index].key.Generation != generation)
+				return 1000;
+
+			return index;
+		}
+
+		/// <summary>
 		/// Enumerates boundary points of the given region's rectangle.
 		/// </summary>
 		/// <param name="regionArea">The region's area to enumerate through.</param>

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -779,9 +779,7 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner)
 		{
-			// 1.4.5.7 replaced the Projectile.identity field with ProjectileKey. The key's Index
-			// component is a client-local identity, NOT the server slot; Projectile.keyToIndex
-			// maps (spawner, identity) onto the real index in Main.projectile.
+			// key.Index is a client-local identity; keyToIndex maps (spawner, identity) -> real index
 			if (identity < 0 || identity > 1000 || owner < 0 || owner > 255)
 				return 1000;
 
@@ -789,7 +787,7 @@ namespace TShockAPI
 			if (index < 0 || index >= Main.maxProjectiles)
 				return 1000;
 
-			// keyToIndex entries are never cleared, so confirm the slot still holds this key.
+			// keyToIndex is never cleared, so verify the slot still holds this key
 			var key = Main.projectile[index].key;
 			if (key.Spawner == owner && key.Index == identity)
 				return index;
@@ -806,9 +804,7 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner, int generation)
 		{
-			// An identity is reused as soon as the client retires it, so matching only spawner and
-			// identity resolves a new projectile onto the slot its predecessor still occupies.
-			// Vanilla compares the whole key; the generation is what separates the two.
+			// generation separates a reused identity from its predecessor
 			int index = SearchProjectile(identity, owner);
 			if (index < 0 || index >= Main.maxProjectiles)
 				return 1000;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -779,7 +779,6 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner)
 		{
-			// key.Index is a client-local identity; keyToIndex maps (spawner, identity) -> real index
 			if (identity < 0 || identity > 1000 || owner < 0 || owner > 255)
 				return 1000;
 
@@ -804,7 +803,6 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner, int generation)
 		{
-			// generation separates a reused identity from its predecessor
 			int index = SearchProjectile(identity, owner);
 			if (index < 0 || index >= Main.maxProjectiles)
 				return 1000;

--- a/TShockAPI/Utils.cs
+++ b/TShockAPI/Utils.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 TShock, a server mod for Terraria
 Copyright (C) 2011-2019 Pryaxis & TShock Contributors
 
@@ -779,10 +779,21 @@ namespace TShockAPI
 		/// <returns>projectile ID</returns>
 		public int SearchProjectile(short identity, int owner)
 		{
-			// 1.4.5.7 replaced Projectile.identity with ProjectileKey, whose index component
-			// is the slot in Main.projectile, so the lookup is direct.
-			if (identity >= 0 && identity < Main.maxProjectiles && Main.projectile[identity].owner == owner)
-				return identity;
+			// 1.4.5.7 replaced the Projectile.identity field with ProjectileKey. The key's Index
+			// component is a client-local identity, NOT the server slot; Projectile.keyToIndex
+			// maps (spawner, identity) onto the real index in Main.projectile.
+			if (identity < 0 || identity > 1000 || owner < 0 || owner > 255)
+				return 1000;
+
+			int index = Projectile.keyToIndex[owner, identity];
+			if (index < 0 || index >= Main.maxProjectiles)
+				return 1000;
+
+			// keyToIndex entries are never cleared, so confirm the slot still holds this key.
+			var key = Main.projectile[index].key;
+			if (key.Spawner == owner && key.Index == identity)
+				return index;
+
 			return 1000;
 		}
 

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -38,7 +38,7 @@
 		<PackageReference Include="GetText.NET" Version="8.0.5" /> <!-- only used to extract out to ./bin. -->
 
 		<!-- the launcher doesnt need the direct OTAPI reference, but since PackageReference[ExcludeFromSingleFile] doesnt work, exclude the assets and copy manually -->
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.11" ExcludeAssets="all" GeneratePathProperty="true" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.12" ExcludeAssets="all" GeneratePathProperty="true" />
 		<None Include="$(PkgOTAPI_Upcoming)\lib\net9.0\OTAPI.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/TShockLauncher/TShockLauncher.csproj
+++ b/TShockLauncher/TShockLauncher.csproj
@@ -38,7 +38,7 @@
 		<PackageReference Include="GetText.NET" Version="8.0.5" /> <!-- only used to extract out to ./bin. -->
 
 		<!-- the launcher doesnt need the direct OTAPI reference, but since PackageReference[ExcludeFromSingleFile] doesnt work, exclude the assets and copy manually -->
-		<PackageReference Include="OTAPI.Upcoming" Version="3.3.12" ExcludeAssets="all" GeneratePathProperty="true" />
+		<PackageReference Include="OTAPI.Upcoming" Version="3.3.14" ExcludeAssets="all" GeneratePathProperty="true" />
 		<None Include="$(PkgOTAPI_Upcoming)\lib\net9.0\OTAPI.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local-otapi" value="/home/zak/local-nuget" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-otapi" value="/home/zak/local-nuget" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Continues @ZakFahey's first pass in #3299 with the fixes needed to make 1.4.5.7/.8 actually playable. 

- resolve ProjectileKey via keyToIndex and check generations
- send the client's generation when removing a projectile
- bounds-check the npc id in the catch handler, and the projectile index in the kill handler
- drop the local nuget source so OTAPI restores from nuget.org

Depends on Pryaxis/TSAPI#283 Submodule pointer intentionally left on general-devel.
 
Tested on .NET 9 / linux-arm64 with a vanilla 1.4.5.7/.8 client: connect, play, enemies spawn and sync, projectiles resolve correctly.
