### PR TITLE
fix: whitelist NPC debuffs added in 1.4.5

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -3261,6 +3261,11 @@ namespace TShockAPI
 			{ BuffID.Tipsy, 3659 },
 			{ BuffID.Lovestruck, 1800 },
 			{ BuffID.GelBalloonBuff, 1800 },
+			{ BuffID.PotentAcid, 120 },
+			{ BuffID.ChlorophyteSpore, 300 },
+			{ BuffID.AcceleratePoisons, 300 },
+			{ BuffID.BlueLightning, 420 },
+			{ BuffID.RedLightning, 420 },
 		};
 
 		/// <summary>


### PR DESCRIPTION
Bouncer.OnNPCAddBuff kicks any player whose client sends an NPC buff that is not in NPCAddBuffTimeMax. Five debuffs reachable from vanilla player actions were missing, so using the corresponding items kicked the player immediately:

  PotentAcid (395)        Flask of Poison melee enchant
  ChlorophyteSpore (397)  proj 1127
  AcceleratePoisons (398) Catalyst Band
  BlueLightning (399)     LightningStrikeShot (proj 1117)
  RedLightning (400)      ArcSurge (proj 1122)

Durations are the maxima from Projectile.StatusNPC and Player, so the existing time-based cheat detection is unchanged.

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. If you would like to not make particles add your changes to the changelog manually please consider saying you've already updated the changelog. Thanks! -->
