### PR TITLE
add support for 1.4.5.7's respawn timer skip

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -2950,8 +2950,16 @@ namespace TShockAPI
 		{
 			if (args.Player.Dead && args.Player.RespawnTimer > 0)
 			{
-				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
-				return true;
+				// The player is allowed skip their respawn timer
+				if (args.Player.CanSkipRespawnTimer())
+				{
+					args.Player.RespawnTimer = 0;
+				}
+				else
+				{
+					TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleSpawn rejected dead player spawn request {0}", args.Player.Name));
+					return true;
+				}
 			}
 
 			byte player = args.Data.ReadInt8();

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1744,11 +1744,7 @@ namespace TShockAPI
 
 			if (TPlayer.pvpDeath)
 				return false;
-			// Not accounted for in case of network lag.
-			/*
-			if (TPlayer.deadTime < Player.DeadSkipLockoutTime)
-				return false;
-			*/
+
 			if (TPlayer.NearAnyNPCsThatBlockRespawn())
 				return false;
 

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -1744,8 +1744,9 @@ namespace TShockAPI
 
 			if (TPlayer.pvpDeath)
 				return false;
+			// Not accounted for in case of network lag.
 			/*
-			if (deadTime < DeadSkipLockoutTime)
+			if (TPlayer.deadTime < Player.DeadSkipLockoutTime)
 				return false;
 			*/
 			if (TPlayer.NearAnyNPCsThatBlockRespawn())

--- a/TShockAPI/TSPlayer.cs
+++ b/TShockAPI/TSPlayer.cs
@@ -36,6 +36,7 @@ using Timer = System.Timers.Timer;
 using System.Linq;
 using Terraria.GameContent;
 using Terraria.GameContent.Creative;
+using Terraria.GameContent.Events;
 namespace TShockAPI
 {
 	/// <summary>
@@ -1731,6 +1732,32 @@ namespace TShockAPI
 				msg.PackFull(ms);
 				SendRawData(ms.ToArray());
 			}
+		}
+
+		/// <summary>
+		/// If the player is allowed to skip the respawn timer. Does not account for time spent being dead in case of network lag.
+		/// </summary>
+		public bool CanSkipRespawnTimer()
+		{
+			if (TPlayer.ghost)
+				return false;
+
+			if (TPlayer.pvpDeath)
+				return false;
+			/*
+			if (deadTime < DeadSkipLockoutTime)
+				return false;
+			*/
+			if (TPlayer.NearAnyNPCsThatBlockRespawn())
+				return false;
+
+			if (TPlayer.AnyBossHindersRespawnTime())
+				return false;
+
+			if (Main.snowMoon || Main.pumpkinMoon || DD2Event.Ongoing)
+				return false;
+
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added support for the QoL feature added in Terraria 1.4.5.7 which allows for skipping the respawn timer under certain circumstances.

I chose to not check if 90 frames have passed since the player died in order to avoid potential network lag causing the player's spawn to appear too fast to the server (and get rejected). Feedback is appreciated.
