### PR TITLE
Fix Trusty Digtoise cannot dig and block Trusty Cattiva dig permission bypass

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -792,11 +792,12 @@ namespace TShockAPI
 					         args.Player.TPlayer.mount.Type != MountID.Drill &&
 					         args.Player.TPlayer.mount.Type != MountID.DiggingMoleMinecart)
 					{
-						if (args.Player.TPlayer.ownedProjectileCounts[ProjectileID.PalworldDigtoise] > 0)
+						if (args.Player.TPlayer.ownedProjectileCounts[ProjectileID.PalworldDigtoise] > 0
+							|| args.Player.TPlayer.ownedProjectileCounts[ProjectileID.PalworldTrustyDigtoise] > 0)
 						{
 							var digtoiseProjectile = Main.projectile
 								.FirstOrDefault(p =>
-									p is { active: true, type: ProjectileID.PalworldDigtoise } && p.owner == args.Player.Index);
+									p is { active: true, type: ProjectileID.PalworldDigtoise or ProjectileID.PalworldTrustyDigtoise } && p.owner == args.Player.Index );
 
 							// Digtoise starts digging
 							if (digtoiseProjectile?.ai[0] is 1f or 2f or 3f

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3348,8 +3348,7 @@ namespace TShockAPI
 			var index = TShock.Utils.SearchProjectile(ident, owner, key.Generation);
 
 			// Cattiva's dig ability can bypass build permissions via vanilla exploit in Terraria v1.4.5
-			// Block ai[0] == 3 (dig state)
-			if (type == ProjectileID.PalworldMinionCattiva && ai[0] == 3f)
+			if ((type == ProjectileID.PalworldMinionCattiva || type == ProjectileID.PalworldMinionTrustyCattiva) && ai[0] == 3f)
 			{
 				TShock.Log.ConsoleDebug(GetString("GetDataHandlers / HandleProjectileNew rejected Palworld Minion Cattiva dig sync {0}", args.Player.Name));
 				return true;


### PR DESCRIPTION
Terraria v1.4.5.7 introduced the Trusty variants of the Palworld companion pets:
**Trusty Digtoise** and **Trusty Cattiva**.

The existing protections only covered their regular counterparts, so this PR
adds support for the new variants.