### PR TITLE
fix: restore portal gun gate creation

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1432,7 +1432,7 @@ namespace TShockAPI
 
 			// Portal Gun Gate projectiles must meet several validation criteria:
 			// 1. The angle must be within valid discrete directions (45 degree increments)
-			// 2. Must have an active PortalGunBolt projectile associated
+			// 2. Must have a PortalGunBolt record from this player that has not been consumed yet
 			if (type == ProjectileID.PortalGunGate)
 			{
 			    // Validate the gate angle is one of 8 possible cardinal directions (every 45 degrees)
@@ -1447,7 +1447,7 @@ namespace TShockAPI
 			    }
 
 			    // Validate we found an active bolt projectile
-			    var boltProjectileData = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => Main.projectile[p.Index].type == ProjectileID.PortalGunBolt);
+			    var boltProjectileData = args.Player.RecentlyCreatedProjectiles.FirstOrDefault(p => p.Type == ProjectileID.PortalGunBolt && !p.Killed);
 			    if (boltProjectileData.Type == 0 || boltProjectileData.Killed)
 			    {
 				    TShock.Log.ConsoleDebug(GetString("Bouncer / OnNewProjectile rejected from portal gate from {0} (missing active Portal Gun bolt)", args.Player.Name, discreteDirection));

--- a/TShockAPI/GetDataHandlers.cs
+++ b/TShockAPI/GetDataHandlers.cs
@@ -3360,7 +3360,9 @@ namespace TShockAPI
 
 			lock (args.Player.RecentlyCreatedProjectiles)
 			{
-				if (!args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
+				// Portal Gun bolts resolve to the sentinel index here, so never deduplicate them: each fired
+				// bolt needs its own record, or a second portal gate would find no unconsumed bolt to match.
+				if (type == ProjectileID.PortalGunBolt || !args.Player.RecentlyCreatedProjectiles.Any(p => p.Index == index))
 				{
 					args.Player.RecentlyCreatedProjectiles.Add(new GetDataHandlers.ProjectileStruct()
 					{


### PR DESCRIPTION
## Summary

Fixes a regression where portal gun gates (ProjectileID 602) could never be
created on servers. The broken gate validation was introduced in commit
8f596968 ("feat(Bouncer): add portal validation to block portal exploit").

### Root cause

Projectile creation packets are validated by the Bouncer before the vanilla
server has spawned the projectile, so `SearchProjectile` cannot resolve a real
slot and the recorded entry keeps the sentinel index (1000). The gate check
then read `Main.projectile[entry.Index]`, i.e. `Main.projectile[1000]`, which
is out of bounds and aborted gate creation. On top of that, records were
deduplicated by `Index`, so every unresolved projectile merged into a single
sentinel entry: the second portal gun bolt was never recorded and its gate was
always rejected.

### Changes

- `Bouncer.cs`: validate gates against the trusted bolt creation records
  instead of dereferencing the (unresolvable) recorded index.
- `GetDataHandlers.cs`: never deduplicate `PortalGunBolt` records so each fired
  bolt gets its own record.

No anti-cheat strength is lost: gates sent without a recent bolt record, or
with an invalid angle, are still rejected.

## Changelog

- Fix portal gun gates (projectile 602) failing to spawn on servers.
