### PR TITLE
fix: allow Power Bombs to destroy hardmode ores on the server

### DIFF
--- a/TShockAPI/Bouncer.cs
+++ b/TShockAPI/Bouncer.cs
@@ -1551,7 +1551,9 @@ namespace TShockAPI
 				|| type == ProjectileID.StickyDynamite
 				|| type == ProjectileID.BombFish
 				|| type == ProjectileID.ScarabBomb
-				|| type == ProjectileID.DirtBomb))
+				|| type == ProjectileID.DirtBomb
+				|| type == ProjectileID.SuperBomb
+				|| type == ProjectileID.SuperStickyBomb))
 			{
 				//  Denotes that the player has recently set a fuse - used for cheat detection.
 				args.Player.RecentFuse = 10;


### PR DESCRIPTION
## What

Power Bomb (item 5594) and Sticky Power Bomb (item 5595) are explosives whose
blast also destroys all six hardmode ores (tiles 107/108/111/221/222/223) —
ores that are otherwise mined with a pickaxe.

On a server these explosions arrive as per-tile KillTile edits, which
`Bouncer.OnTileEdit` only accepts while the thrower has a lit fuse
(`RecentFuse > 0`), holds an item flagged in `ItemID.Sets.Explosives`, or holds
a suitable tool. Ore tiles are not in `breakableTiles`, so they always hit that
check.

`RecentFuse` is armed in `Bouncer.OnNewProjectile`, but the fuse list only
covered the older bombs — the Power Bomb projectiles were missing. So once the
bomb was thrown, the ore edits were rejected and the ores were rolled back,
while breakable tiles (e.g. dirt) still broke. Single-player was unaffected.

## Fix

Add `ProjectileID.SuperBomb` (1086) and `ProjectileID.SuperStickyBomb` (1087)
to the fuse list in `Bouncer.OnNewProjectile`, mirroring how Bomb Fish and Dirt
Bomb were added before.
