### PR TITLE
fixe the issue where players recently fired bullets would be saved to an invalid index

### DIFF
--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3344,8 +3344,6 @@ namespace TShockAPI
 				return true;
 			}
 
-			var index = TShock.Utils.SearchProjectile(ident, owner, key.Generation);
-
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
 			// Block ai[0] == 3 (dig state)
 			if (type == ProjectileID.PalworldMinionCattiva && ai[0] == 3f)
@@ -3354,16 +3352,16 @@ namespace TShockAPI
 				return true;
 			}
 
-			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, index, args.Player, ai, key.Generation))
+			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, ident, args.Player, ai, key.Generation))
 				return true;
 
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
+				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == ident))
 				{
 					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 					{
-						Index = index,
+						Index = ident,
 						Type = type,
 						CreatedAt = DateTime.Now
 					});

--- a/TShockAPI/Models/PlayerUpdate/ControlSet.cs
+++ b/TShockAPI/Models/PlayerUpdate/ControlSet.cs
@@ -77,6 +77,15 @@ namespace TShockAPI.Models.PlayerUpdate
 		}
 
 		/// <summary>
+		/// Gets or Sets the controlDash flag
+		/// </summary>
+		public bool ControlDash
+		{
+			get => bitsbyte[7];
+			set => bitsbyte[7] = value;
+		}
+
+		/// <summary>
 		/// Constructs a new instance of ControlsModel with the given backing bitsbyte
 		/// </summary>
 		/// <param name="bitsbyte"></param>


### PR DESCRIPTION
This will cause an invalid index to be stored when creating bullets, and using the RecentlyCreatedProjectiles code may have potential issues, just like the portal detection in Bouncer.

``` csharp

           var index = TShock.Utils.SearchProjectile(ident, owner, key.Generation);

			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
			// Block ai[0] == 3 (dig state)
			if (type == ProjectileID.PalworldMinionCattiva && ai[0] == 3f)
			{
				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected Palworld Minion Cattiva dig sync {0}", args.Player.Name));
				return true;
			}

			if (OnNewProjectile(args.Data, ident, pos, vel, knockback, dmg, owner, type, ident, args.Player, ai, key.Generation))
				return true;

			lock (args.Player.RecentlyCreatedProjectiles)
			{
				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == ident))
				{
					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
					{
						Index = index,
						Index = ident,
						Type = type,
						CreatedAt = DateTime.Now
					});
				}
			}
```

<!-- Put the text you want in the changelog in your PR body so we can add it to the changelog. If you would like to not make particles add your changes to the changelog manually please consider saying you've already updated the changelog. Thanks! -->
